### PR TITLE
docs: CLAUDE.md hierarchy, rules/, commands/ and length guidelines

### DIFF
--- a/howto/CLAUDE.project-template.md
+++ b/howto/CLAUDE.project-template.md
@@ -4,6 +4,15 @@
 > für projektspezifischen Kontext — Agenten lesen sie, statt eigenen Kontext zu haben.
 >
 > Generiert von agent-meta v{{AGENT_META_VERSION}} — `{{AGENT_META_DATE}}`
+>
+> **Längenempfehlung:** 200–500 Zeilen optimal. Über 500 Zeilen → Detailwissen in
+> `docs/ARCHITECTURE.md`, `docs/API.md` o.ä. auslagern und manuell verlinken.
+> Agent-spezifisches Wissen → `.claude/3-project/<rolle>-ext.md` (Extension).
+>
+> **CLAUDE.md Hierarchie (Claude Code lädt in dieser Reihenfolge):**
+> 1. `~/.claude/CLAUDE.md` — global, alle Projekte (~50 Zeilen max, persönliche Präferenzen)
+> 2. `<projekt>/CLAUDE.md` — diese Datei, projektspezifisch (von agent-meta verwaltet)
+> 3. `<ordner>/CLAUDE.md` — optional in Unterordnern (z.B. `src/backend/CLAUDE.md`)
 
 ---
 
@@ -86,6 +95,9 @@ Generiert von agent-meta v{{AGENT_META_VERSION}} — `{{AGENT_META_DATE}}`
 ---
 
 ## Sprachregeln
+
+<!-- Die globale Rule .claude/rules/language.md (generiert von sync.py) deckt den Kern ab. -->
+<!-- Hier nur projektspezifische Abweichungen eintragen — sonst leer lassen. -->
 
 - `README.md` → **Englisch**
 - Alle anderen Dokumente → **Deutsch**

--- a/howto/instantiate-project.md
+++ b/howto/instantiate-project.md
@@ -8,6 +8,66 @@ Agenten werden von `sync.py` **generiert** — nie manuell kopiert oder bearbeit
 Den Projektkontext liefert die `CLAUDE.md` des Projekts.
 Projektspezifische Erweiterungen leben in `.claude/3-project/`.
 
+### CLAUDE.md Hierarchie
+
+Claude Code lädt Kontext-Dateien in dieser Reihenfolge (alle werden zusammengeführt):
+
+```
+~/.claude/CLAUDE.md          ← global, alle Projekte (~50 Zeilen max)
+<projekt>/CLAUDE.md          ← projektspezifisch — von agent-meta verwaltet
+<ordner>/CLAUDE.md           ← optional in Unterordnern (z.B. src/backend/CLAUDE.md)
+```
+
+| Ebene | Inhalt | Wer pflegt es |
+|-------|--------|---------------|
+| Global (`~/.claude/CLAUDE.md`) | Persönliche Präferenzen, eigene Verbote, persönliche Kommunikationsstil | Du — manuell, einmalig |
+| Projekt (`CLAUDE.md`) | Tech-Stack, Commands, Architektur, DoD, Agenten-Hints | agent-meta (managed block) + Du (manuell) |
+| Ordner (`<ordner>/CLAUDE.md`) | Subsystem-spezifische Regeln (z.B. nur für `src/backend/`) | Du — manuell, bei Bedarf |
+
+**Empfehlung für die globale CLAUDE.md:** Persönliche Präferenzen die für *alle* Projekte gelten —
+kein projektspezifisches Wissen. Maximal ~50 Zeilen.
+
+**Ordner-level CLAUDE.md:** Sinnvoll wenn ein Unterordner eigene Konventionen hat die im
+Hauptkontext zu viel Platz wäre. Wird von agent-meta nicht berührt.
+
+### .claude/rules/ — modulare Regeln
+
+```
+.claude/rules/
+  branch-guard.md       ← von agent-meta generiert (sync.py)
+  commit-conventions.md ← von agent-meta generiert
+  language.md           ← von agent-meta generiert (mit substituierten Variablen)
+  dod-criteria.md       ← von agent-meta generiert
+  meine-regel.md        ← projekt-eigen (nie von sync.py berührt)
+```
+
+Regeln in `.claude/rules/` werden von Claude Code **automatisch** in jeden Agenten-Kontext
+und den Hauptchat geladen — kein `Read`-Tool nötig. agent-meta-verwaltete Rules werden bei
+jedem Sync aktualisiert; projekt-eigene Rules werden nie überschrieben.
+
+Projekt-eigene Rule anlegen:
+```bash
+py .agent-meta/scripts/sync.py --create-rule meine-regel
+```
+
+### .claude/commands/ — Custom Slash Commands
+
+```
+.claude/commands/
+  deploy.md      → /project:deploy
+  review.md      → /project:review
+```
+
+Slash Commands laufen im **Haupt-Kontext** (kein isoliertes Context Window wie Agenten).
+Geeignet für schnelle, wiederkehrende Einzel-Aktionen. agent-meta verwaltet commands/ nicht —
+du legst diese Dateien manuell an.
+
+| `.claude/agents/` | `.claude/commands/` |
+|-------------------|---------------------|
+| Vollständige Persona, isolierter Kontext | Schneller Einzel-Workflow im Hauptchat |
+| Für komplexe, mehrstufige Aufgaben | Für wiederkehrende Einzel-Aktionen |
+| Von agent-meta generiert und verwaltet | Manuell angelegt, nie von sync.py berührt |
+
 ---
 
 ## Ersteinrichtung

--- a/howto/sync-concept.md
+++ b/howto/sync-concept.md
@@ -68,8 +68,12 @@ agent-meta/
       ...
     snippets/                ← kopiert aus agent-meta/snippets/
     skills/                  ← kopiert aus external/ Submodulen
-    rules/                   ← kopiert aus agent-meta/rules/ (auto-loaded in alle Agenten)
+    rules/                   ← auto-loaded in alle Agenten + Hauptchat
+      *.md                     ← von agent-meta verwaltet (sync.py, mit Variablensubstitution)
+      meine-regel.md           ← projekt-eigen (nie von sync.py berührt)
     hooks/                   ← kopiert aus agent-meta/hooks/ + in settings.json registriert
+    commands/                ← Custom Slash Commands (/project:<name>), manuell angelegt
+      deploy.md                ← → /project:deploy (läuft im Hauptkontext, kein isolierter Context)
     3-project/               ← handgeschrieben, nie von sync.py überschrieben
       <prefix>-<rolle>-ext.md  ← Extension (additiv geladen)
       <rolle>.md               ← Override (ersetzt Agenten komplett)
@@ -95,6 +99,21 @@ agent-meta/
 | `.claude/settings.local.json` | Nein (gitignored) | sync.py (einmalig) | Persönliche Permissions |
 
 `CLAUDE.personal.md` wird einmalig aus `howto/CLAUDE.personal-template.md` kopiert und danach nie wieder von sync.py angefasst. Jeder Entwickler füllt sie für sich aus.
+
+---
+
+## Abgrenzung: rules/ vs. 3-project/ vs. commands/
+
+| Mechanismus | Scope | Laden | Quelle | Von sync.py verwaltet |
+|-------------|-------|-------|--------|----------------------|
+| `.claude/rules/*.md` | **Alle** Agenten + Hauptchat | Automatisch | agent-meta + Projekt | Ja (agent-meta-Rules) / Nein (projekt-eigene) |
+| `.claude/3-project/*-ext.md` | **Ein** Agenten-Typ | Explizit per Read-Hook | Projekt | Nein |
+| `.claude/commands/*.md` | Hauptchat (kein isolierter Kontext) | Als Slash-Command `/project:<name>` | Projekt | Nein |
+
+**Wann was:**
+- Regel gilt für alle Agenten und Hauptchat → `.claude/rules/`
+- Zusatzwissen für einen spezifischen Agenten → `.claude/3-project/<rolle>-ext.md`
+- Wiederkehrender Einzel-Workflow im Hauptchat → `.claude/commands/`
 
 ---
 


### PR DESCRIPTION
## Summary

- **#6** global `~/.claude/CLAUDE.md`: Hierarchie global → project → folder dokumentiert in `instantiate-project.md` + Hinweis im Template
- **#7** folder-level CLAUDE.md: Erklärt in Hierarchie-Tabelle (`instantiate-project.md`)
- **#8** Längenempfehlung: 200–500 Zeilen optimal, Hinweis im Template-Header
- **#9** `.claude/rules/`: Bereits implementiert — jetzt korrekt dokumentiert (auto-loaded, Abgrenzung zu ext.md, `--create-rule`)
- **#10** `.claude/commands/`: Slash Commands erklärt (manuell, Hauptkontext, nicht von sync.py verwaltet), Abgrenzung zu Agenten

Closes #6, #7, #8, #9, #10

## Test plan

- [x] `howto/CLAUDE.project-template.md` — Längenhinweis + Hierarchie + language.md Hinweis vorhanden
- [x] `howto/instantiate-project.md` — neuer Abschnitt mit Hierarchie, rules/, commands/ Erklärung
- [x] `howto/sync-concept.md` — Verzeichnisbaum aktualisiert, Abgrenzungstabelle ergänzt
- [x] Keine Code-Änderungen — reine Doku

🤖 Generated with [Claude Code](https://claude.com/claude-code)