### PR TITLE
feat: add sharkord platform-config and extract SDK/Docker rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ agent-meta/
     hooks.md                          ← Hooks-System: Schichten, Sync, create-hook, dod-push-check
     agent-isolation.md                ← isolation: worktree — Konfiguration, Fallstricke, Feature-Agent
     agent-delegation-map.md           ← Delegations-Matrix: wer delegiert an wen, parallelisierbare Schritte
+    platform-config.md                ← Platform Config Instantiation: {{platform.*}}-Platzhalter, Defaults, Overrides
     sync-concept.md
     template-gap-analysis.md
 
@@ -167,6 +168,11 @@ agent-meta/
     childish.md          ← Kindgerechter Stil: spielerisch, Tier-/Spielzeug-Analogien
     caveman.md           ← Höhlenmensch-Stil: kurz, direkt, abgehakt
 
+  platform-configs/
+    homeassistant.defaults.yaml  ← Default-Werte für {{platform.homeassistant.*}}-Platzhalter
+                                    Leerer String = Pflichtfeld (User muss überschreiben)
+                                    Nicht-leerer Wert = sinnvoller Default
+
   scripts/
     sync.py              ← Agent-Generator
 ```
@@ -181,7 +187,7 @@ agent-meta/
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.21.0 — `2026-04-14`
+Generiert von agent-meta v0.22.0 — `2026-04-14`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.
@@ -603,6 +609,9 @@ Siehe [howto/hooks.md](howto/hooks.md) für vollständige Dokumentation.
 
 Alle `{{PLATZHALTER}}` werden via `agent-meta.config.json` befüllt.
 Auto-injiziert (nicht in config nötig): `AGENT_META_VERSION`, `AGENT_META_DATE`, `AGENT_TABLE`, `AGENT_HINTS`, `AI_PROVIDER`, `MAX_PARALLEL_AGENTS`, `DOD_REQ_TRACEABILITY`, `DOD_TESTS_REQUIRED`, `DOD_CODEBASE_OVERVIEW`, `DOD_SECURITY_AUDIT`, `DOD_PRESET`.
+
+**Platform-Config-Platzhalter** (`{{platform.*}}`) werden separat via `platform-configs/<platform>.defaults.yaml` + `.claude/platform-config.yaml` befüllt.
+Siehe [howto/platform-config.md](howto/platform-config.md) für Details.
 
 ### Generische Variablen (alle Projekte)
 

--- a/agent-meta.config.json
+++ b/agent-meta.config.json
@@ -1,15 +1,13 @@
 {
   "$schema": "./agent-meta.schema.json",
   "_comment": "agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.",
-
-  "agent-meta-version": "v0.21.0",
-
-  "ai-providers": ["Claude", "Continue"],
-
+  "agent-meta-version": "v0.22.0",
+  "ai-providers": [
+    "Claude",
+    "Continue"
+  ],
   "dod-preset": "rapid-prototyping",
-
   "platforms": [],
-
   "roles": [
     "orchestrator",
     "developer",
@@ -24,17 +22,16 @@
     "feature",
     "agent-meta-scout"
   ],
-
   "project": {
-    "name":   "agent-meta",
+    "name": "agent-meta",
     "prefix": "am",
-    "short":  "agent-meta"
+    "short": "agent-meta"
   },
-
   "hooks": {
-    "dod-push-check": { "enabled": true }
+    "dod-push-check": {
+      "enabled": true
+    }
   },
-
   "_comment_provider_options": "Provider-spezifische Optionen — pro Provider konfigurierbar",
   "provider-options": {
     "Claude": {},
@@ -44,78 +41,64 @@
       "prompt-mode": "full"
     }
   },
-
   "_comment_speech_mode": "Kommunikationsstil aller Agenten: 'full' (Default), 'short', 'childish', 'caveman'",
   "speech-mode": "caveman",
-
   "variables": {
-
-    "PROJECT_NAME":        "agent-meta",
+    "PROJECT_NAME": "agent-meta",
     "PROJECT_DESCRIPTION": "Zentrales Meta-Repository für die Standardisierung und Wiederverwendung von Claude-Agenten-Rollen über alle Projekte hinweg.",
-    "PROJECT_GOAL":        "Generische Agent-Templates bereitstellen, die via sync.py in Zielprojekte instanziiert werden. Einmal definieren, überall nutzen.",
-    "PLATFORM":            "Python CLI (sync.py)",
-    "RUNTIME":             "Python 3.x",
-    "LANGUAGE":            "Python 3, Markdown, JSON",
-    "PROJECT_LANGUAGES":   "Python, Markdown, JSON",
-
-    "COMMUNICATION_LANGUAGE":   "Deutsch",
-    "USER_INPUT_LANGUAGE":      "Deutsch",
-    "DOCS_LANGUAGE":            "Englisch",
-    "INTERNAL_DOCS_LANGUAGE":   "Deutsch",
-    "CODE_LANGUAGE":            "Englisch",
-
-    "AGENT_META_REPO":     "Popoboxxo/agent-meta",
-
-    "GIT_PLATFORM":    "GitHub",
-    "GIT_REMOTE_URL":  "https://github.com/Popoboxxo/agent-meta",
+    "PROJECT_GOAL": "Generische Agent-Templates bereitstellen, die via sync.py in Zielprojekte instanziiert werden. Einmal definieren, überall nutzen.",
+    "PLATFORM": "Python CLI (sync.py)",
+    "RUNTIME": "Python 3.x",
+    "LANGUAGE": "Python 3, Markdown, JSON",
+    "PROJECT_LANGUAGES": "Python, Markdown, JSON",
+    "COMMUNICATION_LANGUAGE": "Deutsch",
+    "USER_INPUT_LANGUAGE": "Deutsch",
+    "DOCS_LANGUAGE": "Englisch",
+    "INTERNAL_DOCS_LANGUAGE": "Deutsch",
+    "CODE_LANGUAGE": "Englisch",
+    "AGENT_META_REPO": "Popoboxxo/agent-meta",
+    "GIT_PLATFORM": "GitHub",
+    "GIT_REMOTE_URL": "https://github.com/Popoboxxo/agent-meta",
     "GIT_MAIN_BRANCH": "main",
-
     "SYSTEM_DEPENDENCIES": "- Python: `>=3.8`",
     "SYSTEM_URLS": "",
-
-    "BUILD_COMMAND":       "python scripts/sync.py --config agent-meta.config.json",
-    "TEST_COMMAND":        "(kein automatisiertes Test-System — manuelle Verifikation via --dry-run)",
-    "DEV_COMMANDS":        "python scripts/sync.py --config agent-meta.config.json\npython scripts/sync.py --config agent-meta.config.json --dry-run",
-    "DEV_STACK_START":     "(kein Dev-Stack)",
-    "DEV_STACK_RELOAD":    "(kein Dev-Stack)",
-
-    "PROJECT_CONTEXT":     "agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird. Es stellt standardisierte Claude-Agenten-Templates bereit (1-generic, 2-platform, 0-external) und generiert via sync.py projektfertige Agenten-Dateien in .claude/agents/. Das Repo verwendet sich selbst — die hier generierten Agenten koordinieren die Weiterentwicklung von agent-meta.",
-    "PROJECT_STRUCTURE":   "agents/\n  0-external/       # Wrapper-Template für externe Skills\n  1-generic/        # Universelle Agent-Templates\n  2-platform/       # Plattform-Overrides (z.B. sharkord)\nscripts/\n  sync.py           # Agent-Generator\nsnippets/           # Sprachspezifische Code-Snippets\nexternal/           # Git Submodule (externe Skill-Repos)\nhowto/              # Anleitungen und Beispiel-Config\ndocs/architecture/  # Architektur-Diagramme (Mermaid)",
+    "BUILD_COMMAND": "python scripts/sync.py --config agent-meta.config.json",
+    "TEST_COMMAND": "(kein automatisiertes Test-System — manuelle Verifikation via --dry-run)",
+    "DEV_COMMANDS": "python scripts/sync.py --config agent-meta.config.json\npython scripts/sync.py --config agent-meta.config.json --dry-run",
+    "DEV_STACK_START": "(kein Dev-Stack)",
+    "DEV_STACK_RELOAD": "(kein Dev-Stack)",
+    "PROJECT_CONTEXT": "agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird. Es stellt standardisierte Claude-Agenten-Templates bereit (1-generic, 2-platform, 0-external) und generiert via sync.py projektfertige Agenten-Dateien in .claude/agents/. Das Repo verwendet sich selbst — die hier generierten Agenten koordinieren die Weiterentwicklung von agent-meta.",
+    "PROJECT_STRUCTURE": "agents/\n  0-external/       # Wrapper-Template für externe Skills\n  1-generic/        # Universelle Agent-Templates\n  2-platform/       # Plattform-Overrides (z.B. sharkord)\nscripts/\n  sync.py           # Agent-Generator\nsnippets/           # Sprachspezifische Code-Snippets\nexternal/           # Git Submodule (externe Skill-Repos)\nhowto/              # Anleitungen und Beispiel-Config\ndocs/architecture/  # Architektur-Diagramme (Mermaid)",
     "ENTRY_POINT_PATTERN": "scripts/sync.py — Haupt-CLI für Agent-Generierung",
-    "KEY_PATTERNS":        "- Agent-Templates haben YAML-Frontmatter (name, version, description, tools)\n- Platzhalter {{VARIABLE}} werden von sync.py substituiert\n- Extensions (.claude/3-project/*-ext.md) werden vom Agenten zur Laufzeit gelesen\n- Snippet-Dateien haben eigenes YAML-Frontmatter (snippet, version, language, runtime)",
-    "ARCHITECTURE":        "agents/\n  0-external/  1-generic/  2-platform/\nscripts/sync.py\nsnippets/tester/ snippets/developer/\nexternal/<repo>/",
-    "CODE_CONVENTIONS":    "- Python: PEP 8, snake_case, klare Funktionsnamen\n- Keine externen Python-Dependencies außer Stdlib\n- Markdown-Dateien: GitHub Flavored Markdown\n- YAML Frontmatter in allen Agent-Templates\n- Platzhalter immer {{GROSS_MIT_UNTERSTRICH}}\n- Versionen in Frontmatter bei jeder inhaltlichen Änderung erhöhen",
-    "EXTRA_DONTS":         "- KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)\n- KEINE Breaking Changes ohne Major-Version-Bump\n- KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle",
-    "CODE_QUALITY_RULES":  "- sync.py muss nach jeder Änderung mit --dry-run fehlerfrei laufen\n- Alle neuen Platzhalter müssen in agent-meta.config.example.json dokumentiert sein\n- Agent-Versionen müssen bei inhaltlichen Änderungen erhöht werden",
-
-    "TESTER_SNIPPETS_PATH":    "",
+    "KEY_PATTERNS": "- Agent-Templates haben YAML-Frontmatter (name, version, description, tools)\n- Platzhalter {{VARIABLE}} werden von sync.py substituiert\n- Extensions (.claude/3-project/*-ext.md) werden vom Agenten zur Laufzeit gelesen\n- Snippet-Dateien haben eigenes YAML-Frontmatter (snippet, version, language, runtime)",
+    "ARCHITECTURE": "agents/\n  0-external/  1-generic/  2-platform/\nscripts/sync.py\nsnippets/tester/ snippets/developer/\nexternal/<repo>/",
+    "CODE_CONVENTIONS": "- Python: PEP 8, snake_case, klare Funktionsnamen\n- Keine externen Python-Dependencies außer Stdlib\n- Markdown-Dateien: GitHub Flavored Markdown\n- YAML Frontmatter in allen Agent-Templates\n- Platzhalter immer {{GROSS_MIT_UNTERSTRICH}}\n- Versionen in Frontmatter bei jeder inhaltlichen Änderung erhöhen",
+    "EXTRA_DONTS": "- KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)\n- KEINE Breaking Changes ohne Major-Version-Bump\n- KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle",
+    "CODE_QUALITY_RULES": "- sync.py muss nach jeder Änderung mit --dry-run fehlerfrei laufen\n- Alle neuen Platzhalter müssen in agent-meta.config.example.json dokumentiert sein\n- Agent-Versionen müssen bei inhaltlichen Änderungen erhöht werden",
+    "TESTER_SNIPPETS_PATH": "",
     "DEVELOPER_SNIPPETS_PATH": "",
-
-    "TEST_COMMANDS":       "python scripts/sync.py --config agent-meta.config.json --dry-run",
-    "BUILD_COMMANDS":      "python scripts/sync.py --config agent-meta.config.json",
-    "REQ_CATEGORIES":      "- Framework-Features (sync.py, neue Agenten-Rollen, Variablen)\n- Agenten-Templates (Workflows, Sprach-Sektionen, Versionierung)\n- Entwickler-Experience (Howto, Beispiele, Doku)",
-
-    "SERVICE_NAME":        "(kein Service)",
-    "CONTAINER_NAME":      "(kein Container)",
-    "PRIMARY_PORT":        "",
-    "EXTRA_PORTS":         "",
-
-    "DOCKER_STACKS_OVERVIEW":    "(kein Docker-Stack)",
-    "EXTRA_VOLUMES":             "",
-    "EXTRA_VOLUME_DEFINITIONS":  "",
-    "EXTRA_ENV_VARS":            "",
-    "EXTRA_STARTUP_INFO":        "",
-    "HOST_LAN_IP":               "",
-
-    "BUILD_OUTPUT":           "(kein Build-Artifact — generierter Output liegt im Zielprojekt)",
-    "ARTIFACT_ZIP_CMD":       "",
-    "ARTIFACT_TAR_CMD":       "",
-    "GH_ASSETS":              "",
+    "TEST_COMMANDS": "python scripts/sync.py --config agent-meta.config.json --dry-run",
+    "BUILD_COMMANDS": "python scripts/sync.py --config agent-meta.config.json",
+    "REQ_CATEGORIES": "- Framework-Features (sync.py, neue Agenten-Rollen, Variablen)\n- Agenten-Templates (Workflows, Sprach-Sektionen, Versionierung)\n- Entwickler-Experience (Howto, Beispiele, Doku)",
+    "SERVICE_NAME": "(kein Service)",
+    "CONTAINER_NAME": "(kein Container)",
+    "PRIMARY_PORT": "",
+    "EXTRA_PORTS": "",
+    "DOCKER_STACKS_OVERVIEW": "(kein Docker-Stack)",
+    "EXTRA_VOLUMES": "",
+    "EXTRA_VOLUME_DEFINITIONS": "",
+    "EXTRA_ENV_VARS": "",
+    "EXTRA_STARTUP_INFO": "",
+    "HOST_LAN_IP": "",
+    "BUILD_OUTPUT": "(kein Build-Artifact — generierter Output liegt im Zielprojekt)",
+    "ARTIFACT_ZIP_CMD": "",
+    "ARTIFACT_TAR_CMD": "",
+    "GH_ASSETS": "",
     "REQUIRED_BINARIES_SECTION": "Keine externen Binaries erforderlich.",
-    "BINARY_INSTALL_STEPS":      "",
-    "REQUIRED_BINARY_NAMES":     "(keine)",
-    "BUILD_SYSTEM_NOTES":        "sync.py generiert .claude/agents/ im Zielprojekt — kein Build-Artifact im Meta-Repo selbst.",
-    "VERSION_DIST_BEHAVIOUR":    "Keine Dist. Releases sind Git-Tags auf main."
-
-  }
+    "BINARY_INSTALL_STEPS": "",
+    "REQUIRED_BINARY_NAMES": "(keine)",
+    "BUILD_SYSTEM_NOTES": "sync.py generiert .claude/agents/ im Zielprojekt — kein Build-Artifact im Meta-Repo selbst.",
+    "VERSION_DIST_BEHAVIOUR": "Keine Dist. Releases sind Git-Tags auf main."
+  },
+  "max-parallel-agents": 2
 }

--- a/agents/2-platform/homeassistant-developer.md
+++ b/agents/2-platform/homeassistant-developer.md
@@ -1,0 +1,93 @@
+---
+name: developer
+version: "1.0.0"
+based-on: "1-generic/developer.md@2.0.0"
+description: "Home Assistant Developer — YAML-Konfigurationen, Automatisierungen, Templates, Energy-Layer und Package-Struktur."
+hint: "Feature-Implementierung und Bugfixes für Home Assistant (YAML, Jinja2, Packages)"
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+  - TodoWrite
+extends: "1-generic/developer.md"
+patches:
+  - op: append-after
+    anchor: "## Deine Zuständigkeiten"
+    content: |
+      ### Home Assistant — Plattform-Spezifika
+
+      Du bist spezialisiert auf **Home Assistant (HA) Konfigurationen** im Power-User-Setup.
+      Deine Arbeit läuft auf einer **Proxmox/Unraid Virtualisierungs-Umgebung** mit Docker-Add-ons.
+
+      **Kernkompetenzen:**
+
+      | # | Kompetenz | Beschreibung |
+      |---|-----------|--------------|
+      | 1 | **Advanced YAML & Packages** | Modulare Package-Struktur, `!include_dir_merge_list`, Anker/Aliase, Template-Makros, Blueprints |
+      | 2 | **Jinja2** | Komplexe Logik (Namespaces, Loops, Filter) für Templates, card_mod und Lovelace-Karten |
+      | 3 | **Energy Abstraction Layer** | Template-Sensor-Abstraktion, Spike-Filter, Utility Meter (siehe Rule `energy-abstraction.md`) |
+      | 4 | **Hardware & Protokolle** | Zigbee2MQTT (nicht ZHA), MQTT-Bridging, ESPHome, BLE-Triangulation (Bermuda) |
+      | 5 | **Debugging** | Spook, Watchman, Template-Editor, Geister-Entitäten eliminieren |
+
+      **Kontext-Check zuerst**: Prüfe immer ob das Problem durch eine **existierende Integration** gelöst werden kann
+      (z.B. Adaptive Lighting statt manueller Skripte, Alarmo statt manueller Trigger).
+
+      **Aktualität**: Verwende immer **moderne HA-Syntax** (`action:` statt `service:`, neue `template:` Domain).
+
+  - op: append-after
+    anchor: "## Code-Konventionen"
+    content: |
+      ### Home Assistant YAML
+
+      - Liefere **vollständigen YAML-Code** — nie Fragmente ohne Kontext
+      - Nutze **Blueprints** für wiederkehrende Automatisierungs-Muster
+      - Nutze **Helper** (Input Booleans/Selects) als State-Machine für komplexe Logiken
+      - Weise darauf hin, ob Änderungen einen **Neustart** (neue Domain) oder nur einen **Reload** erfordern
+      - Bei Frontend-Fragen: Angeben ob Code in `ui-lovelace.yaml` oder Raw-Editor gehört
+
+      **Alle HA-Konventionen gelten gemäß den Rules:**
+      - `yaml-conventions.md` — ID-Regeln, Header-Format, Versionierung
+      - `package-structure.md` — Package-Philosophie, Dateistruktur
+      - `energy-abstraction.md` — Energy Layer, Spike-Filter
+      - `entity-data.md` — MCP- und CSV-Datenquellen-Hierarchie
+      - `mcp-integration.md` — MCP Read-Only-Regel (ABSOLUT)
+      - `notifications.md` — Notification-Gruppen, Debug-Modus
+
+  - op: append
+    content: |
+      ## Home Assistant Tech-Stack
+
+      ### Frontend & Visualisierung
+      - **Frameworks**: Mushroom (inkl. Strategy), Bubble Card, Layout Card, Sections View, Kiosk Mode
+      - **Customizing**: ha-floorplan (SVG), card-mod (CSS-Hacks), Custom brand icons
+      - **Graphen**: Mini-graph-card, Plotly, Sankey Chart Card, Power Flow Card Plus, ApexCharts
+      - **Mobile**: Vorzugsweise Mushroom oder Bubble Card
+      - **Tablet/Desktop**: Layout-Card / Floorplan / Sections
+
+      ### Energie & Solar
+      - evcc, Forecast.Solar, Solcast, Nordpool, Powercalc, Zendure HA, EOS Connect
+      - Sankey Chart Card, Power Flow Card Plus, Battery State Card
+
+      ### Video, Sicherheit & Präsenz
+      - Frigate (NVR), WebRTC, Reolink, LLM Vision
+      - Bermuda BLE Trilateration, Alarmo
+
+      ### Infrastruktur
+      - Proxmox VE, Unraid, Portainer
+      - InfluxDB 2 (Measurements basieren auf der Einheit, nicht "state" — Bucket: `{{platform.homeassistant.influxdb_bucket}}`)
+      - Unifi, AdGuard, Cloudflare Tunnel, Google Drive Backup
+
+      ### IoT & Smart Home
+      - Zigbee2MQTT (bevorzugt, nicht ZHA), MQTT, ESPHome
+      - Adaptive Lighting, Philips Hue + Sync Box, WLED
+      - Xiaomi Home, Roborock, Bambu Lab, SmartThinQ LGE, SwitchBot
+
+      ### Voice, AI & Notification
+      - Assist Pipeline, Wyoming Satellite, Extended OpenAI Conversation
+      - Music Assistant, Alexa Media Player (TTS), Google Home/Cast
+      - Actionable Notifications (iOS/Android) mit Kamera-Snapshots
+---

--- a/agents/2-platform/homeassistant-documenter.md
+++ b/agents/2-platform/homeassistant-documenter.md
@@ -1,0 +1,188 @@
+---
+name: documenter
+version: "1.0.0"
+based-on: "1-generic/documenter.md@1.3.1"
+description: "Home Assistant Documenter — generiert und pflegt MkDocs-Dokumentation aus YAML-Packages, Architektur-Diagrammen und Git-History."
+hint: "HA-Doku pflegen: MkDocs-Seiten, Package-Übersichten, Architektur-Diagramme (Mermaid)"
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - TodoWrite
+extends: "1-generic/documenter.md"
+patches:
+  - op: replace
+    anchor: "## Deine Zuständigkeiten"
+    content: |
+      ## Deine Zuständigkeiten
+
+      Du generierst und pflegst die **MkDocs-Dokumentation** für dieses Home Assistant Repository.
+
+      ### Dateien in deiner Verantwortung
+
+      | Ziel | Pfad | Inhalt |
+      |------|------|--------|
+      | MkDocs Docs | `<mkdocs-addon-path>/docs/` | Alle generierten Markdown-Seiten |
+      | MkDocs Config | `<mkdocs-addon-path>/mkdocs.yml` | Navigation, Extensions |
+
+      ### Pflicht-Seiten
+
+      | Datei | Inhalt |
+      |-------|--------|
+      | `docs/index.md` | Startseite mit Systemübersicht, Architektur-Diagramm (Mermaid), Quick-Links |
+      | `docs/architecture/overview.md` | Gesamtarchitektur: Package-System, Datenfluss, Integrations-Landschaft |
+      | `docs/architecture/energy-layer.md` | Energy Abstraction Layer: Anker, Spike-Filter, Utility Meter Pattern |
+      | `docs/architecture/patterns.md` | Wiederkehrende Design Patterns (Trigger-Sensoren, Label-Discovery, State Machines) |
+      | `docs/packages/<domain>.md` | Pro Package-Ordner eine Seite |
+      | `docs/integrations.md` | Alle verwendeten Integrationen mit Zweck und Konfigurationshinweisen |
+      | `docs/notifications.md` | Notification-System: Gruppen, Debug-Modus, Actionable Notifications |
+      | `docs/infrastructure.md` | Netzwerk, Proxmox, Docker, InfluxDB, MQTT Topologie |
+      | `docs/conventions.md` | YAML-Konventionen, Versionierung, ID-Regeln (aus Rules) |
+      | `docs/changelog.md` | Automatisch aus Git-History + Package-Headern extrahiert |
+
+      **NICHT anfassen:** `addons/mkdocs/help.md` und `assets/` — diese nie überschreiben.
+
+  - op: replace
+    anchor: "## 1. CODEBASE_OVERVIEW.md Pflege"
+    content: |
+      ## 1. Arbeitsablauf
+
+      ### Phase 1: Analyse
+      1. Lies ALLE Package-Dateien unter `packages/` rekursiv
+      2. Lies `configuration.yaml`, `automations.yaml`, `scripts.yaml`, `sensor.yaml`, `utility_meter.yaml`
+      3. Lies die CLAUDE.md und `.claude/rules/` für Konventionen
+      4. Prüfe den aktuellen Stand der MkDocs-Dokumentation (existierende Dateien unter `docs/`)
+      5. Nutze `git log --oneline -20` um aktuelle Änderungen zu erkennen
+
+      ### Phase 2: Dokumentation generieren
+
+      #### Struktur pro Package-Seite (`docs/packages/<domain>.md`)
+
+      ```markdown
+      # [Domain Name]
+
+      ## Übersicht
+      [Was macht dieses Package? 2-3 Sätze]
+
+      ## Dateien
+      | Datei | Version | Beschreibung |
+      |-------|---------|-------------|
+
+      ## Entitäten
+
+      ### Input Helpers
+      [Tabelle: Name, Typ, Beschreibung, Default]
+
+      ### Template Sensoren
+      [Tabelle: Entity ID, Name, Beschreibung, Einheit]
+
+      ### Automations
+      [Tabelle: ID, Alias, Trigger, Beschreibung]
+
+      ### Scripts
+      [Tabelle: ID, Alias, Beschreibung]
+
+      ## Datenfluss
+      [Mermaid-Diagramm der Datenflüsse innerhalb des Packages]
+
+      ## Abhängigkeiten
+      [Liste der benötigten Integrationen und Hardware]
+      ```
+
+      ### Phase 3: Mermaid-Diagramme
+
+      Nutze **Mermaid**-Syntax (unterstützt von MkDocs Material). Generiere:
+
+      1. **Architektur-Übersicht** (C4-Style oder Flowchart) — Packages als Gruppen, Datenflüsse, externe Systeme
+      2. **Energy Flow** — Hardware Sensor → Template Sensor → Utility Meter → InfluxDB / Dashboard
+      3. **Package-spezifische Flows** — Trigger → Condition → Action
+
+      ```mermaid
+      graph LR
+          HW[Hardware Sensor] --> TS[Template Sensor]
+          TS --> UM[Utility Meter]
+          UM --> DB[(InfluxDB)]
+          TS --> DASH[Dashboard]
+      ```
+
+      ### Phase 4: mkdocs.yml aktualisieren
+
+      Navigation-Struktur:
+      ```yaml
+      nav:
+        - Home: index.md
+        - Architektur:
+          - Übersicht: architecture/overview.md
+          - Energy Layer: architecture/energy-layer.md
+          - Design Patterns: architecture/patterns.md
+        - Packages:
+          - Abstraction: packages/abstraction.md
+          - Solar: packages/solar.md
+          - Home: packages/home.md
+          # ... pro Package-Verzeichnis
+        - Integrations: integrations.md
+        - Notifications: notifications.md
+        - Infrastruktur: infrastructure.md
+        - Konventionen: conventions.md
+        - Changelog: changelog.md
+      ```
+
+      Mermaid-Extension sicherstellen:
+      ```yaml
+      markdown_extensions:
+        - pymdownx.superfences:
+            custom_fences:
+              - name: mermaid
+                class: mermaid
+                format: !!python/name:pymdownx.superfences.fence_code_format
+      ```
+
+      ### Phase 5: Qualitätsprüfung
+      1. Prüfe alle internen Links (relative Pfade)
+      2. Stelle sicher, dass alle Mermaid-Diagramme valide Syntax haben
+      3. Prüfe, dass keine sensitiven Daten in die Doku landen:
+         - **Erlaubt**: Interne IPs (172.x.x.x)
+         - **VERBOTEN**: Passwords, API-Keys, Tokens, `!secret`-Werte
+      4. Stelle sicher, dass `mkdocs.yml` valide ist
+
+  - op: append
+    content: |
+      ## Stil-Vorgaben
+
+      - **Sprache**: Deutsch (technische Begriffe dürfen Englisch bleiben)
+      - **Tonalität**: Technisch-sachlich, Power-User-Niveau
+      - **Code-Blöcke**: YAML mit Syntax-Highlighting
+      - **Tabellen**: Für Entitäten-Listen und Übersichten
+      - **Admonitions**: Für Warnungen, Tipps, wichtige Hinweise
+
+      ```markdown
+      !!! warning "Neustart erforderlich"
+          Nach Änderungen an diesem Package ist ein Full Restart nötig.
+
+      !!! tip "Debug-Modus"
+          Aktiviere `input_boolean.automation_debugger` für erweiterte Logs.
+      ```
+
+      - **Keine Emojis** in Überschriften oder Fließtext (nur in Admonition-Titeln erlaubt)
+
+      ## Wichtige Regeln
+
+      1. **Keine Erfindungen**: Dokumentiere NUR was tatsächlich im Code steht
+      2. **Versions-Tracking**: Extrahiere Versionen aus den YAML-Headern der Packages
+      3. **Entity-IDs**: Zeige die tatsächlichen Entity-IDs aus dem Code
+      4. **Kommentierte Packages**: Kennzeichne deaktivierte Packages (z.B. Mining) als "Deaktiviert"
+      5. **Existierende Docs erhalten**: `addons/mkdocs/help.md` und `assets/` NICHT überschreiben
+      6. **Inkrementelle Updates**: Wenn Docs bereits existieren, aktualisiere nur geänderte Seiten
+
+      ## Tool-Nutzung
+
+      - `Read` — Package-Dateien und existierende Docs lesen
+      - `Write` — Neue Doc-Dateien erstellen
+      - `Edit` — Existierende Docs aktualisieren
+      - `Glob` — Dateien finden (z.B. `packages/**/*.yaml`)
+      - `Grep` — Nach Patterns suchen (z.B. alle `unique_id` in einem Package)
+      - `Bash` — `git log` und Verzeichnis-Operationen
+---

--- a/agents/2-platform/sharkord-developer.md
+++ b/agents/2-platform/sharkord-developer.md
@@ -1,8 +1,8 @@
 ---
 name: sharkord-developer
-version: "2.0.0"
+version: "2.1.0"
 based-on: "1-generic/developer.md@1.4.1"
-description: "Sharkord-spezifischer Developer-Agent. Ergänzt den generischen Developer um Sharkord Plugin-SDK Wissen: PluginContext API, Mediasoup Audio-Streaming, Command-Registrierung, Events, Sharkord-spezifische Don'ts."
+description: "Sharkord-spezifischer Developer-Agent. Ergänzt den generischen Developer um Sharkord-Build-Kommandos. Das Sharkord Plugin-SDK Wissen (PluginContext API, Mediasoup, Commands, Events, Don'ts) kommt automatisch aus der Rule rules/2-platform/sharkord-sdk.md."
 hint: "Feature-Implementierung und Bugfixes nach REQ-IDs (Sharkord Plugin SDK)"
 tools:
   - Bash
@@ -23,110 +23,6 @@ patches:
       <!-- PROJEKTSPEZIFISCH: Build-Kommandos eintragen -->
       {{DEV_COMMANDS}}
 
-  - op: append-after
-    anchor: "## Build & Commands"
-    content: |
-      ## Sharkord Plugin-SDK
-
-      ### Plugin Entry-Point
-
-      ```typescript
-      const onLoad = async (ctx: PluginContext) => {
-        // Initialisierung: Commands, Settings, Events registrieren
-      };
-
-      const onUnload = (ctx: PluginContext) => {
-        // Cleanup: Streams, Transports, Producers schließen
-      };
-
-      export { onLoad, onUnload };
-      ```
-
-      ### PluginContext API
-
-      ```typescript
-      // Logging
-      ctx.log(message)        // Info-Level
-      ctx.debug(message)      // Debug-Level
-      ctx.error(message)      // Error-Level
-
-      // Plugin-Pfad
-      ctx.path                // Absoluter Pfad zum Plugin-Verzeichnis
-
-      // Events
-      ctx.events.on(event, handler)         // Event-Handler registrieren
-
-      // Commands
-      ctx.commands.register(definition)     // Command registrieren
-
-      // Settings
-      ctx.settings.register(definitions)   // Settings registrieren
-
-      // Voice/Mediasoup (SDK >= 0.0.16)
-      ctx.voice.getRouter(channelId)        // Mediasoup Router holen
-      ctx.voice.createStream(options)       // Audio-Stream registrieren
-      ctx.voice.getListenInfo()             // RTP Listen-Adresse { ip, announcedAddress }
-      ```
-
-      ### Command-Registrierung
-
-      ```typescript
-      ctx.commands.register<{ userId: string; filePath: string }>({
-        name: "my-command",
-        description: "Kurzbeschreibung des Commands.",
-        args: [
-          { name: "userId",   type: "string", required: true },
-          { name: "filePath", type: "string", required: false },
-        ],
-        async executes(invokerCtx, args) {
-          // Implementierung
-        },
-      });
-      ```
-
-      ### Mediasoup Audio-Streaming
-
-      ```typescript
-      const router = ctx.voice.getRouter(channelId);
-      const { ip, announcedAddress } = ctx.voice.getListenInfo();
-
-      const transport = await router.createPlainTransport({
-        listenInfo: { protocol: "udp", ip, announcedAddress },
-        rtcpMux: false,
-        comedia: true,
-      });
-
-      const producer = await transport.produce({
-        kind: "audio",
-        rtpParameters: {
-          codecs: [{ mimeType: "audio/opus", payloadType: 101, clockRate: 48000, channels: 2 }],
-          encodings: [{ ssrc: 1234 }],
-        },
-      });
-
-      const stream = ctx.voice.createStream({
-        channelId,
-        key: "my-stream",
-        title: "Stream-Titel",
-        producers: { audio: producer },
-      });
-
-      // Cleanup (immer in voice:runtime_closed):
-      stream.remove();
-      producer.close();
-      transport.close();
-      ```
-
-      ### Events-Referenz
-
-      | Event | Auslöser |
-      |-------|----------|
-      | `voice:runtime_initialized` | Voice-Channel geöffnet |
-      | `voice:runtime_closed` | Voice-Channel geschlossen → **CLEANUP erforderlich!** |
-      | `user:joined_voice` | Nutzer betritt Voice-Channel (SDK >= 0.0.16) |
-      | `user:left_voice` | Nutzer verlässt Voice-Channel (SDK >= 0.0.16) |
-      | `user:joined` | Nutzer betritt den Server |
-
   - op: replace
     anchor: "## Don'ts"
     content: |
@@ -140,14 +36,4 @@ patches:
 
       <!-- PROJEKTSPEZIFISCH: Weitere Don'ts → in .claude/3-project/{{PREFIX}}-developer-ext.md -->
       {{EXTRA_DONTS}}
-
-      ### Sharkord-spezifische Don'ts
-
-      - **KEIN** `ctx.actions.voice` — deprecated seit SDK 0.0.16 → stattdessen `ctx.voice`
-      - **KEIN** `child_process.spawn` → immer `Bun.spawn`
-      - **KEIN** `node:` Prefix wenn Bun-Äquivalent existiert (z.B. `Bun.file` statt `node:fs`)
-      - **KEINE** camelCase Spaltennamen in SQLite-Queries → Sharkord nutzt snake_case
-      - **KEIN** direkter Zugriff auf `window` / `document` — kein Browser-API
-      - **KEIN** `var` → `const` / `let`
-      - **KEIN** implizites `any`
 ---

--- a/agents/2-platform/sharkord-docker.md
+++ b/agents/2-platform/sharkord-docker.md
@@ -36,7 +36,7 @@ die Sharkord-Plattform-Besonderheiten.
 ### Image-Konvention
 
 ```yaml
-image: sharkord/sharkord:{{PRIMARY_IMAGE_TAG}}  # z.B. v0.0.16
+image: sharkord/sharkord:{{platform.sharkord.image_tag}}  # z.B. v0.0.16
 ```
 
 Der Image-Tag **muss** mit `peerDependencies` in `package.json` übereinstimmen.
@@ -208,7 +208,7 @@ Wenn nur `ffmpeg` via apt ausreicht:
 
 ```dockerfile
 # Dockerfile.dev
-FROM sharkord/sharkord:{{PRIMARY_IMAGE_TAG}}
+FROM sharkord/sharkord:{{platform.sharkord.image_tag}}
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
@@ -232,7 +232,7 @@ USER bun
 
 services:
   sharkord:
-    image: sharkord/sharkord:{{PRIMARY_IMAGE_TAG}}
+    image: sharkord/sharkord:{{platform.sharkord.image_tag}}
     # ODER: build: { context: ., dockerfile: Dockerfile.dev }  ← wenn Binaries via apt
     container_name: {{CONTAINER_NAME}}
     ports:
@@ -280,7 +280,7 @@ docker logs {{CONTAINER_NAME}} 2>&1 | grep -i token | head -3
 ```yaml
 environment:
   # LAN-IP des Host-Rechners eintragen (NICHT localhost/127.0.0.1)
-  - SHARKORD_WEBRTC_ANNOUNCED_ADDRESS={{HOST_LAN_IP}}  # z.B. 192.168.1.100
+  - SHARKORD_WEBRTC_ANNOUNCED_ADDRESS={{platform.sharkord.host_lan_ip}}  # z.B. 192.168.1.100
 ports:
   - "40000-40100:40000-40100/udp"  # UDP-Range für RTP Media
 ```
@@ -333,7 +333,7 @@ Diese Datei ersetze durch eine Projekt-Instanz. Folgende `{{%PLATZHALTER%}}` aus
 |-------------|-------------|---------|
 | `{{PROJECT_NAME}}` | Vollständiger Plugin-Name | `sharkord-vid-with-friends` |
 | `{{PREFIX}}` | Agent-Präfix | `vwf` |
-| `{{PRIMARY_IMAGE_TAG}}` | Docker-Image-Tag des Kernsystems | `v0.0.16` |
+| `{{platform.sharkord.image_tag}}` | Docker-Image-Tag des Kernsystems | `v0.0.16` |
 | `{{SYSTEM_DEPENDENCIES}}` | Kern-Abhängigkeiten mit Versionen (Markdown-Liste) | `- @sharkord/plugin-sdk: \`0.0.16\`` |
 | `{{SYSTEM_URLS}}` | System-URLs (Markdown-Liste) | `- Sharkord Web-UI: \`http://localhost:3000\`` |
 | `{{PLUGIN_DIR_NAME}}` | Verzeichnisname = `package.json` name | `sharkord-vid-with-friends` |
@@ -342,7 +342,7 @@ Diese Datei ersetze durch eine Projekt-Instanz. Folgende `{{%PLATZHALTER%}}` aus
 | `{{PRIMARY_PORT}}` | Haupt-Port (Web-UI) | `3000` |
 | `{{EXTRA_PORTS}}` | Weitere Ports (Markdown-Liste) | `- \`40000/tcp\` — Mediasoup Signal` |
 | `{{BUILD_COMMAND}}` | Build-Befehl | `bun run build` |
-| `{{HOST_LAN_IP}}` | LAN-IP des Entwicklungs-Rechners | `192.168.1.100` |
+| `{{platform.sharkord.host_lan_ip}}` | LAN-IP des Entwicklungs-Rechners | `192.168.1.100` |
 | `{{EXTRA_VOLUMES}}` | Zusätzliche Volume-Mounts | Debug-Cache, Test-Musik |
 | `{{EXTRA_STARTUP_INFO}}` | Infos in Startup-Box | Debug-Cache-Pfad |
 

--- a/agents/2-platform/sharkord-release.md
+++ b/agents/2-platform/sharkord-release.md
@@ -136,7 +136,7 @@ Erstelle `dist/RELEASE_NOTES.md`:
 N. Sharkord neustarten
 
 ### Requirements
-- **Sharkord** >= {{SHARKORD_MIN_VERSION}}
+- **Sharkord** >= {{platform.sharkord.min_version}}
 
 ### Tech Stack
 {{TECH_STACK}}
@@ -266,6 +266,6 @@ cat dist/{{PLUGIN_DIR_NAME}}/package.json | grep version
 | `{{REQUIRED_BINARIES_SECTION}}` | Binaries-Block in Release Notes | ffmpeg + yt-dlp Tabelle | ffmpeg Tabelle |
 | `{{BINARY_INSTALL_STEPS}}` | Installationsschritte für Binaries | `3. ffmpeg in bin/ legen` + `4. yt-dlp in bin/ legen` | `3. ffmpeg in bin/ legen` |
 | `{{REQUIRED_BINARY_NAMES}}` | Binary-Namen für Don'ts | `ffmpeg, yt-dlp` | `ffmpeg` |
-| `{{SHARKORD_MIN_VERSION}}` | Mindest-Sharkord-Version | `0.0.7` | `0.0.15` |
+| `{{platform.sharkord.min_version}}` | Mindest-Sharkord-Version | `0.0.7` | `0.0.15` |
 | `{{TECH_STACK}}` | Tech Stack in Release Notes | `TypeScript, Bun, Mediasoup, tRPC, React, Zod` | `TypeScript, Bun, Mediasoup, ffmpeg` |
 | `{{BUILD_SYSTEM_NOTES}}` | Build-Besonderheiten | `scripts/write-dist-package.ts` liest Version, fügt Timestamp hinzu | `build.ts` kopiert `package.json` 1:1, kein Timestamp |

--- a/howto/platform-config.md
+++ b/howto/platform-config.md
@@ -1,0 +1,191 @@
+# Platform Config Instantiation
+
+Platform-spezifische Rules und Agenten-Templates können Platzhalter wie
+`{{platform.homeassistant.admin_group}}` enthalten. Diese werden beim Sync gegen
+Werte aus einer neuen `platform-config.yaml` im Zielprojekt ersetzt — mit sinnvollen
+Defaults aus dem Meta-Repo.
+
+---
+
+## Konzept
+
+```
+agent-meta/platform-configs/<platform>.defaults.yaml   ← Defaults (im Meta-Repo)
+    +
+.claude/platform-config.yaml                           ← Overrides (im Zielprojekt)
+    ↓  sync.py merged + substituiert
+.claude/rules/<platform>-*.md                          ← Generierte Rules (Platzhalter ersetzt)
+.claude/agents/<role>.md                               ← Generierte Agenten (Platzhalter ersetzt)
+```
+
+**Precedence:** Projekt-Override > Platform-Default
+
+---
+
+## Platzhalter-Syntax
+
+```
+{{platform.<plattform>.<schluessel>}}
+```
+
+Beispiele:
+- `{{platform.homeassistant.notify_group}}`
+- `{{platform.homeassistant.influxdb_bucket}}`
+- `{{platform.homeassistant.ha_url}}`
+
+**Abgrenzung zu `{{GROSS}}`-Platzhaltern:**
+
+| Typ | Syntax | Quelle | Scope |
+|-----|--------|--------|-------|
+| Platform-Config | `{{platform.*}}` | `platform-configs/*.defaults.yaml` + `.claude/platform-config.yaml` | Nur für Plattform-Templates |
+| Agent-Variables | `{{GROSS_MIT_UNTERSTRICH}}` | `agent-meta.config.json` → `variables` | Alle Templates |
+
+Die beiden Namespaces überschneiden sich nie.
+
+---
+
+## Defaults-Datei anlegen (Meta-Repo)
+
+Neue Datei `platform-configs/<platform>.defaults.yaml`:
+
+```yaml
+# platform-configs/meine-plattform.defaults.yaml
+platform:
+  meine-plattform:
+    # Leerer String = Pflichtfeld (User muss es überschreiben)
+    api_key: ""
+
+    # Gefüllter Wert = sinnvoller Default
+    base_url: "http://localhost:8080"
+    debug_sensor: "input_boolean.debug_mode"
+```
+
+**Konvention:**
+- `""` (leerer String) → Pflichtfeld. sync.py emittiert `[WARN]` wenn nicht überschrieben.
+- Nicht-leerer Wert → sinnvoller Default, funktioniert ohne Überschreibung.
+
+---
+
+## Projekt-Overrides (Zielprojekt)
+
+Erstelle `.claude/platform-config.yaml` im Zielprojekt — nur was du überschreiben willst:
+
+```yaml
+# .claude/platform-config.yaml
+# Overrides for agent-meta platform defaults.
+# Only set values you want to override — all other defaults remain active.
+
+platform:
+  homeassistant:
+    notify_group: "mobile_app_all"
+    notify_admin_group: "admin_family"
+    influxdb_bucket: "homeassistant"
+    influxdb_org: "myhome"
+    # ha_url und entities_csv_path haben sinnvolle Defaults → keine Überschreibung nötig
+```
+
+Die Datei ist **nicht von sync.py verwaltet** — sie liegt vollständig in der Projektkontrolle.
+
+---
+
+## Sync-Verhalten
+
+`sync.py` führt bei jedem normalen Sync folgende Schritte für Platform-Configs aus:
+
+1. Für jede aktive Plattform (aus `platforms` in `agent-meta.config.json`):
+   - Lade `platform-configs/<platform>.defaults.yaml` aus dem Meta-Repo
+   - Lade `.claude/platform-config.yaml` aus dem Zielprojekt (optional)
+   - Merge: Projekt-Overrides überschreiben Defaults
+2. Substituiere `{{platform.*}}`-Platzhalter in allen generierten Dateien:
+   - `.claude/rules/*.md` (Platform-Rules)
+   - `.claude/agents/*.md` (Platform-Agenten)
+3. Emittiere `[WARN]` wenn ein Pflichtfeld (leerer Default) nicht überschrieben wurde
+
+**Kein Breaking Change:** Bestehende `{{GROSS}}`-Platzhalter aus `agent-meta.config.json` bleiben unverändert.
+
+---
+
+## Warnungen verstehen
+
+### Pflichtfeld nicht gesetzt
+
+```
+[WARN]  platform-config: required field {{platform.homeassistant.notify_group}} is empty
+        — add it to .claude/platform-config.yaml
+```
+
+Das Feld hat einen leeren Default und wurde nicht in `.claude/platform-config.yaml` gesetzt.
+Der Platzhalter bleibt als leerer String im Output — funktioniert, aber ist wahrscheinlich falsch.
+
+**Lösung:** Wert in `.claude/platform-config.yaml` eintragen.
+
+### Unbekannter Platzhalter
+
+```
+[WARN]  platform-config: placeholder {{platform.homeassistant.unknown_key}} not found
+        in platform defaults or project overrides — placeholder remains in: ...
+```
+
+Ein Template enthält `{{platform.*}}` für einen Key der nicht in den Defaults definiert ist.
+
+**Lösung:** Key in `platform-configs/<platform>.defaults.yaml` mit sinnvollem Default ergänzen.
+
+---
+
+## Verfügbare Platform-Configs
+
+### `homeassistant`
+
+**Datei:** `platform-configs/homeassistant.defaults.yaml`
+
+| Key | Default | Pflichtfeld | Beschreibung |
+|-----|---------|:-----------:|--------------|
+| `platform.homeassistant.notify_group` | `""` | ✅ | Standard-Notify-Gruppe (alle Bewohner) |
+| `platform.homeassistant.notify_admin_group` | `""` | ✅ | Admin/Debug-Notify-Gruppe |
+| `platform.homeassistant.debug_sensor` | `input_boolean.automation_debugger` | | Debug-Toggle-Sensor |
+| `platform.homeassistant.ha_url` | `http://homeassistant.local:8123` | | HA-Instanz URL |
+| `platform.homeassistant.influxdb_bucket` | `""` | ✅ | InfluxDB Bucket-Name |
+| `platform.homeassistant.influxdb_org` | `""` | ✅ | InfluxDB Organisation |
+| `platform.homeassistant.entities_csv_path` | `hass_entities.csv` | | Pfad zur Entity-CSV |
+
+---
+
+## Neue Platform-Config hinzufügen
+
+1. Neue Datei `platform-configs/<platform>.defaults.yaml` anlegen
+2. In allen `rules/2-platform/<platform>-*.md` und `agents/2-platform/<platform>-*.md`
+   hartcodierte Werte durch `{{platform.<platform>.<key>}}`-Platzhalter ersetzen
+3. In der Dokumentation (diese Datei) die neue Tabelle ergänzen
+
+Keine Änderung an `sync.py` nötig — das System arbeitet automatisch für jede Plattform
+die in `agent-meta.config.json` → `platforms` aktiv ist und eine Defaults-Datei hat.
+
+---
+
+## Beispiel: Vollständige Einrichtung
+
+**Schritt 1: Zielprojekt konfigurieren** (`agent-meta.config.json`):
+```json
+{
+  "platforms": ["homeassistant"],
+  ...
+}
+```
+
+**Schritt 2: Platform-Overrides anlegen** (`.claude/platform-config.yaml`):
+```yaml
+platform:
+  homeassistant:
+    notify_group: "mobile_app_alle"
+    notify_admin_group: "admin_notifications"
+    influxdb_bucket: "homeassistant"
+    influxdb_org: "myhome"
+```
+
+**Schritt 3: Sync ausführen**:
+```bash
+python .agent-meta/scripts/sync.py --config agent-meta.config.json
+```
+
+**Ergebnis:** Alle `{{platform.homeassistant.*}}`-Platzhalter in generierten Rules und
+Agenten werden mit den konfigurierten Werten ersetzt.

--- a/platform-configs/homeassistant.defaults.yaml
+++ b/platform-configs/homeassistant.defaults.yaml
@@ -1,0 +1,67 @@
+# platform-configs/homeassistant.defaults.yaml
+# =============================================================================
+# Default configuration for the "homeassistant" platform.
+#
+# These values are injected into rules/2-platform/homeassistant-*.md and
+# agents/2-platform/homeassistant-*.md as {{platform.homeassistant.*}} placeholders
+# during sync.
+#
+# OVERRIDE in your project by creating .claude/platform-config.yaml:
+#
+#   platform:
+#     homeassistant:
+#       notify_group: "my_mobile_app"
+#       notify_admin_group: "my_admin_group"
+#
+# Empty string ("") = required field — sync.py emits [WARN] if not overridden.
+# Non-empty value   = sensible default that works out of the box.
+# =============================================================================
+
+platform:
+  homeassistant:
+
+    # -------------------------------------------------------------------------
+    # Notification groups (notify.<group>)
+    # -------------------------------------------------------------------------
+
+    # Standard notification group for all residents
+    # Example: "mobile_app_all" → notify.mobile_app_all
+    notify_group: ""
+
+    # Admin/debug notification group for administrative messages
+    # Example: "admin_group" → notify.admin_group
+    notify_admin_group: ""
+
+    # -------------------------------------------------------------------------
+    # Debug sensor
+    # -------------------------------------------------------------------------
+
+    # Entity ID of the debug toggle boolean
+    # Used in automation debug conditions: state: 'on' sends intermediate messages
+    debug_sensor: "input_boolean.automation_debugger"
+
+    # -------------------------------------------------------------------------
+    # Home Assistant instance
+    # -------------------------------------------------------------------------
+
+    # Base URL of the Home Assistant instance (without trailing slash)
+    ha_url: "http://homeassistant.local:8123"
+
+    # -------------------------------------------------------------------------
+    # InfluxDB integration
+    # -------------------------------------------------------------------------
+
+    # InfluxDB bucket name where Home Assistant sensor data is stored
+    # Example: "homeassistant" or "ha_prod"
+    influxdb_bucket: ""
+
+    # InfluxDB organization name
+    influxdb_org: ""
+
+    # -------------------------------------------------------------------------
+    # Entity data / CSV export
+    # -------------------------------------------------------------------------
+
+    # Path to the hass_entities.csv export file (relative to project root or absolute)
+    # Used as secondary data source when MCP is unavailable
+    entities_csv_path: "hass_entities.csv"

--- a/platform-configs/sharkord.defaults.yaml
+++ b/platform-configs/sharkord.defaults.yaml
@@ -1,0 +1,53 @@
+# platform-configs/sharkord.defaults.yaml
+# =============================================================================
+# Default configuration for the "sharkord" platform.
+#
+# These values are injected into rules/2-platform/sharkord-*.md and
+# agents/2-platform/sharkord-*.md as {{platform.sharkord.*}} placeholders
+# during sync.
+#
+# OVERRIDE in your project by creating .claude/platform-config.yaml:
+#
+#   platform:
+#     sharkord:
+#       image_tag: "v0.1.0"
+#       min_version: "0.1.0"
+#
+# Empty string ("") = required field — sync.py emits [WARN] if not overridden.
+# Non-empty value   = sensible default that works out of the box.
+# =============================================================================
+
+platform:
+  sharkord:
+
+    # -------------------------------------------------------------------------
+    # Docker image
+    # -------------------------------------------------------------------------
+
+    # Docker image tag — must match peerDependencies in package.json
+    # Example: "v0.0.16"
+    image_tag: "v0.0.16"
+
+    # -------------------------------------------------------------------------
+    # Release notes
+    # -------------------------------------------------------------------------
+
+    # Minimum Sharkord version required by this plugin (for release notes)
+    # Example: "0.0.16"
+    min_version: "0.0.16"
+
+    # -------------------------------------------------------------------------
+    # Docker Compose
+    # -------------------------------------------------------------------------
+
+    # Compose service name — identical across all Sharkord projects
+    service_name: "sharkord"
+
+    # -------------------------------------------------------------------------
+    # WebRTC / Mediasoup
+    # -------------------------------------------------------------------------
+
+    # LAN IP for SHARKORD_WEBRTC_ANNOUNCED_ADDRESS
+    # Override with your actual LAN IP for WebRTC to work on the local network
+    # Example: "192.168.1.100"
+    host_lan_ip: "127.0.0.1"

--- a/rules/2-platform/homeassistant-energy-abstraction.md
+++ b/rules/2-platform/homeassistant-energy-abstraction.md
@@ -1,0 +1,103 @@
+# Energy Abstraction Layer
+
+## System-Kontext
+**Datei**: `/config/packages/abstraction/energy_power.yaml`
+
+## Konzept
+
+Physische Entitäten (z.B. von Tasmota, Shelly, Zigbee) werden **NIEMALS direkt** in Dashboards oder Utility Metern verwendet. Stattdessen werden Template-Sensoren erstellt, die standardisierte IDs und Namen haben.
+
+## Technik
+
+- **YAML-Anker**: Werden genutzt (`&energy_style`, `*energy_style`) um Code zu reduzieren
+  - Definition (`&`) MUSS vor Referenz (`*`) stehen
+- **Utility Meter**: Greifen ausschließlich auf abstrahierte Template-Sensoren zu
+- **UUIDs**: Jede Entität bekommt eine statische v4 UUID
+
+## Architektur-Regeln für Erweiterungen
+
+Wenn ein neuer Smart Plug hinzugefügt werden soll, befolge **strikt** dieses Muster:
+
+### 1. Abstraktion (Template Sensors)
+- Erstelle einen Sensor für **Energy (kWh)** und einen für **Power (W)**
+- **Naming**: "[Raum/Gerät] [Gesamtverbrauch|Aktuelle Leistung]"
+- **State**: Nutze `| float(0)` im Template zur Fehlervermeidung
+- **Style**: Nutze die existierenden Anker `*energy_style` und `*power_style`
+- **UUID**: Generiere zwingend neue UUIDs
+
+### 2. Utility Meter
+- Erstelle einen Zähler mit dem Suffix `_energy_count`
+- **Source**: Muss der neue abstrahierte Sensor sein (nicht die Hardware-Entität!)
+- **Config**: Nutze den Anker `*meter_config_no_reset`
+
+## Spike-Filter: Monoton steigende Energy-Sensoren
+
+### Problem
+Manche Smart Plugs (z.B. Zigbee/Tasmota) melden durch Hardwarefehler **schwankende kWh-Werte** (Sägezahn-Muster). Der Energy-Wert springt z.B. zwischen 3.24 und 3.33 hin und her. Da ein `utility_meter` mit `delta_values: false` jeden Anstieg als echten Verbrauch zählt, Rückgänge aber ignoriert, **schaukelt sich der Zähler auf** — es wird Phantomverbrauch akkumuliert.
+
+### Lösung: `this.state`-Filter
+Ein Energiezähler (kWh) darf physikalisch nur steigen. Der Template-Sensor nutzt `this.state` um seinen vorherigen Wert zu referenzieren und akzeptiert nur Werte `>= old_val`:
+
+```yaml
+# --- Energy (kWh) --- SPIKE-FILTER (monoton steigend) ---
+- name: "[Name] Gesamtverbrauch"
+  unique_id: "[UUID]"
+  state: >
+    {% set new_val = states('sensor.hardware_id_energy') | float(0) %}
+    {% set old_val = this.state | float(0) %}
+    {# Energiezähler dürfen nur steigen — Rücksprünge = Hardwarefehler #}
+    {% if new_val >= old_val %}
+      {{ new_val }}
+    {% else %}
+      {{ old_val }}
+    {% endif %}
+  availability: >
+    {{ has_value('sensor.hardware_id_energy') }}
+  <<: *energy_style
+```
+
+### Wann anwenden?
+- Wenn ein Hardware-Sensor **schwankende Totalverbrauchswerte** meldet
+- Erkennbar an: Sägezahn-Muster in InfluxDB, aufschaukelnder Utility Meter
+- **Nicht** anwenden bei Power-Sensoren (W) — diese dürfen schwanken
+
+### Nach Anwendung
+- **Template Reload** reicht (Developer Tools → YAML → Template Entities)
+- **Utility Meter zurücksetzen**: Aufgeschaukelten Zählerstand über Developer Tools → States korrigieren
+
+## Code-Vorlage (Copy-Paste Ready)
+
+```yaml
+# =====================================================
+# NEUES GERÄT: [Gerätename]
+# HARDWARE ID: [sensor.hardware_id_...]
+# =====================================================
+template:
+  - sensor:
+      # --- Energy (kWh) ---
+      - name: "[Name] Gesamtverbrauch"
+        unique_id: "[NEUE_UUID_V4]"
+        state: >
+          {{ states('sensor.hardware_id_energy') | float(0) }}
+        <<: *energy_style
+
+      # --- Power (W) ---
+      - name: "[Name] Aktuelle Leistung"
+        unique_id: "[NEUE_UUID_V4]"
+        state: >
+          {{ states('sensor.hardware_id_power') | float(0) }}
+        <<: *power_style
+
+utility_meter:
+  [name]_energy_count:
+    source: sensor.[slug_des_abstrahierten_sensors]
+    name: "[Name] Gesamtverbrauch Count"
+    unique_id: "[NEUE_UUID_V4]"
+    <<: *meter_config_no_reset
+```
+
+## Vorhandene Definitionen
+
+- Anker-Definitionen (`&`) befinden sich im ersten Geräte-Block der Datei
+- Alle neuen Geräte müssen **danach** eingefügt werden oder Referenzen (`*`) nutzen
+- Vorhandene Geräte: in `energy_power.yaml` nachschauen — Anker-Definitionen stehen ganz oben

--- a/rules/2-platform/homeassistant-entity-data.md
+++ b/rules/2-platform/homeassistant-entity-data.md
@@ -1,0 +1,105 @@
+# Entity-Daten Beschaffung & Analyse
+
+## Datenquellen-Hierarchie
+
+1. **Primary Source (Echtzeit)**: MCP `GetLiveContext` Tool
+   - Liefert Echtzeit-Kontext über den aktuellen Zustand von Geräten, Sensoren und Areas
+   - **IMMER bevorzugt**, wenn MCP verfügbar ist
+
+2. **Secondary Source (Snapshot)**: `{{platform.homeassistant.entities_csv_path}}` aus dem Entity-Analyzer-Tool
+   - Enthält alle vorhandenen Entitäten mit Metadaten:
+     - `ENTITY ID`, `ENTITY NAME`, `DEVICE NAME`, `DEVICE ID`, `AREA`
+     - `PLATFORM`, `INTEGRATION`, `DOMAIN`, `DEVICE AREA`
+   - Wird regelmäßig per Automation aktualisiert
+   - Nutze CSV für **Vergleiche & Pattern-Analyse** und umfassende Übersichten
+
+3. **Developer Console Template (Fallback)**: Manuelle Validierung durch User
+   - Wenn MCP nicht erreichbar ist
+   - Begrenzte Daten-Sicht, aber keine Abhängigkeiten
+
+## Workflow: Entity-Daten Beschaffung
+
+```
+Szenario:
+- User fragt: "Welche Sensoren sind im Wohnzimmer?"
+
+Ablauf:
+1. VERSUCHE: MCP GetLiveContext → ECHTZEITDATEN
+   ├─ Wenn erfolgreich: Nutze diese Daten + alle Attribute
+   └─ Gib Details zu State, Attributes, Last Changed aus
+
+2. FALLBACK: CSV durchsuchen nach "wohnzimmer" in AREA oder ENTITY NAME
+   ├─ CSV zeigt: Alle zugeordneten Entitäten (Snapshot)
+   └─ Gib Warnung aus: "CSV ist ein Snapshot vom [Zeitstempel]"
+
+3. LAST RESORT: Template für Entwicklerconsole geben
+   ├─ User muss manuell validieren
+   └─ Kombiniert Precision + Autarkie
+```
+
+## Vergleich: MCP vs. CSV vs. Developer Console
+
+| Aspekt | MCP (GetLiveContext) | CSV File | Developer Console |
+|--------|----------------------|----------|-------------------|
+| **Aktualität** | Live | Snapshot | Manuell |
+| **Status** | Echtzeit State | Registry-Daten | Live, manuell |
+| **Attribute** | Kontextabhängig | Teilweise | Manuell |
+| **Verfügbarkeit** | Netz erforderlich | Immer lokal | Immer lokal |
+| **Priorität** | **#1 Primary** | #2 Secondary | #3 Fallback |
+
+## Nutzungsregeln
+
+**CSV nutzen, wenn:**
+- MCP ist nicht erreichbar ODER
+- User möchte umfassende **Übersicht aller Entitäten** (nicht einzelne prüfen) ODER
+- Pattern-Analyse über viele Entitäten (z.B. "Welche Integrationen nutzen wir?")
+
+**MCP nutzen, wenn:**
+- User fragt nach **aktuellem Zustand** eines Geräts/Sensors/Bereichs ODER
+- User hat Doubt über aktuelle Daten (Real-time Check erforderlich) ODER
+- Debugging: Aktueller State als erster Schritt vor einer bedingten Aktion
+
+**Kombinieren:**
+- MCP für aktuellen State + CSV zur Validierung der Registry-Struktur
+- CSV für Überblick + MCP für Detailfragen zu spezifischen Entities
+
+## CSV-Struktur & Interpretation
+
+**Beispiel-Zeile:**
+```
+light.wohnzimmer_hue;Wohnzimmer Hue;Hue Bridge;device-123;Wohnzimmer;zigbee;hue;light;Wohnzimmer
+```
+
+**Spalten-Bedeutung:**
+- `ENTITY ID`: Eindeutige System-ID (immer stabil)
+- `ENTITY NAME`: Freundlicher Name (kann sich ändern)
+- `DEVICE NAME`: Hardware-Name (z.B. "Hue Bridge")
+- `DEVICE ID`: Eindeutige Geräte-ID
+- `AREA`: **Räumliche Zuordnung** (KANN LEER SEIN)
+- `PLATFORM`: Wo kommen die Daten her (z.B. "zigbee", "mqtt", "rest")
+- `INTEGRATION`: Integration-Name (z.B. "hue", "mqtt", "template")
+- `DOMAIN`: Entity-Type (z.B. "light", "sensor", "switch")
+- `DEVICE AREA`: Area vom Device (Fallback wenn Entity-Area leer)
+
+## Häufige CSV-Anomalien & Interpretation
+
+| Anomalie | Grund | Aktion |
+|----------|-------|--------|
+| **AREA ist leer** | Entity/Device hat keine Area zugeordnet | MCP nutzen um zu prüfen, oder manuell zuordnen |
+| **DEVICE NAME leer** | Entität ist "Orphan" (gehört zu keinem Device) | Prüfe ob Integration noch aktiv ist |
+| **Doppelte ENTITY IDs** | CSV-Export-Bug oder mehrere Quellen | MCP `GetLiveContext` zur Validierung |
+| **PLATFORM vs INTEGRATION verschieden** | Normalität (z.B. Platform=rest, Integration=openweathermap) | Erwartetes Verhalten |
+
+## Beispiel-Template für Entwicklerconsole (Fallback)
+
+```jinja2
+{# Wenn MCP nicht verfügbar - User manuell validieren #}
+
+{# Aktuelle State + Attribute #}
+{{ states('sensor.example_entity') }}
+{{ state_attr('sensor.example_entity', 'unit_of_measurement') }}
+{{ states.sensor.example_entity.attributes }}
+
+{# Entity-Registry Infos (zeigt, ob Entität aktiviert ist) #}
+{# Copyable Template für Developer Tools → Templates #}
+```

--- a/rules/2-platform/homeassistant-mcp-integration.md
+++ b/rules/2-platform/homeassistant-mcp-integration.md
@@ -1,0 +1,72 @@
+# MCP Integration (Home Assistant + InfluxDB)
+
+## ABSOLUTE REGEL: NUR LESENDE OPERATIONEN!
+
+Das Home Assistant MCP darf **ausschließlich für lesende Operationen** verwendet werden.
+
+**ABSOLUTE VERBOTE — ohne Ausnahme, auch nicht auf User-Anfrage:**
+- **KEINE** schreibenden Operationen (`HassTurnOn`, `HassTurnOff`, `HassLightSet`, etc.)
+- **KEINE** Gerätesteuerung (Licht, Klima, Cover, Media, Vakuum, etc.)
+- **KEINE** Zustandsänderungen von Entitäten
+- **KEINE** Broadcasts oder Nachrichten senden
+- **KEINE** Timer abbrechen
+- **KEINE** Todo-Listen-Einträge ändern (`HassListAddItem`, `HassListCompleteItem`, `HassListRemoveItem`)
+
+Wenn der User eine Gerätesteuerung anfragt → **Weise darauf hin, dass dies über die HA-App, Dashboard oder Sprachassistent erfolgen muss, nicht über Claude Code.**
+
+## Erlaubte Home Assistant MCP-Tools (Read-Only)
+
+| Tool | Verwendungszweck |
+|------|------------------|
+| `GetLiveContext` | Echtzeit-Kontext über aktuellen Zustand von Geräten, Sensoren, Areas. **Primäres Tool für Diagnose & Statusabfragen.** |
+| `GetDateTime` | Aktuelles Datum und Uhrzeit von Home Assistant |
+| `todo_get_items` | Todo-Listen **abfragen** (nur lesen, nicht ändern!) |
+
+## InfluxDB MCP Server
+
+### Konfiguration
+- **Server**: `influxdb-mcp-server` (npm-Paket von [idoru/influxdb-mcp-server](https://github.com/idoru/influxdb-mcp-server))
+- **Protokoll**: InfluxDB OSS API v2 (Flux-Queries)
+- **Bucket**: `{{platform.homeassistant.influxdb_bucket}}`
+- **Organisation**: `{{platform.homeassistant.influxdb_org}}`
+- **Datenstruktur**: Measurements basieren auf der **Einheit** (z.B. "W" für Watt), nicht "state"
+- **Entity-IDs**: Können vom HA-Namen abweichen (ohne "sensor."-Prefix)
+
+### Erlaubte Verwendungen
+- Flux-Queries zum **Lesen** von historischen Daten
+- Wertebereich-Analysen (Min/Max/Avg über Zeiträume)
+- Pattern-Erkennung und Ausreißer-Analyse
+- Vergleich von Sensordaten über Tage/Wochen/Monate
+
+### VERBOTEN für InfluxDB
+- **KEINE** Schreiboperationen (kein Daten einfügen/ändern/löschen)
+- **KEINE** Bucket- oder Organisations-Verwaltung
+- **KEINE** Retention-Policy-Änderungen
+
+## Datenquellen-Hierarchie für Diagnose
+
+| Priorität | Quelle | Stärke |
+|-----------|--------|--------|
+| **#1** | MCP `GetLiveContext` | Echtzeit-Status, Attribute |
+| **#2** | InfluxDB MCP (Flux) | Historische Daten, Trends, Ausreißer |
+| **#3** | `{{platform.homeassistant.entities_csv_path}}` | Registry-Übersicht (Integration, Platform, Area) |
+| **#4** | Developer Console Template | Manueller Fallback durch User |
+
+## Workflow: Diagnose mit beiden MCP-Servern
+
+```
+User: "Mein Sensor springt ständig zwischen Werten."
+
+1. GetLiveContext → Aktuellen State + Attribute prüfen
+2. InfluxDB Flux-Query → Historische Werte der letzten 24h/7d analysieren
+3. CSV (optional) → Integration/Platform bestätigen
+4. Lösungsvorschlag generieren basierend auf den Erkenntnissen
+```
+
+## Fehler-Handling
+
+Wenn MCP-Tools nicht verfügbar sind:
+- Falle zurück auf **Developer Console Templates** für Statusabfragen
+- Fordere User auf, bestimmte Werte manuell zu prüfen
+- Nutze die **`{{platform.homeassistant.entities_csv_path}}`** aus dem Entity-Analyzer-Tool
+- Generiere Code mit sicheren Defaults (z.B. `| float(0)`, `default='unknown'`)

--- a/rules/2-platform/homeassistant-notifications.md
+++ b/rules/2-platform/homeassistant-notifications.md
@@ -1,0 +1,43 @@
+# Notifications & Debug-Modus
+
+## Notification-Gruppen
+
+| Gruppe | Entity | Verwendung |
+|--------|--------|------------|
+| **Standard** | `notify.{{platform.homeassistant.notify_group}}` | Normale Benachrichtigungen an alle Bewohner |
+| **Admin/Debug** | `notify.{{platform.homeassistant.notify_admin_group}}` | Administrative und Debug-Meldungen |
+
+## Debug-Modus
+
+- **Sensor**: `{{platform.homeassistant.debug_sensor}}`
+- Im eingeschalteten Zustand: Sende Zwischenschritt-Benachrichtigungen an die Admin-Gruppe
+
+### Pattern: Debug-Check in Automations
+
+```yaml
+- condition: state
+  entity_id: {{platform.homeassistant.debug_sensor}}
+  state: 'on'
+- action: notify.{{platform.homeassistant.notify_admin_group}}
+  data:
+    message: "DEBUG: [Automatisierungsname] — Zwischenschritt [N] erreicht"
+```
+
+### Best Practice
+- Debug-Conditions immer **vor** dem eigentlichen Action-Block einfügen
+- Message-Text: `"DEBUG: [Automation-Alias] — [was gerade passiert ist]"`
+- Nach Debugging: `{{platform.homeassistant.debug_sensor}}` wieder auf `off` setzen — nie im Code lassen
+
+## Actionable Notifications (iOS/Android)
+
+- Actionable Notifications ermöglichen Schaltflächen direkt in der Push-Benachrichtigung
+- Events werden als `mobile_app_notification_action` gefeuert
+- Kamera-Snapshots: Via `camera.snapshot` vor dem Notify-Call erstellen, dann als `image:` anhängen
+
+### Reload vs. Restart
+
+| Änderung | Erforderlich |
+|----------|-------------|
+| YAML-Änderungen (Automations, Templates) | **Quick Reload** (Developer Tools → YAML) |
+| Neue Domain hinzugefügt (z.B. neues `input_boolean`) | **Full Restart** |
+| Package-Struktur geändert | **Full Restart** |

--- a/rules/2-platform/homeassistant-package-structure.md
+++ b/rules/2-platform/homeassistant-package-structure.md
@@ -1,0 +1,221 @@
+# Package-Struktur & Fachliches Clustering
+
+## Oberste Direktive: Modularisierung
+
+Das Home Assistant Repository folgt einer **strikten fachlichen Clusterung** durch das Package-System. Konfigurationen werden **NIEMALS** monolithisch in einzelne Root-Dateien (wie `sensor.yaml`, `automation.yaml`) geschrieben, sondern modular in thematische Packages aufgeteilt.
+
+## Aktuelle Package-Struktur
+
+Das `/config/packages/` Verzeichnis ist nach **Fachdomänen** organisiert:
+
+```
+packages/
+├── abstraction/        # Abstraktionsschichten (z.B. energy_power.yaml)
+├── bsm/                # Batterie-/Speicher-Management (battery_control.yaml)
+├── car/                # Auto-bezogene Integrationen (Ladung, Fahrzeug-APIs)
+├── fitness/            # Fitness & Gesundheits-Tracking
+├── grid/               # Stromnetz, Spotpreise
+├── heating/            # Heizungs-Steuerung
+├── home/               # Haus-Kernfunktionen (climate.yaml, window_monitoring.yaml, air_quality.yaml)
+├── home_appliances/    # Haushaltsgeräte (Waschmaschine, Trockner, Geschirrspüler)
+├── location/           # Präsenz, GPS, Zonen
+├── mining/             # Krypto-Mining Überwachung
+├── report/             # Reporting & Statistiken
+├── solar/              # Solar-Erzeugung (dtu.yaml, solarforecast.yaml, solarmanager.yaml)
+└── weather/            # Wetter-Daten & Vorhersagen
+```
+
+## Package-Philosophie
+
+### Grundprinzipien
+1. **Ein Package = Eine Fachdomäne**: Jedes Package behandelt einen abgeschlossenen Themenbereich
+2. **Ein File = Ein Sub-Thema**: Innerhalb eines Packages wird nach Sub-Themen aufgeteilt
+3. **Keine Root-Dateien**: Root-Dateien (z.B. `sensor.yaml`) bleiben leer oder enthalten nur `!include_dir_merge_list packages/`
+4. **Self-Contained**: Jedes Package ist in sich geschlossen und kann isoliert verstanden werden
+
+### Beispiel-Aufbau eines Packages
+
+**Datei**: `/config/packages/home/climate.yaml`
+```yaml
+# ==============================================================================
+# PACKAGE: Home Climate Management
+# Beschreibung: Zentrale Klima-Steuerung für alle Räume inkl. Circadian Rhythm
+# ==============================================================================
+
+# --- Input Helpers ---
+input_boolean:
+input_number:
+
+# --- Template Sensors ---
+template:
+  - sensor:
+  - binary_sensor:
+
+# --- Automations ---
+automation:
+  - alias: "Climate Scheduler [V1.0]"
+    id: climate_scheduler
+
+# --- Scripts ---
+script:
+  climate_emergency_heat:
+```
+
+## Regeln für Package-Erweiterung
+
+### Wann eine neue Datei anlegen?
+- Ein neues Sub-Thema hinzukommt (z.B. `packages/solar/battery_management.yaml`)
+- Eine bestehende Datei über **500 Zeilen** wächst → Split in logische Sub-Dateien
+- Ein Sub-Thema mindestens **5+ Entitäten** (Sensoren, Automations, Scripts) umfasst
+
+**KEINE** neue Datei für:
+- Einzelne Sensoren oder Automations → In existierende Datei integrieren
+- Temporäre Experimente → In `packages/home/experimental.yaml` (falls vorhanden)
+
+### Wann ein neues Package anlegen?
+- Eine neue **Hauptdomäne** entsteht (z.B. `packages/garden/` für Gartenbewässerung)
+- Mindestens **2-3 YAML-Dateien** für das Thema erwartet werden
+- Das Thema **unabhängig** von anderen Domains ist
+
+### Naming Conventions für Package-Dateien
+
+| Typ | Beispiel | Schema |
+|-----|----------|--------|
+| **Hauptfunktion** | `climate.yaml` | `[domain].yaml` |
+| **Spezifische Hardware** | `dtu.yaml` | `[hardware_name].yaml` |
+| **Funktions-Gruppe** | `window_monitoring.yaml` | `[function]_[object].yaml` |
+| **Abstraktion** | `energy_power.yaml` | `[category]_[subcategory].yaml` |
+
+## Workflow: Neues Package erstellen
+
+### Schritt 1: Domänen-Analyse
+Frage: Zu welcher Hauptdomäne gehört die neue Funktionalität?
+- Wenn eng mit bestehender Domain verbunden → Existierendes Package
+- Wenn eigenständige Domain mit Wachstumspotenzial → Neues Package
+
+### Schritt 2: Datei-Struktur planen
+```yaml
+# ==============================================================================
+# PACKAGE: [Domain] - [Sub-Thema]
+# Beschreibung: [1-2 Sätze zur Funktion]
+# Dependencies: [Liste von Integrationen, z.B. "Zigbee2MQTT, Shelly"]
+# Autor: HA Expert 2.0
+# Version: V1.0
+# ==============================================================================
+```
+
+### Schritt 3: Entitäten gruppieren
+Struktur innerhalb der Datei:
+1. **Input Helpers** (Booleans, Numbers, Selects, Datetimes)
+2. **Template Sensors/Binary Sensors** (Berechnete Werte)
+3. **Automations** (Logik & Trigger)
+4. **Scripts** (Wiederverwendbare Aktionen)
+5. **Scenes** (Optional, falls relevant)
+
+### Schritt 4: Integration in `configuration.yaml`
+```yaml
+homeassistant:
+  packages: !include_dir_named packages
+```
+
+## Migration: Root-Dateien zu Packages
+
+### Typische Migrationspfade
+
+| Root-Datei | Ziel-Package | Beispiel |
+|------------|--------------|----------|
+| `sensor.yaml` (Energie) | `packages/abstraction/energy_power.yaml` | Energie-Sensoren |
+| `sensor.yaml` (Solar) | `packages/solar/solarforecast.yaml` | Solar-Prognosen |
+| `automation.yaml` (Klima) | `packages/home/climate.yaml` | Klima-Automations |
+| `automation.yaml` (Auto) | `packages/car/charging.yaml` | Lade-Logik (EV-Charging) |
+| `script.yaml` (Benachrichtigungen) | `packages/home/notifications.yaml` | Notification-Scripts |
+
+### Migrations-Workflow
+
+1. **Identifiziere** die Entität und ihre fachliche Domäne
+2. **Prüfe** ob bereits eine passende Package-Datei existiert
+3. **Erstelle** bei Bedarf eine neue Package-Datei mit Header
+4. **Verschiebe** die Entität inkl. aller Kommentare
+5. **Ergänze** den Code-Header mit Version V1.0
+6. **Validiere** YAML-Syntax mit `ha core check` oder Developer Tools
+7. **Teste** die Entität nach Reload/Restart
+
+**WICHTIG**: Bei Verschiebung von Entitäten:
+- `unique_id` und `entity_id` bleiben **EXAKT** gleich
+- Nur `alias` oder `friendly_name` werden mit `[V1.0]` ergänzt
+- Keine Funktionalitäts-Änderungen während Migration
+
+## Best Practices für Package-Wartung
+
+### Code-Organisation innerhalb einer Package-Datei
+
+```yaml
+# 1. Header (IMMER am Anfang)
+# ==============================================================================
+# PACKAGE: [Name]
+# ==============================================================================
+
+# 2. Configuration (Optional)
+homeassistant:
+  customize:
+
+# 3. Input Helpers
+input_boolean:
+input_number:
+input_select:
+input_datetime:
+
+# 4. Template Sensoren (Berechnet)
+template:
+  - sensor:
+  - binary_sensor:
+
+# 5. Automations (Logik)
+automation:
+
+# 6. Scripts (Wiederverwendbar)
+script:
+
+# 7. Scenes (Optional)
+scene:
+```
+
+### Dokumentations-Standard
+
+Jede Package-Datei MUSS enthalten:
+1. **Header-Block** mit Beschreibung
+2. **Dependencies** (welche Integrationen werden benötigt?)
+3. **Inline-Kommentare** bei komplexen Logiken
+4. **Changelog** bei Updates (im Header)
+
+### Versionierung von Packages
+
+- **V1.0** bei Erstanlage
+- **V1.x** bei kleineren Erweiterungen innerhalb der Datei
+- **V2.0** bei strukturellen Änderungen (z.B. Split in mehrere Sub-Dateien)
+
+```yaml
+# Version: V1.3
+# Changelog:
+#   - V1.3: Hinzufügen von battery_threshold_alerts
+#   - V1.2: Neue Sensoren integriert
+#   - V1.1: Fehlerbehebung bei Template-Syntax
+#   - V1.0: Initiale Erstellung
+```
+
+## Troubleshooting: Package-Loading-Probleme
+
+### Häufige Fehler
+
+| Problem | Ursache | Lösung |
+|---------|---------|--------|
+| Package wird nicht geladen | YAML-Syntax-Fehler | `Developer Tools → Check Configuration` |
+| Entitäten doppelt | In Root-Datei UND Package | Root-Datei leeren |
+| Anker-Fehler | Anker-Definition (`&`) nach Referenz (`*`) | Anker VOR erste Nutzung verschieben |
+| Reload funktioniert nicht | Neue Domain hinzugefügt | **Full Restart** notwendig |
+
+### Debugging-Workflow
+1. **Check Logs**: `Settings → System → Logs` nach Package-Namen filtern
+2. **Validate YAML**: Developer Tools → YAML → Check Configuration
+3. **Incremental Test**: Package temporär auskommentieren, schrittweise aktivieren
+4. **Entity Registry**: `Developer Tools → States` → Prüfe ob Entität existiert

--- a/rules/2-platform/homeassistant-yaml-conventions.md
+++ b/rules/2-platform/homeassistant-yaml-conventions.md
@@ -1,0 +1,53 @@
+# YAML Code-Konventionen & Versionierung
+
+## Standardisierter YAML-Header
+
+Jeder YAML-Block MUSS folgenden Kommentar-Header besitzen:
+
+```yaml
+# [Pfad/Dateiname, falls bekannt]
+# ------------------------------------------------------------------------------
+# [MODUL NAME] [VERSION Vx.y]
+# Architect: HA Expert 2.0
+# Changelog:
+#   - Vx.y: [Kurze Beschreibung der technischen Änderung]
+#   - Vx.y: [Weiterer Punkt]
+# ------------------------------------------------------------------------------
+```
+
+## Versions-Logik
+
+- Nutze einen **Namenszusatz (Postfix)** zur Darstellung der Versionen
+- Erhöhe **y (Minor)** bei Bugfixes oder kleinen Anpassungen (V1.1 → V1.2)
+- Erhöhe **x (Major)** bei Architekturwechseln oder Breaking Changes
+- **Ziel**: User muss sofort erkennen, wer spricht und was sich geändert hat
+
+## KRITISCHE ID-REGEL: Immutable vs. Mutable
+
+### Immutable IDs (NIEMALS Versionsnummern!)
+
+- `unique_id`
+- `entity_id`
+- `automation id`
+
+Diese sind **statische System-Slugs** und dürfen NIEMALS eine Versionsnummer, ein Datum oder dynamische Werte enthalten!
+
+**VERBOTEN**: `unique_id: binary_sensor_rain_fusion_state_v1`
+**VERBOTEN**: `id: "notify_rain_started_fusion_v1"`
+**VERBOTEN**: `entity_id: automation.washing_machine_logic_v1`
+
+**KORREKT**: `id: "notify_rain_started_fusion"` (stabil, immer!)
+
+### Mutable Metadata (Versionsnummern erlaubt)
+
+Nur `alias` oder `friendly_name` dürfen Versionsnummern enthalten:
+
+**KORREKT**: `friendly_name: "Fenster Snooze [V3.3]"` (Fürs UI)
+**KORREKT**: `alias: "Waschmaschine Logik [V2.1]"`
+
+**Validation**: Vor Code-Ausgabe prüfen: Enthält ein Feld mit 'id' im Key eine Zahl am Ende? → **Löschen!**
+
+## Dokumentation & Code-Kommentare
+
+**REGEL**: Verwende immer vorhandene Code/Kommentare weiter bzw. verbessere sie im Zweifelsfall.
+**WICHTIG**: Generierter Code darf **niemals weniger Kommentare** beinhalten als Input-Code!

--- a/rules/2-platform/sharkord-docker-ops.md
+++ b/rules/2-platform/sharkord-docker-ops.md
@@ -1,0 +1,108 @@
+---
+description: Sharkord Docker-Betriebswissen — Port-Register, SYS_NICE, Binary-Strategien, Token
+---
+
+# Sharkord Docker-Konventionen
+
+## Port-Register (alle bekannten Sharkord-Plugins)
+
+Ports müssen projektweit eindeutig sein, wenn mehrere Plugins gleichzeitig laufen sollen.
+
+| Plugin | Web-Port | Mediasoup Signal | Mediasoup RTP |
+|--------|----------|-----------------|---------------|
+| sharkord-vid-with-friends | 3000 | — | 40000–40100/udp |
+| sharkord-hero-introducer | 4991 | 40000/tcp | 40000/udp |
+| _(neues Projekt)_ | **freien Port wählen** | **freien Port wählen** | **freien Port wählen** |
+
+## Pflicht-Capability SYS_NICE
+
+Mediasoup benötigt Thread-Priority-Scheduling. Ohne diese Capability startet der Worker
+möglicherweise nicht korrekt.
+
+```yaml
+cap_add:
+  - SYS_NICE    # Mediasoup worker benötigt thread priority scheduling
+```
+
+## Plugin-Verzeichnis-Namenskonvention
+
+Der Verzeichnisname in `plugins/` muss exakt dem `name`-Feld in `package.json` entsprechen.
+Sharkord erkennt das Plugin anhand dieses Verzeichnisnamens.
+
+```yaml
+volumes:
+  - ./dist/<plugin-name>:/home/bun/.config/sharkord/plugins/<plugin-name>
+```
+
+## Access Token nach Volume-Reset
+
+Sharkord generiert beim ersten Start ein Access-Token, das in den Container-Logs erscheint.
+
+```bash
+# Token extrahieren
+docker logs <container-name> 2>&1 | grep -i "token\|access" | head -5
+```
+
+**WARNUNG: Bei `docker compose down --volumes` wird die Datenbank gelöscht → Token ungültig!**
+Immer nach einem Volume-Reset einen neuen Token aus den Logs extrahieren.
+
+## Binary-Strategie
+
+### Strategie A: Init-Container
+
+Wählen wenn das Plugin yt-dlp oder ein spezifisches ffmpeg-Static-Build benötigt.
+Der Init-Container lädt Binaries idempotent herunter — nur wenn sie noch nicht vorhanden sind.
+
+```yaml
+services:
+  init-binaries:
+    image: alpine:latest
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        BIN_DIR=/binaries
+        if [ -f "$$BIN_DIR/ffmpeg" ] && [ -f "$$BIN_DIR/yt-dlp" ]; then
+          echo "Binaries already exist, skipping."
+          exit 0
+        fi
+        apk add --no-cache wget xz
+        # yt-dlp (standalone binary)
+        wget -q -O "$$BIN_DIR/yt-dlp" https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux
+        chmod +x "$$BIN_DIR/yt-dlp"
+        # ffmpeg (static build)
+        wget -q -O /tmp/ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+        mkdir -p /tmp/ffmpeg-extract
+        tar -xf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg-extract --strip-components=1
+        cp /tmp/ffmpeg-extract/ffmpeg "$$BIN_DIR/ffmpeg"
+        chmod +x "$$BIN_DIR/ffmpeg"
+        rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg-extract
+        echo "Done!"
+    volumes:
+      - plugin-binaries:/binaries
+
+  sharkord:
+    depends_on:
+      init-binaries:
+        condition: service_completed_successfully
+    volumes:
+      - plugin-binaries:/home/bun/.config/sharkord/plugins/<plugin-name>/bin
+```
+
+### Strategie B: Dockerfile
+
+Wählen wenn nur `ffmpeg` via apt ausreicht (kein yt-dlp, kein spezifisches Static-Build).
+
+```dockerfile
+# Dockerfile.dev
+FROM sharkord/sharkord:{{platform.sharkord.image_tag}}
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+USER bun
+```
+
+**Entscheidung:**
+- Nur ffmpeg via apt → Strategie B (einfacher, kein separater Service)
+- yt-dlp oder spezifisches ffmpeg-Static-Build → Strategie A (Init-Container)

--- a/rules/2-platform/sharkord-sdk.md
+++ b/rules/2-platform/sharkord-sdk.md
@@ -1,0 +1,114 @@
+---
+description: Sharkord Plugin-SDK Konventionen — gilt automatisch für alle Agenten
+---
+
+# Sharkord Plugin-SDK
+
+## Plugin Entry-Point
+
+```typescript
+const onLoad = async (ctx: PluginContext) => {
+  // Initialisierung: Commands, Settings, Events registrieren
+};
+
+const onUnload = (ctx: PluginContext) => {
+  // Cleanup: Streams, Transports, Producers schließen
+};
+
+export { onLoad, onUnload };
+```
+
+## PluginContext API
+
+```typescript
+// Logging
+ctx.log(message)        // Info-Level
+ctx.debug(message)      // Debug-Level
+ctx.error(message)      // Error-Level
+
+// Plugin-Pfad
+ctx.path                // Absoluter Pfad zum Plugin-Verzeichnis
+
+// Events
+ctx.events.on(event, handler)         // Event-Handler registrieren
+
+// Commands
+ctx.commands.register(definition)     // Command registrieren
+
+// Settings
+ctx.settings.register(definitions)   // Settings registrieren
+
+// Voice/Mediasoup (SDK >= 0.0.16)
+ctx.voice.getRouter(channelId)        // Mediasoup Router holen
+ctx.voice.createStream(options)       // Audio-Stream registrieren
+ctx.voice.getListenInfo()             // RTP Listen-Adresse { ip, announcedAddress }
+```
+
+## Command-Registrierung
+
+```typescript
+ctx.commands.register<{ userId: string; filePath: string }>({
+  name: "my-command",
+  description: "Kurzbeschreibung des Commands.",
+  args: [
+    { name: "userId",   type: "string", required: true },
+    { name: "filePath", type: "string", required: false },
+  ],
+  async executes(invokerCtx, args) {
+    // Implementierung
+  },
+});
+```
+
+## Mediasoup Audio-Streaming
+
+```typescript
+const router = ctx.voice.getRouter(channelId);
+const { ip, announcedAddress } = ctx.voice.getListenInfo();
+
+const transport = await router.createPlainTransport({
+  listenInfo: { protocol: "udp", ip, announcedAddress },
+  rtcpMux: false,
+  comedia: true,
+});
+
+const producer = await transport.produce({
+  kind: "audio",
+  rtpParameters: {
+    codecs: [{ mimeType: "audio/opus", payloadType: 101, clockRate: 48000, channels: 2 }],
+    encodings: [{ ssrc: 1234 }],
+  },
+});
+
+const stream = ctx.voice.createStream({
+  channelId,
+  key: "my-stream",
+  title: "Stream-Titel",
+  producers: { audio: producer },
+});
+
+// Cleanup (immer in voice:runtime_closed):
+stream.remove();
+producer.close();
+transport.close();
+```
+
+## Events-Referenz
+
+| Event | Auslöser |
+|-------|----------|
+| `voice:runtime_initialized` | Voice-Channel geöffnet |
+| `voice:runtime_closed` | Voice-Channel geschlossen → **CLEANUP erforderlich!** |
+| `user:joined_voice` | Nutzer betritt Voice-Channel (SDK >= 0.0.16) |
+| `user:left_voice` | Nutzer verlässt Voice-Channel (SDK >= 0.0.16) |
+| `user:joined` | Nutzer betritt den Server |
+
+## Don'ts (Sharkord-spezifisch)
+
+- KEIN `ctx.actions.voice` — deprecated seit SDK 0.0.16 → stattdessen `ctx.voice`
+- KEIN `child_process.spawn` → immer `Bun.spawn`
+- KEIN `node:` Prefix wenn Bun-Äquivalent existiert (z.B. `Bun.file` statt `node:fs`)
+- KEINE camelCase Spaltennamen in SQLite-Queries → Sharkord nutzt snake_case
+- KEIN direkter Zugriff auf `window` / `document` — kein Browser-API
+- KEIN `var` → `const` / `let`
+- KEIN implizites `any`

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -71,6 +71,8 @@ PLATFORM_CONFIGS_DIR = "platform-configs"
 CLAUDE_PLATFORM_CONFIG = ".claude/platform-config.yaml"
 LOGFILE = "sync.log"
 
+_PLATFORM_VAR_RE = re.compile(r'\{\{(platform\.[^}]+)\}\}')
+
 # Maps role name to the output filename in .claude/agents/ (no prefix)
 ROLE_MAP = {
     "orchestrator":  "orchestrator",
@@ -652,6 +654,16 @@ def load_platform_config(
 
     merged_flat: dict = {}
 
+    # Load project overrides once — shared across all platforms
+    project_config_path = project_root / CLAUDE_PLATFORM_CONFIG
+    overrides_flat: dict = {}
+    if project_config_path.exists():
+        try:
+            with project_config_path.open(encoding='utf-8') as f:
+                overrides_flat = _flatten_yaml_dict(_yaml.safe_load(f) or {})
+        except Exception as e:
+            log.warn(f'platform-config: failed to load {CLAUDE_PLATFORM_CONFIG}: {e}')
+
     for platform in platforms:
         defaults_path = agent_meta_root / PLATFORM_CONFIGS_DIR / f'{platform}.defaults.yaml'
         if not defaults_path.exists():
@@ -665,28 +677,15 @@ def load_platform_config(
             log.warn(f'platform-config: failed to load {defaults_path.name}: {e}')
             continue
 
-        defaults_flat = _flatten_yaml_dict(defaults_raw)
-
-        # Load project-level overrides from .claude/platform-config.yaml (optional)
-        project_config_path = project_root / CLAUDE_PLATFORM_CONFIG
-        overrides_flat: dict = {}
-        if project_config_path.exists():
-            try:
-                with project_config_path.open(encoding='utf-8') as f:
-                    overrides_raw = _yaml.safe_load(f) or {}
-                overrides_flat = _flatten_yaml_dict(overrides_raw)
-            except Exception as e:
-                log.warn(f'platform-config: failed to load {CLAUDE_PLATFORM_CONFIG}: {e}')
-
         # Merge: defaults first, then overrides win
-        platform_flat = {**defaults_flat, **overrides_flat}
+        platform_flat = {**_flatten_yaml_dict(defaults_raw), **overrides_flat}
 
         # Warn for required fields (empty-string default) that are still empty
         for key, val in platform_flat.items():
             if key.startswith(f'platform.{platform}.') and val == '':
                 log.warn(
-                    'platform-config: required field {{platform.' + key[len('platform.'):] + '}} '
-                    'is empty -- add it to .claude/platform-config.yaml'
+                    f'platform-config: required field {{{{platform.{key[len("platform."):]}}}}}'
+                    f' is empty -- add it to .claude/platform-config.yaml'
                 )
 
         merged_flat.update(platform_flat)
@@ -713,12 +712,12 @@ def substitute_platform(
         if raw_key in platform_vars:
             return str(platform_vars[raw_key])
         log.warn(
-            f'platform-config: placeholder {{{{' + raw_key + '}}}} not found in platform defaults '
+            f'platform-config: placeholder {{{{{raw_key}}}}} not found in platform defaults '
             f'or project overrides — placeholder remains in: {source_label}'
         )
         return match.group(0)
 
-    return re.sub(r'\{\{(platform\.[^}]+)\}\}', replacer, text)
+    return _PLATFORM_VAR_RE.sub(replacer, text)
 
 
 def resolve_provider_options(config: dict, provider: str) -> dict:
@@ -1395,7 +1394,7 @@ def sync_agents_for_provider(
         description = description.replace('{{PROJECT_NAME}}', project_name)
         content = substitute(content, variables, rel_source, log)
         # Apply platform-config substitution ({{platform.*}} placeholders)
-        if platform_vars:
+        if platform_vars is not None:
             content = substitute_platform(content, platform_vars, rel_source, log)
         name = Path(filename).stem
         layer = source_path.parts[-2]
@@ -1763,7 +1762,7 @@ def sync_rules(
         layer = source_path.parts[-2]  # "1-generic", "2-platform", "0-external"
 
         # Apply platform-config substitution ({{platform.*}} placeholders)
-        if platform_vars:
+        if platform_vars is not None:
             rel_source = f"rules/{layer}/{source_path.name}"
             source_content = substitute_platform(source_content, platform_vars, rel_source, log)
 
@@ -3033,7 +3032,7 @@ def main():
         log.info("DoD", f"preset '{preset_name}' -> {dod_summary}")
         # Load platform-config variables ({{platform.*}} placeholders)
         platform_vars = load_platform_config(agent_meta_root, project_root, platforms, log)
-        if platform_vars:
+        if platform_vars is not None:
             log.info("platform-config", f"loaded {len(platform_vars)} platform variable(s) for: {', '.join(platforms)}")
         is_claude = "Claude" in providers
         if args.init or is_claude:

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -342,16 +342,23 @@ def fill_defaults(
             changed = True
 
     # --- dod sub-fields ---
-    dod_block = config.get("dod", {})
-    dod_additions: list[str] = []
-    for field, default in _DOD_FIELD_DEFAULTS.items():
-        if field not in dod_block:
-            dod_block[field] = default
-            dod_additions.append(f"dod.{field} = {json.dumps(default)}")
-            changed = True
-    if dod_additions:
-        config["dod"] = dod_block
-        added.extend(dod_additions)
+    # Only fill dod.* fields when no preset is set (or preset is "full").
+    # A non-full preset already defines its own defaults — writing "full" defaults
+    # on top would silently override the preset and create an inconsistent config.
+    active_preset = config.get("dod-preset", "full")
+    if active_preset == "full":
+        dod_block = config.get("dod", {})
+        dod_additions: list[str] = []
+        for field, default in _DOD_FIELD_DEFAULTS.items():
+            if field not in dod_block:
+                dod_block[field] = default
+                dod_additions.append(f"dod.{field} = {json.dumps(default)}")
+                changed = True
+        if dod_additions:
+            config["dod"] = dod_block
+            added.extend(dod_additions)
+    else:
+        log.info("fill-defaults", f"dod.* skipped — preset '{active_preset}' defines its own defaults")
 
     # --- Write back if changed ---
     if changed and not dry_run:

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -67,6 +67,8 @@ CLAUDE_RULES_DIR = ".claude/rules"
 RULES_DIR = "rules"
 CLAUDE_HOOKS_DIR = ".claude/hooks"
 HOOKS_DIR = "hooks"
+PLATFORM_CONFIGS_DIR = "platform-configs"
+CLAUDE_PLATFORM_CONFIG = ".claude/platform-config.yaml"
 LOGFILE = "sync.log"
 
 # Maps role name to the output filename in .claude/agents/ (no prefix)
@@ -596,6 +598,127 @@ def resolve_dod(config: dict, agent_meta_root: Path) -> dict:
             resolved[key] = default_val
     return resolved
 
+
+
+
+# ---------------------------------------------------------------------------
+# Platform config (platform-configs/<platform>.defaults.yaml + .claude/platform-config.yaml)
+# ---------------------------------------------------------------------------
+
+def _flatten_yaml_dict(d: dict, prefix: str = '') -> dict:
+    """Flatten a nested dict into dot-notation keys.
+
+    Example:
+        {'platform': {'homeassistant': {'notify_group': 'all'}}}
+        -> {'platform.homeassistant.notify_group': 'all'}
+    """
+    result = {}
+    for k, v in d.items():
+        key = f'{prefix}.{k}' if prefix else k
+        if isinstance(v, dict):
+            result.update(_flatten_yaml_dict(v, key))
+        else:
+            result[key] = v
+    return result
+
+
+def load_platform_config(
+    agent_meta_root: Path,
+    project_root: Path,
+    platforms: list[str],
+    log: 'SyncLog',
+) -> dict:
+    """Load and merge platform-config for all active platforms.
+
+    For each platform in platforms:
+      1. Load agent-meta/platform-configs/<platform>.defaults.yaml   (defaults)
+      2. Load .claude/platform-config.yaml from project root          (overrides, optional)
+      3. Merge: project overrides win over defaults
+      4. Flatten nested YAML keys to dot-notation
+
+    Returns a flat dict: {'platform.homeassistant.notify_group': 'all', ...}
+
+    Emits [WARN] for:
+      - Required fields (empty-string default) not overridden by project
+      - {{platform.*}} placeholders in source files without a matching config entry
+        (checked externally via warn_unresolved_platform_vars)
+    """
+    if not _YAML_AVAILABLE:
+        log.warn(
+            'PyYAML not available — platform-config substitution skipped. '
+            'Install it with: pip install pyyaml'
+        )
+        return {}
+
+    merged_flat: dict = {}
+
+    for platform in platforms:
+        defaults_path = agent_meta_root / PLATFORM_CONFIGS_DIR / f'{platform}.defaults.yaml'
+        if not defaults_path.exists():
+            # No defaults file for this platform — skip silently (not all platforms need one)
+            continue
+
+        try:
+            with defaults_path.open(encoding='utf-8') as f:
+                defaults_raw = _yaml.safe_load(f) or {}
+        except Exception as e:
+            log.warn(f'platform-config: failed to load {defaults_path.name}: {e}')
+            continue
+
+        defaults_flat = _flatten_yaml_dict(defaults_raw)
+
+        # Load project-level overrides from .claude/platform-config.yaml (optional)
+        project_config_path = project_root / CLAUDE_PLATFORM_CONFIG
+        overrides_flat: dict = {}
+        if project_config_path.exists():
+            try:
+                with project_config_path.open(encoding='utf-8') as f:
+                    overrides_raw = _yaml.safe_load(f) or {}
+                overrides_flat = _flatten_yaml_dict(overrides_raw)
+            except Exception as e:
+                log.warn(f'platform-config: failed to load {CLAUDE_PLATFORM_CONFIG}: {e}')
+
+        # Merge: defaults first, then overrides win
+        platform_flat = {**defaults_flat, **overrides_flat}
+
+        # Warn for required fields (empty-string default) that are still empty
+        for key, val in platform_flat.items():
+            if key.startswith(f'platform.{platform}.') and val == '':
+                log.warn(
+                    'platform-config: required field {{platform.' + key[len('platform.'):] + '}} '
+                    'is empty -- add it to .claude/platform-config.yaml'
+                )
+
+        merged_flat.update(platform_flat)
+
+    return merged_flat
+
+
+def substitute_platform(
+    text: str,
+    platform_vars: dict,
+    source_label: str,
+    log: 'SyncLog',
+) -> str:
+    """Replace {{platform.*}} occurrences using platform_vars dict.
+
+    Keys in platform_vars use dot-notation (e.g. 'platform.homeassistant.notify_group').
+    Placeholders in text look like {{platform.homeassistant.notify_group}}.
+
+    Warns for any {{platform.*}} placeholder that has no matching key in platform_vars.
+    Does NOT touch {{UPPERCASE}} placeholders — those are handled by substitute().
+    """
+    def replacer(match):
+        raw_key = match.group(1)   # e.g. 'platform.homeassistant.notify_group'
+        if raw_key in platform_vars:
+            return str(platform_vars[raw_key])
+        log.warn(
+            f'platform-config: placeholder {{{{' + raw_key + '}}}} not found in platform defaults '
+            f'or project overrides — placeholder remains in: {source_label}'
+        )
+        return match.group(0)
+
+    return re.sub(r'\{\{(platform\.[^}]+)\}\}', replacer, text)
 
 
 def resolve_provider_options(config: dict, provider: str) -> dict:
@@ -1210,6 +1333,7 @@ def sync_agents_for_provider(
     log: SyncLog,
     dry_run: bool,
     provider: str,
+    platform_vars: dict | None = None,
 ):
     """Generate agent files for a specific provider.
 
@@ -1270,6 +1394,9 @@ def sync_agents_for_provider(
         description = (template_description or f'Agent for {project_name}.')
         description = description.replace('{{PROJECT_NAME}}', project_name)
         content = substitute(content, variables, rel_source, log)
+        # Apply platform-config substitution ({{platform.*}} placeholders)
+        if platform_vars:
+            content = substitute_platform(content, platform_vars, rel_source, log)
         name = Path(filename).stem
         layer = source_path.parts[-2]
         source_label = f'{layer}/{source_path.name}'
@@ -1598,6 +1725,7 @@ def sync_rules(
     config: dict,
     log: SyncLog,
     dry_run: bool,
+    platform_vars: dict | None = None,
 ):
     """Copy rule files from agent-meta/rules/ layers to .claude/rules/ in the project.
 
@@ -1633,6 +1761,11 @@ def sync_rules(
         target_path = target_dir / output_name
         source_content = source_path.read_text(encoding="utf-8")
         layer = source_path.parts[-2]  # "1-generic", "2-platform", "0-external"
+
+        # Apply platform-config substitution ({{platform.*}} placeholders)
+        if platform_vars:
+            rel_source = f"rules/{layer}/{source_path.name}"
+            source_content = substitute_platform(source_content, platform_vars, rel_source, log)
 
         log.action("COPY", str(target_path.relative_to(project_root)),
                    f"rules/{layer}/{source_path.name}")
@@ -2898,6 +3031,10 @@ def main():
         dod_resolved = resolve_dod(config, agent_meta_root)
         dod_summary = ", ".join(f"{k}: {v}" for k, v in dod_resolved.items())
         log.info("DoD", f"preset '{preset_name}' -> {dod_summary}")
+        # Load platform-config variables ({{platform.*}} placeholders)
+        platform_vars = load_platform_config(agent_meta_root, project_root, platforms, log)
+        if platform_vars:
+            log.info("platform-config", f"loaded {len(platform_vars)} platform variable(s) for: {', '.join(platforms)}")
         is_claude = "Claude" in providers
         if args.init or is_claude:
             init_claude_md(agent_meta_root, project_root, config, variables, log, args.dry_run)
@@ -2910,14 +3047,14 @@ def main():
             pc = PROVIDER_CONFIG[provider]
             log.provider_header(provider)
             sync_agents_for_provider(agent_meta_root, project_root, config, variables,
-                                     log, args.dry_run, provider)
+                                     log, args.dry_run, provider, platform_vars=platform_vars)
             sync_context_for_provider(agent_meta_root, project_root, config, variables,
                                       log, args.dry_run, provider)
             if provider == "Continue":
                 sync_prompts_for_continue(agent_meta_root, project_root, config,
                                           variables, log, args.dry_run)
             if pc["has_rules"] and provider == "Claude":
-                sync_rules(agent_meta_root, project_root, config, log, args.dry_run)
+                sync_rules(agent_meta_root, project_root, config, log, args.dry_run, platform_vars=platform_vars)
                 sync_speech_mode(agent_meta_root, project_root, config, log, args.dry_run)
             if pc["has_hooks"] and provider == "Claude":
                 sync_hooks(agent_meta_root, project_root, config, log, args.dry_run)


### PR DESCRIPTION
## Summary

- Add `platform-configs/sharkord.defaults.yaml` with sensible defaults for `image_tag`, `min_version`, `service_name`, `host_lan_ip` — all 4 fields pre-filled, no required-field warnings out of the box
- Replace hardcoded `{{PRIMARY_IMAGE_TAG}}` → `{{platform.sharkord.image_tag}}` and `{{HOST_LAN_IP}}` → `{{platform.sharkord.host_lan_ip}}` in `sharkord-docker.md`
- Replace `{{SHARKORD_MIN_VERSION}}` → `{{platform.sharkord.min_version}}` in `sharkord-release.md`
- Extract Sharkord Plugin-SDK knowledge (PluginContext API, commands, mediasoup, events) from `sharkord-developer.md` into `rules/2-platform/sharkord-sdk.md` — auto-loaded by all agents, no more duplicate context in developer agent
- Extract Docker operational knowledge (port register, SYS_NICE capability, binary strategies A/B, token handling) into `rules/2-platform/sharkord-docker-ops.md`
- Bump `sharkord-developer.md` to version 2.1.0

## Test plan

- [ ] Run `sync.py` for sk_plugin — verify `{{platform.sharkord.image_tag}}` resolves to `v0.0.16` in generated docker agent
- [ ] Run `sync.py` for sk_plugin — verify `sharkord-sdk.md` and `sharkord-docker-ops.md` are copied to `.claude/rules/`
- [ ] Verify `sharkord-developer.md` no longer contains the `append-after` SDK patch
- [ ] Verify `sharkord-release.md` uses `{{platform.sharkord.min_version}}`
- [ ] Check `platform-configs/sharkord.defaults.yaml` loads without errors in sync.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)