### PR TITLE
feat: gitignore:true flag for external skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -891,7 +891,8 @@ Projekte aktivieren freigegebene Skills über einen eigenen Block in `.meta-conf
 ```json
 {
   "external-skills": {
-    "my-skill": { "enabled": true }
+    "my-skill": { "enabled": true },
+    "large-skill": { "enabled": true, "gitignore": true }
   }
 }
 ```
@@ -902,6 +903,10 @@ Projekte aktivieren freigegebene Skills über einen eigenen Block in `.meta-conf
 
 Fehlt der `external-skills`-Block komplett → kein externer Skill wird generiert (sicheres Default).
 Referenziert ein Projekt einen unbekannten oder nicht-approved Skill → `[WARN]` im sync.log.
+
+**`gitignore: true`** (optional): `sync.py` fügt `.claude/skills/<skill-name>/` automatisch zum
+`.gitignore` managed block hinzu. Beim Deaktivieren wird der Eintrag wieder entfernt. Sinnvoll
+wenn der Skill große oder generierte Dateien nach `.claude/skills/` kopiert.
 
 ### Skill hinzufügen
 

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -383,6 +383,10 @@
           "enabled": {
             "type": "boolean",
             "description": "Generate wrapper agent for this skill."
+          },
+          "gitignore": {
+            "type": "boolean",
+            "description": "Add .claude/skills/<skill-name>/ to the .gitignore managed block. Use when the skill copies large or generated files that should not be committed."
           }
         },
         "required": [

--- a/howto/external-skills.md
+++ b/howto/external-skills.md
@@ -142,6 +142,31 @@ git add .claude/agents/ .claude/skills/ .meta-config/project.yaml
 git commit -m "feat: activate home-organization skill"
 ```
 
+### Skill-Dateien aus Git ausschließen (`gitignore: true`)
+
+Manche Skills kopieren große oder generierte Dateien nach `.claude/skills/<skill-name>/`
+(z.B. 3D-Modelle, Referenzdatenbanken), die nicht in Git gehören.
+
+Mit `gitignore: true` fügt sync.py den Pfad automatisch zum `.gitignore` managed block hinzu:
+
+```json
+{
+  "external-skills": {
+    "opengrid-openscad": {
+      "enabled": true,
+      "gitignore": true
+    }
+  }
+}
+```
+
+`sync.py` verwaltet den Eintrag vollständig:
+- **Aktiviert** (`gitignore: true`): `.claude/skills/opengrid-openscad/` wird zu `.gitignore` hinzugefügt
+- **Deaktiviert** (`gitignore: false` oder Feld fehlt): Eintrag wird aus `.gitignore` entfernt
+- **Skill deaktiviert** (`enabled: false`): Eintrag wird ebenfalls entfernt
+
+Der Eintrag erscheint im `# --- agent-meta managed ---` Block der `.gitignore` — nie manuell dort einfügen.
+
 ---
 
 ## Schritt 3: Skill deaktivieren

--- a/scripts/lib/context.py
+++ b/scripts/lib/context.py
@@ -310,19 +310,24 @@ def ensure_gitignore_entries(
     log: SyncLog,
     dry_run: bool,
     gitignore_entries: list[str] | None = None,
+    exact_entries: list[str] | None = None,
 ):
     """Ensure required entries exist in a managed block in .gitignore.
 
     Writes a clearly marked block so users know the entries are managed by
     agent-meta and should not be removed manually.
-    If the block already exists, it is updated in-place (entries added, never removed).
-    Entries that already exist outside the block are not duplicated.
 
-    gitignore_entries: list of entries to add. If None, reads from providers.config.yaml (Claude).
+    gitignore_entries: entries to add (additive — never removes existing block entries).
+    exact_entries: if provided, the managed block is set to exactly these entries
+                   (entries no longer needed are removed from the block).
     """
-    if gitignore_entries is None:
+    if exact_entries is not None:
+        required = list(exact_entries)
+    elif gitignore_entries is not None:
+        required = list(gitignore_entries)
+    else:
         # Default: Claude entries (backward compat)
-        gitignore_entries = [
+        required = [
             ".claude/settings.local.json",
             ".claude/agent-memory-local/",
             "CLAUDE.personal.md",
@@ -344,12 +349,28 @@ def ensure_gitignore_entries(
             line.strip() for line in block_match.group(1).splitlines() if line.strip()
         }
 
-    missing = [e for e in gitignore_entries if e not in block_entries]
-    if not missing:
+    required_set = set(required)
+    if exact_entries is not None:
+        # Exact mode: block must contain exactly required_set
+        new_block_entries = sorted(required_set)
+        changed = block_entries != required_set
+        added = sorted(required_set - block_entries)
+        removed = sorted(block_entries - required_set)
+    else:
+        # Additive mode: add missing entries, never remove
+        missing = [e for e in required if e not in block_entries]
+        if not missing:
+            log.skip(".gitignore", "all required entries already present")
+            return
+        new_block_entries = sorted(block_entries | required_set)
+        changed = True
+        added = missing
+        removed = []
+
+    if not changed:
         log.skip(".gitignore", "all required entries already present")
         return
 
-    new_block_entries = sorted(block_entries | set(missing))
     new_block = (
         GITIGNORE_BLOCK_BEGIN + "\n"
         + "\n".join(new_block_entries) + "\n"
@@ -361,7 +382,12 @@ def ensure_gitignore_entries(
     else:
         new_content = existing.rstrip("\n") + "\n\n" + new_block + "\n"
 
-    log.action("UPDATE", ".gitignore", f"added to managed block: {', '.join(missing)}")
+    parts = []
+    if added:
+        parts.append(f"added: {', '.join(added)}")
+    if removed:
+        parts.append(f"removed: {', '.join(removed)}")
+    log.action("UPDATE", ".gitignore", f"managed block — {'; '.join(parts)}")
     if not dry_run:
         gitignore_path.write_text(new_content, encoding="utf-8")
 

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -88,6 +88,29 @@ _CONFIG_CANDIDATES = [
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _collect_skill_gitignore_entries(config: dict, ext_config: dict) -> list[str]:
+    """Return .gitignore paths for skills with gitignore: true in project config.
+
+    Only generates entries for skills that are approved + enabled (two-gate).
+    """
+    entries: list[str] = []
+    project_skills = config.get("external-skills", {})
+    for skill_name, skill_project_cfg in project_skills.items():
+        if not skill_project_cfg.get("gitignore", False):
+            continue
+        skill_meta = ext_config.get("skills", {}).get(skill_name, {})
+        if not skill_meta.get("approved", False):
+            continue
+        if not skill_project_cfg.get("enabled", False):
+            continue
+        entries.append(f".claude/skills/{skill_name}/")
+    return entries
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -246,14 +269,14 @@ def main():
             init_settings_json(project_root, log, args.dry_run)
             init_settings_local_json(project_root, log, args.dry_run)
             claude_pc = provider_config.get("Claude", {})
-            gitignore_entries = claude_pc.get("gitignore_entries", [
+            base_gitignore_entries = claude_pc.get("gitignore_entries", [
                 ".claude/settings.local.json",
                 ".claude/agent-memory-local/",
                 "CLAUDE.personal.md",
                 "sync.log",
             ])
-            ensure_gitignore_entries(project_root, log, args.dry_run,
-                                     gitignore_entries=gitignore_entries)
+            # Skill gitignore entries are collected after skills are processed (below)
+            # and merged via exact_entries so stale entries are removed automatically.
         # Per-provider sync
         for provider in providers:
             pc = provider_config[provider]
@@ -284,6 +307,12 @@ def main():
                 elif not ext_config["skills"][skill_name].get("approved", False):
                     log.warn(f"external-skills: '{skill_name}' is not approved by meta-maintainer -- skipping")
         sync_external_skills(agent_meta_root, project_root, config, variables, log, args.dry_run)
+        # Update .gitignore managed block: base entries + gitignore:true skill entries
+        if is_claude:
+            skill_gitignore_entries = _collect_skill_gitignore_entries(config, ext_config)
+            all_gitignore_entries = base_gitignore_entries + skill_gitignore_entries
+            ensure_gitignore_entries(project_root, log, args.dry_run,
+                                     exact_entries=all_gitignore_entries)
 
     log_path = project_root / LOGFILE
     _providers = resolve_providers(config, load_providers_config(agent_meta_root)) if config else []


### PR DESCRIPTION
## Summary

- Projects can now set `gitignore: true` per skill in `.meta-config/project.yaml`
- `sync.py` manages the `.gitignore` managed block exactly — adds entries for active `gitignore: true` skills, removes them when skills are disabled/deactivated
- `ensure_gitignore_entries()` refactored: new `exact_entries` parameter for full managed-block control (vs. additive-only `gitignore_entries`)
- Schema updated: `gitignore` boolean added to external-skill entry in `project-config.schema.json`
- Documented in `howto/external-skills.md` and `CLAUDE.md`

## Closes

Closes #18

## Test plan

- [ ] Set `gitignore: true` for an enabled skill → `.gitignore` managed block contains `.claude/skills/<skill>/`
- [ ] Remove `gitignore: true` (or set `false`) → entry removed from managed block on next sync
- [ ] Disable skill (`enabled: false`) with `gitignore: true` → entry not added
- [ ] No `external-skills` block in config → `.gitignore` unchanged (only base entries)
- [ ] Dry-run shows correct ADD/REMOVE log messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)