### PR TITLE
feat: lifecycle trigger system for git event-driven agent tasks

### DIFF
--- a/.claude/hooks/.agent-meta-managed
+++ b/.claude/hooks/.agent-meta-managed
@@ -1,1 +1,2 @@
 dod-push-check.sh
+lifecycle-check.sh

--- a/.claude/hooks/lifecycle-check.sh
+++ b/.claude/hooks/lifecycle-check.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# hook: lifecycle-check
+# version: 1.0.0
+# event: PostToolUse
+# matcher: Bash
+# description: Detects git lifecycle events (tag push, merge, version bump) and writes pending tasks to .claude/pending-tasks.md
+# enabled_by_default: false
+
+# Claude Code passes hook context as JSON on stdin.
+# PostToolUse hooks receive the tool result — exit code is ignored.
+
+INPUT=$(cat)
+
+# python3 required for JSON parsing
+command -v python3 &>/dev/null || exit 0
+
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null)
+COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
+EXIT_CODE=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); r=d.get('tool_result',{}); print(r.get('exit_code','0') if isinstance(r,dict) else '0')" 2>/dev/null)
+
+# Only intercept successful Bash tool calls
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+[ "$EXIT_CODE" = "0" ] || exit 0
+
+# Locate lifecycle_check.py (relative to this hook's location or via AGENT_META_ROOT)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIFECYCLE_PY="$(dirname "$(dirname "$SCRIPT_DIR")")/scripts/lifecycle_check.py"
+
+# Fallback: search for .agent-meta submodule from cwd
+if [ ! -f "$LIFECYCLE_PY" ]; then
+  LIFECYCLE_PY="$PWD/.agent-meta/scripts/lifecycle_check.py"
+fi
+
+[ -f "$LIFECYCLE_PY" ] || exit 0
+
+# ---------------------------------------------------------------------------
+# Detect lifecycle event from the git command that just ran
+# ---------------------------------------------------------------------------
+
+EVENT=""
+
+# on-release: git push with a tag (git push origin v1.2.3 or git push --tags)
+if echo "$COMMAND" | grep -qE 'git push' && \
+   echo "$COMMAND" | grep -qE '(--tags?|v[0-9]+\.[0-9]+\.[0-9]+)'; then
+  EVENT="on-release"
+
+# on-version-bump-*: commit message contains "bump version to X.Y.Z" or "chore: bump"
+elif echo "$COMMAND" | grep -qE 'git commit'; then
+  COMMIT_MSG=$(echo "$COMMAND" | grep -oP '(?<=-m ["\x27]).*(?=["\x27])' | head -1)
+  if echo "$COMMIT_MSG" | grep -qiE 'bump.*version|version.*bump|chore.*bump'; then
+    # Detect patch/minor/major from version numbers in commit message
+    # Heuristic: look for X.Y.Z pattern
+    VERSION=$(echo "$COMMIT_MSG" | grep -oP '\d+\.\d+\.\d+' | head -1)
+    if [ -n "$VERSION" ]; then
+      PATCH=$(echo "$VERSION" | cut -d. -f3)
+      MINOR=$(echo "$VERSION" | cut -d. -f2)
+      MAJOR=$(echo "$VERSION" | cut -d. -f1)
+      # Check if previous tag exists to determine bump type
+      PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1)
+      if [ -n "$PREV_TAG" ]; then
+        PREV_MAJOR=$(echo "$PREV_TAG" | cut -d. -f1)
+        PREV_MINOR=$(echo "$PREV_TAG" | cut -d. -f2)
+        if [ "$MAJOR" != "$PREV_MAJOR" ]; then
+          EVENT="on-version-bump-major"
+        elif [ "$MINOR" != "$PREV_MINOR" ]; then
+          EVENT="on-version-bump-minor"
+        else
+          EVENT="on-version-bump-patch"
+        fi
+      else
+        EVENT="on-version-bump-patch"
+      fi
+    fi
+  fi
+
+# on-merge: git merge command or commit on main after a branch
+elif echo "$COMMAND" | grep -qE 'git merge|gh pr merge'; then
+  EVENT="on-merge"
+
+# on-commit: any successful git commit (broad catch — only fires if configured)
+elif echo "$COMMAND" | grep -qE 'git commit'; then
+  EVENT="on-commit"
+fi
+
+[ -n "$EVENT" ] || exit 0
+
+# Fire the lifecycle check
+python3 "$LIFECYCLE_PY" "$EVENT"
+
+exit 0

--- a/.claude/rules/.agent-meta-managed
+++ b/.claude/rules/.agent-meta-managed
@@ -5,6 +5,7 @@ conventions.md
 dod-criteria.md
 issue-lifecycle.md
 language.md
+lifecycle-tasks.md
 speech-mode.md
 sync-interface.md
 use-orchestrator.md

--- a/.claude/rules/lifecycle-tasks.md
+++ b/.claude/rules/lifecycle-tasks.md
@@ -1,0 +1,42 @@
+# Lifecycle-Tasks — Ausstehende Aufgaben prüfen
+
+Beim Start einer neuen Konversation: prüfe ob `.claude/pending-tasks.md` existiert.
+
+## Pflicht beim Konversations-Start
+
+```bash
+# Prüfen ob Lifecycle-Tasks ausstehen
+test -f .claude/pending-tasks.md && cat .claude/pending-tasks.md
+```
+
+Wenn die Datei existiert und offene Tasks enthält (`- [ ]`):
+
+1. Informiere den User:
+   > "Es gibt ausstehende Lifecycle-Tasks aus einem Git-Event. Soll ich diese jetzt bearbeiten?"
+
+2. Zeige die offenen Tasks kompakt (Agent + Aufgabe, eine Zeile je Task).
+
+3. Wenn User bestätigt → delegiere Tasks an die genannten Agenten.
+
+4. Nach Erledigung aller Tasks: lösche `.claude/pending-tasks.md`.
+
+## Wann diese Rule greift
+
+Lifecycle-Tasks entstehen wenn der `lifecycle-check`-Hook aktiv ist und ein konfiguriertes
+Git-Event erkannt wird (z.B. Release-Tag, Version-Bump, Merge).
+
+Konfiguration in `.meta-config/project.yaml`:
+```yaml
+lifecycle-triggers:
+  on-release:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release."
+  on-merge:
+    - agent: validator
+      task: "Quick DoD check for merged changes."
+```
+
+## Wenn keine Tasks offen sind
+
+Datei existiert nicht oder enthält keine `- [ ]` Zeilen → nichts tun.
+Datei nicht committen — sie ist gitignored (`.claude/pending-tasks.md`).

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@ CLAUDE.personal.md
 sync.log
 
 # --- agent-meta managed (do not edit) ---
-.claude/settings.local.json
 .claude/agent-memory-local/
+.claude/pending-tasks.md
+.claude/settings.local.json
 CLAUDE.personal.md
 sync.log
 # --- end agent-meta managed ---

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -11,6 +11,7 @@ providers:
     gitignore_entries:
       - .claude/settings.local.json
       - .claude/agent-memory-local/
+      - .claude/pending-tasks.md
       - CLAUDE.personal.md
       - sync.log
 

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -374,6 +374,19 @@
       },
       "additionalProperties": false
     },
+    "lifecycle-triggers": {
+      "type": "object",
+      "description": "Agent tasks to run automatically on git lifecycle events (commit, merge, version bump, release). Requires lifecycle-check hook to be enabled.",
+      "properties": {
+        "on-commit":             { "$ref": "#/$defs/lifecycleTriggerList" },
+        "on-merge":              { "$ref": "#/$defs/lifecycleTriggerList" },
+        "on-version-bump-patch": { "$ref": "#/$defs/lifecycleTriggerList" },
+        "on-version-bump-minor": { "$ref": "#/$defs/lifecycleTriggerList" },
+        "on-version-bump-major": { "$ref": "#/$defs/lifecycleTriggerList" },
+        "on-release":            { "$ref": "#/$defs/lifecycleTriggerList" }
+      },
+      "additionalProperties": false
+    },
     "external-skills": {
       "type": "object",
       "description": "Opt-in external skill activation. Two-Gate: approved in external-skills.config.json AND enabled here.",
@@ -395,5 +408,26 @@
   "required": [
     "project"
   ],
-  "additionalProperties": true
+  "additionalProperties": true,
+  "$defs": {
+    "lifecycleTriggerList": {
+      "type": "array",
+      "description": "List of agent tasks to run for this lifecycle event.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "string",
+            "description": "Agent role to delegate the task to (e.g. 'documenter', 'validator')."
+          },
+          "task": {
+            "type": "string",
+            "description": "Task description passed to the agent."
+          }
+        },
+        "required": ["agent", "task"],
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/hooks/1-generic/lifecycle-check.sh
+++ b/hooks/1-generic/lifecycle-check.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# hook: lifecycle-check
+# version: 1.0.0
+# event: PostToolUse
+# matcher: Bash
+# description: Detects git lifecycle events (tag push, merge, version bump) and writes pending tasks to .claude/pending-tasks.md
+# enabled_by_default: false
+
+# Claude Code passes hook context as JSON on stdin.
+# PostToolUse hooks receive the tool result — exit code is ignored.
+
+INPUT=$(cat)
+
+# python3 required for JSON parsing
+command -v python3 &>/dev/null || exit 0
+
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null)
+COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
+EXIT_CODE=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); r=d.get('tool_result',{}); print(r.get('exit_code','0') if isinstance(r,dict) else '0')" 2>/dev/null)
+
+# Only intercept successful Bash tool calls
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+[ "$EXIT_CODE" = "0" ] || exit 0
+
+# Locate lifecycle_check.py (relative to this hook's location or via AGENT_META_ROOT)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIFECYCLE_PY="$(dirname "$(dirname "$SCRIPT_DIR")")/scripts/lifecycle_check.py"
+
+# Fallback: search for .agent-meta submodule from cwd
+if [ ! -f "$LIFECYCLE_PY" ]; then
+  LIFECYCLE_PY="$PWD/.agent-meta/scripts/lifecycle_check.py"
+fi
+
+[ -f "$LIFECYCLE_PY" ] || exit 0
+
+# ---------------------------------------------------------------------------
+# Detect lifecycle event from the git command that just ran
+# ---------------------------------------------------------------------------
+
+EVENT=""
+
+# on-release: git push with a tag (git push origin v1.2.3 or git push --tags)
+if echo "$COMMAND" | grep -qE 'git push' && \
+   echo "$COMMAND" | grep -qE '(--tags?|v[0-9]+\.[0-9]+\.[0-9]+)'; then
+  EVENT="on-release"
+
+# on-version-bump-*: commit message contains "bump version to X.Y.Z" or "chore: bump"
+elif echo "$COMMAND" | grep -qE 'git commit'; then
+  COMMIT_MSG=$(echo "$COMMAND" | grep -oP '(?<=-m ["\x27]).*(?=["\x27])' | head -1)
+  if echo "$COMMIT_MSG" | grep -qiE 'bump.*version|version.*bump|chore.*bump'; then
+    # Detect patch/minor/major from version numbers in commit message
+    # Heuristic: look for X.Y.Z pattern
+    VERSION=$(echo "$COMMIT_MSG" | grep -oP '\d+\.\d+\.\d+' | head -1)
+    if [ -n "$VERSION" ]; then
+      PATCH=$(echo "$VERSION" | cut -d. -f3)
+      MINOR=$(echo "$VERSION" | cut -d. -f2)
+      MAJOR=$(echo "$VERSION" | cut -d. -f1)
+      # Check if previous tag exists to determine bump type
+      PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1)
+      if [ -n "$PREV_TAG" ]; then
+        PREV_MAJOR=$(echo "$PREV_TAG" | cut -d. -f1)
+        PREV_MINOR=$(echo "$PREV_TAG" | cut -d. -f2)
+        if [ "$MAJOR" != "$PREV_MAJOR" ]; then
+          EVENT="on-version-bump-major"
+        elif [ "$MINOR" != "$PREV_MINOR" ]; then
+          EVENT="on-version-bump-minor"
+        else
+          EVENT="on-version-bump-patch"
+        fi
+      else
+        EVENT="on-version-bump-patch"
+      fi
+    fi
+  fi
+
+# on-merge: git merge command or commit on main after a branch
+elif echo "$COMMAND" | grep -qE 'git merge|gh pr merge'; then
+  EVENT="on-merge"
+
+# on-commit: any successful git commit (broad catch — only fires if configured)
+elif echo "$COMMAND" | grep -qE 'git commit'; then
+  EVENT="on-commit"
+fi
+
+[ -n "$EVENT" ] || exit 0
+
+# Fire the lifecycle check
+python3 "$LIFECYCLE_PY" "$EVENT"
+
+exit 0

--- a/howto/lifecycle-triggers.md
+++ b/howto/lifecycle-triggers.md
@@ -1,0 +1,221 @@
+# Lifecycle Triggers — Agenten-Tasks bei Git-Events
+
+Lifecycle Triggers lösen Agenten-Tasks automatisch aus wenn definierte Git-Events eintreten:
+Release-Tag gesetzt, Version hochgezählt, Branch gemergt.
+
+**Kernprinzip:** Bestimmte Aufgaben (CODEBASE_OVERVIEW, Traceability-Audit, ARCHITECTURE-Update)
+sind nicht bei jedem Commit sinnvoll — sondern nur zu Schlüsselmomenten im Entwicklungsprozess.
+
+---
+
+## Wie es funktioniert
+
+```
+Entwickler macht git push --tags v1.2.0
+        ↓
+lifecycle-check.sh Hook (PostToolUse) erkennt Tag-Push
+        ↓
+lifecycle_check.py liest lifecycle-triggers aus .meta-config/project.yaml
+        ↓
+.claude/pending-tasks.md wird geschrieben (gitignored)
+        ↓
+Beim nächsten Konversationsstart: lifecycle-tasks Rule erinnert Claude
+        ↓
+Claude fragt User → delegiert Tasks an die konfigurierten Agenten
+```
+
+---
+
+## Konfiguration
+
+In `.meta-config/project.yaml`:
+
+```yaml
+lifecycle-triggers:
+  on-release:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release."
+    - agent: validator
+      task: "Run full DoD audit and traceability check."
+
+  on-version-bump-minor:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md — new features may have changed the structure."
+
+  on-version-bump-major:
+    - agent: documenter
+      task: "Full architecture review and ARCHITECTURE.md update."
+    - agent: requirements
+      task: "Review and close completed REQ-IDs."
+
+  on-merge:
+    - agent: validator
+      task: "Quick DoD check for merged changes."
+```
+
+### Unterstützte Events
+
+| Event | Wann ausgelöst | Typische Tasks |
+|-------|---------------|----------------|
+| `on-commit` | Jeder erfolgreiche `git commit` | Leichtgewichtige Checks (sparsam nutzen) |
+| `on-merge` | `git merge` oder `gh pr merge` | DoD-Check, Quick-Audit |
+| `on-version-bump-patch` | Commit mit Patch-Bump-Nachricht | Changelog-Prüfung |
+| `on-version-bump-minor` | Commit mit Minor-Bump-Nachricht | Doku-Update |
+| `on-version-bump-major` | Commit mit Major-Bump-Nachricht | Full Audit, ARCHITECTURE |
+| `on-release` | `git push` mit Tag-Referenz | Vollständige Release-Checkliste |
+
+**Erkennung von Version-Bumps:** Der Hook erkennt Commits deren Nachricht
+`bump version`, `version bump` oder `chore: bump` enthält (case-insensitive).
+
+---
+
+## Aktivierung
+
+### Schritt 1: Hook aktivieren
+
+In `.meta-config/project.yaml`:
+
+```yaml
+hooks:
+  lifecycle-check:
+    enabled: true
+```
+
+### Schritt 2: Sync ausführen
+
+```bash
+py .agent-meta/scripts/sync.py
+```
+
+Der Hook wird nach `.claude/hooks/lifecycle-check.sh` kopiert und in `.claude/settings.json`
+als `PostToolUse` Hook registriert.
+
+### Schritt 3: Triggers konfigurieren
+
+`lifecycle-triggers` Block in `.meta-config/project.yaml` eintragen (s. oben).
+Kein weiterer Sync nötig — `lifecycle_check.py` liest die Config zur Laufzeit.
+
+---
+
+## Pending Tasks Datei
+
+Wenn ein Trigger auslöst, schreibt `lifecycle_check.py` eine Datei:
+
+```
+.claude/pending-tasks.md
+```
+
+Format:
+
+```markdown
+# Ausstehende Lifecycle-Tasks
+
+## Release / Git-Tag — 2026-04-18 14:32
+
+- [ ] **[documenter]** Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release.
+- [ ] **[validator]** Run full DoD audit and traceability check.
+```
+
+**Eigenschaften:**
+- Gitignored (`.claude/pending-tasks.md` wird vom Sync zur `.gitignore` hinzugefügt)
+- Akkumuliert Tasks — neue Einträge werden angehängt, nicht überschrieben
+- Bereits erledigte Tasks (`- [x]`) werden nicht erneut hinzugefügt
+- Nach Erledigung aller Tasks: Datei manuell oder per Agent löschen
+
+---
+
+## Abgrenzung zu bestehenden Hooks
+
+| | Hooks (bestehend) | Lifecycle Triggers (neu) |
+|--|------------------|--------------------------|
+| Trigger | Tool-Aufrufe (`PreToolUse`) | Git-Events (`PostToolUse`) |
+| Aktion | Shell-Script — blockiert oder erlaubt | Agenten-Tasks anstoßen |
+| Token-Kosten | Niedrig (Shell) | Mittel-Hoch (Agent) |
+| Konfiguration | `hooks: name: enabled: true` | `lifecycle-triggers: event: [...]` |
+| Beispiel | `dod-push-check` blockiert Push ohne Tests | `on-release` startet CODEBASE_OVERVIEW-Update |
+
+---
+
+## Empfohlene Konfigurationen
+
+### Minimal (nur Release-Checkliste)
+
+```yaml
+hooks:
+  lifecycle-check:
+    enabled: true
+
+lifecycle-triggers:
+  on-release:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release."
+    - agent: validator
+      task: "Run full DoD audit and traceability check before release."
+```
+
+### Standard (Release + Merge-Check)
+
+```yaml
+lifecycle-triggers:
+  on-release:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release."
+    - agent: validator
+      task: "Run full DoD audit and traceability check."
+  on-merge:
+    - agent: validator
+      task: "Quick DoD check: were all DoD criteria met for the merged changes?"
+  on-version-bump-major:
+    - agent: documenter
+      task: "Full architecture review — update ARCHITECTURE.md and CODEBASE_OVERVIEW.md."
+    - agent: requirements
+      task: "Review open REQ-IDs — close completed requirements."
+```
+
+### Token-Sparend (nur bei Major-Events)
+
+```yaml
+lifecycle-triggers:
+  on-version-bump-major:
+    - agent: documenter
+      task: "Full architecture review and ARCHITECTURE.md update."
+  on-release:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md for this release."
+```
+
+---
+
+## Troubleshooting
+
+### Hook löst nicht aus
+
+1. Prüfe ob der Hook in `settings.json` registriert ist:
+   ```bash
+   cat .claude/settings.json | grep lifecycle
+   ```
+2. Prüfe ob `lifecycle-check` in `.meta-config/project.yaml` auf `enabled: true` steht
+3. Führe `sync.py` erneut aus
+
+### Keine Tasks in `pending-tasks.md`
+
+- Prüfe ob das Git-Kommando dem erkannten Muster entspricht
+  - Tag-Push: `git push origin v1.2.3` oder `git push --tags`
+  - Merge: `git merge` oder `gh pr merge`
+  - Version-Bump: Commit-Nachricht muss `bump version` o.ä. enthalten
+- Prüfe ob `lifecycle-triggers` in `.meta-config/project.yaml` befüllt ist
+- Manuell testen:
+  ```bash
+  python3 .agent-meta/scripts/lifecycle_check.py on-release
+  ```
+
+### PyYAML nicht installiert
+
+`lifecycle_check.py` benötigt PyYAML für YAML-Configs:
+```bash
+pip install pyyaml
+# oder
+pip3 install pyyaml
+```
+
+Bei JSON-Config (`agent-meta.config.json`) wird PyYAML nicht benötigt.

--- a/rules/1-generic/lifecycle-tasks.md
+++ b/rules/1-generic/lifecycle-tasks.md
@@ -1,0 +1,42 @@
+# Lifecycle-Tasks — Ausstehende Aufgaben prüfen
+
+Beim Start einer neuen Konversation: prüfe ob `.claude/pending-tasks.md` existiert.
+
+## Pflicht beim Konversations-Start
+
+```bash
+# Prüfen ob Lifecycle-Tasks ausstehen
+test -f .claude/pending-tasks.md && cat .claude/pending-tasks.md
+```
+
+Wenn die Datei existiert und offene Tasks enthält (`- [ ]`):
+
+1. Informiere den User:
+   > "Es gibt ausstehende Lifecycle-Tasks aus einem Git-Event. Soll ich diese jetzt bearbeiten?"
+
+2. Zeige die offenen Tasks kompakt (Agent + Aufgabe, eine Zeile je Task).
+
+3. Wenn User bestätigt → delegiere Tasks an die genannten Agenten.
+
+4. Nach Erledigung aller Tasks: lösche `.claude/pending-tasks.md`.
+
+## Wann diese Rule greift
+
+Lifecycle-Tasks entstehen wenn der `lifecycle-check`-Hook aktiv ist und ein konfiguriertes
+Git-Event erkannt wird (z.B. Release-Tag, Version-Bump, Merge).
+
+Konfiguration in `.meta-config/project.yaml`:
+```yaml
+lifecycle-triggers:
+  on-release:
+    - agent: documenter
+      task: "Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release."
+  on-merge:
+    - agent: validator
+      task: "Quick DoD check for merged changes."
+```
+
+## Wenn keine Tasks offen sind
+
+Datei existiert nicht oder enthält keine `- [ ]` Zeilen → nichts tun.
+Datei nicht committen — sie ist gitignored (`.claude/pending-tasks.md`).

--- a/scripts/lifecycle_check.py
+++ b/scripts/lifecycle_check.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""lifecycle_check.py — called by the lifecycle-check.sh hook.
+
+Usage:
+  python3 .agent-meta/scripts/lifecycle_check.py <event> [--project-root <path>]
+
+Events: on-commit, on-merge, on-version-bump-patch, on-version-bump-minor,
+        on-version-bump-major, on-release
+
+Reads lifecycle-triggers from .meta-config/project.yaml and appends pending
+tasks to .claude/pending-tasks.md.
+"""
+
+import sys
+import json
+from pathlib import Path
+from datetime import datetime
+
+try:
+    import yaml
+    _HAS_YAML = True
+except ImportError:
+    _HAS_YAML = False
+
+
+# ---------------------------------------------------------------------------
+# Config loading (minimal, no lib/ dependency)
+# ---------------------------------------------------------------------------
+
+def _find_config(project_root: Path) -> Path | None:
+    candidates = [
+        project_root / ".meta-config" / "project.yaml",
+        project_root / "agent-meta.config.yaml",
+        project_root / "agent-meta.config.json",
+    ]
+    return next((c for c in candidates if c.exists()), None)
+
+
+def _load_config(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in (".yaml", ".yml"):
+        if _HAS_YAML:
+            return yaml.safe_load(text) or {}
+        # Minimal YAML fallback: only top-level keys matter for lifecycle-triggers
+        # If PyYAML is not available, return empty (no triggers will fire)
+        return {}
+    return json.loads(text)
+
+
+# ---------------------------------------------------------------------------
+# Pending tasks file
+# ---------------------------------------------------------------------------
+
+PENDING_FILE = ".claude/pending-tasks.md"
+PENDING_HEADER = "# Ausstehende Lifecycle-Tasks\n\n"
+PENDING_FOOTER = (
+    "\n---\n"
+    "_Generiert von lifecycle-check.py — lösche diese Datei wenn alle Tasks erledigt sind._\n"
+)
+
+TRIGGER_LABELS = {
+    "on-commit":              "Commit",
+    "on-merge":               "Branch-Merge",
+    "on-version-bump-patch":  "Patch-Version-Bump",
+    "on-version-bump-minor":  "Minor-Version-Bump",
+    "on-version-bump-major":  "Major-Version-Bump",
+    "on-release":             "Release / Git-Tag",
+}
+
+
+def _read_existing_tasks(path: Path) -> list[str]:
+    """Return existing pending task lines (markdown list items)."""
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [l for l in lines if l.startswith("- [ ]")]
+
+
+def write_pending_tasks(project_root: Path, event: str, tasks: list[dict]) -> None:
+    """Append new pending tasks to .claude/pending-tasks.md."""
+    pending_path = project_root / PENDING_FILE
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = _read_existing_tasks(pending_path)
+    label = TRIGGER_LABELS.get(event, event)
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    new_items = []
+    for t in tasks:
+        agent = t.get("agent", "orchestrator")
+        task = t.get("task", "")
+        item = f"- [ ] **[{agent}]** {task}"
+        if item not in existing:
+            new_items.append(item)
+
+    if not new_items:
+        return  # all tasks already pending
+
+    section = f"## {label} — {timestamp}\n\n" + "\n".join(new_items)
+
+    if pending_path.exists():
+        current = pending_path.read_text(encoding="utf-8")
+        # Append new section before footer
+        if PENDING_FOOTER.strip() in current:
+            current = current.replace(PENDING_FOOTER, f"\n{section}\n{PENDING_FOOTER}")
+        else:
+            current = current.rstrip("\n") + f"\n\n{section}\n"
+        pending_path.write_text(current, encoding="utf-8")
+    else:
+        pending_path.write_text(
+            PENDING_HEADER + section + PENDING_FOOTER, encoding="utf-8"
+        )
+
+    print(f"lifecycle-check: {len(new_items)} task(s) added to {PENDING_FILE} (trigger: {event})")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args:
+        print("Usage: lifecycle_check.py <event> [--project-root <path>]", file=sys.stderr)
+        sys.exit(1)
+
+    event = args[0]
+    project_root = Path.cwd()
+    if "--project-root" in args:
+        idx = args.index("--project-root")
+        project_root = Path(args[idx + 1]).resolve()
+
+    config_path = _find_config(project_root)
+    if not config_path:
+        # No config found — silently exit (project may not use agent-meta)
+        sys.exit(0)
+
+    try:
+        config = _load_config(config_path)
+    except Exception as e:
+        print(f"lifecycle-check: could not load config: {e}", file=sys.stderr)
+        sys.exit(0)
+
+    triggers = config.get("lifecycle-triggers", {})
+    tasks = triggers.get(event, [])
+
+    if not tasks:
+        sys.exit(0)
+
+    write_pending_tasks(project_root, event, tasks)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a configurable system that runs agent tasks automatically at defined git lifecycle events — instead of forgetting or manually triggering them.

**Components:**
- `lifecycle-check.sh` — `PostToolUse` hook that detects git events (tag push, merge, version bump commit)
- `lifecycle_check.py` — reads `lifecycle-triggers` config, appends tasks to `.claude/pending-tasks.md`
- `lifecycle-tasks.md` rule — reminds Claude to check pending tasks at conversation start
- `config/ai-providers.yaml` — adds `.claude/pending-tasks.md` to gitignored entries
- `project-config.schema.json` — full schema for `lifecycle-triggers` with `$defs`
- `howto/lifecycle-triggers.md` — complete documentation with examples

**Usage:**
```yaml
# .meta-config/project.yaml
hooks:
  lifecycle-check:
    enabled: true

lifecycle-triggers:
  on-release:
    - agent: documenter
      task: "Update CODEBASE_OVERVIEW.md and ARCHITECTURE.md for this release."
    - agent: validator
      task: "Run full DoD audit and traceability check."
  on-merge:
    - agent: validator
      task: "Quick DoD check for merged changes."
```

## Closes

Closes #27

## Test plan

- [ ] `sync.py` copies `lifecycle-check.sh` to `.claude/hooks/`
- [ ] `sync.py` copies `lifecycle-tasks.md` to `.claude/rules/`
- [ ] `.claude/pending-tasks.md` added to `.gitignore` managed block
- [ ] Hook not registered in settings.json until `enabled: true` is set
- [ ] `python3 .agent-meta/scripts/lifecycle_check.py on-release` writes `pending-tasks.md` when triggers configured
- [ ] Duplicate tasks not added if already pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)