### PR TITLE
docs+feat: rules/, folder CLAUDE.md, AGENTS.md, rules-preset howto, InfluxDB config (#7, #9, #11, #53, #56)

### DIFF
--- a/.claude/agents/agent-meta-manager.md
+++ b/.claude/agents/agent-meta-manager.md
@@ -1,9 +1,9 @@
 ---
 name: agent-meta-manager
 model: sonnet
-version: "1.4.0"
+version: "1.4.1"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
-generated-from: "1-generic/agent-meta-manager.md@1.4.0"
+generated-from: "1-generic/agent-meta-manager.md@1.4.1"
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
   - Bash
@@ -85,19 +85,21 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten
+## 6. Projektspezifische Agenten & Regeln
 
 ```
-Zusätzliche Regeln/Wissen?    → Extension:  --create-ext <rolle>
-Komplett anderer Workflow?    → Override:   .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
+Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
 ```
 
 ```bash
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
 ```
 
-Extensions so kurz wie möglich halten.
+Extensions und Rules so kurz wie möglich halten.
 
 ---
 
@@ -148,3 +150,4 @@ der richtige Weg — nicht alles in CLAUDE.md packen).
 - NICHT sync ohne danach `sync.log` zu prüfen
 - KEINE manuellen Änderungen in `.claude/agents/`
 - NIE in den managed block von CLAUDE.md schreiben
+- Bei Multi-Tool-Teams (Cursor, OpenAI, etc.): auf Symlink-Strategie hinweisen — `AGENTS.md` ↔ `CLAUDE.md` Symlink, nicht zwei separate Dateien pflegen

--- a/.continue/agents/agent-meta-manager.md
+++ b/.continue/agents/agent-meta-manager.md
@@ -70,19 +70,21 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten
+## 6. Projektspezifische Agenten & Regeln
 
 ```
-Zusätzliche Regeln/Wissen?    → Extension:  --create-ext <rolle>
-Komplett anderer Workflow?    → Override:   .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
+Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
 ```
 
 ```bash
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
 ```
 
-Extensions so kurz wie möglich halten.
+Extensions und Rules so kurz wie möglich halten.
 
 ---
 
@@ -133,3 +135,4 @@ der richtige Weg — nicht alles in CLAUDE.md packen).
 - NICHT sync ohne danach `sync.log` zu prüfen
 - KEINE manuellen Änderungen in `.claude/agents/`
 - NIE in den managed block von CLAUDE.md schreiben
+- Bei Multi-Tool-Teams (Cursor, OpenAI, etc.): auf Symlink-Strategie hinweisen — `AGENTS.md` ↔ `CLAUDE.md` Symlink, nicht zwei separate Dateien pflegen

--- a/.continue/prompts/agent-meta-manager.md
+++ b/.continue/prompts/agent-meta-manager.md
@@ -70,19 +70,21 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten
+## 6. Projektspezifische Agenten & Regeln
 
 ```
-Zusätzliche Regeln/Wissen?    → Extension:  --create-ext <rolle>
-Komplett anderer Workflow?    → Override:   .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
+Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
 ```
 
 ```bash
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
 ```
 
-Extensions so kurz wie möglich halten.
+Extensions und Rules so kurz wie möglich halten.
 
 ---
 
@@ -133,3 +135,4 @@ der richtige Weg — nicht alles in CLAUDE.md packen).
 - NICHT sync ohne danach `sync.log` zu prüfen
 - KEINE manuellen Änderungen in `.claude/agents/`
 - NIE in den managed block von CLAUDE.md schreiben
+- Bei Multi-Tool-Teams (Cursor, OpenAI, etc.): auf Symlink-Strategie hinweisen — `AGENTS.md` ↔ `CLAUDE.md` Symlink, nicht zwei separate Dateien pflegen

--- a/.gemini/agents/agent-meta-manager.md
+++ b/.gemini/agents/agent-meta-manager.md
@@ -1,9 +1,9 @@
 ---
 name: agent-meta-manager
 model: sonnet
-version: "1.4.0"
+version: "1.4.1"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
-generated-from: "1-generic/agent-meta-manager.md@1.4.0"
+generated-from: "1-generic/agent-meta-manager.md@1.4.1"
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
   - Bash
@@ -83,19 +83,21 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten
+## 6. Projektspezifische Agenten & Regeln
 
 ```
-Zusätzliche Regeln/Wissen?    → Extension:  --create-ext <rolle>
-Komplett anderer Workflow?    → Override:   .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
+Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
 ```
 
 ```bash
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
 ```
 
-Extensions so kurz wie möglich halten.
+Extensions und Rules so kurz wie möglich halten.
 
 ---
 
@@ -146,3 +148,4 @@ der richtige Weg — nicht alles in CLAUDE.md packen).
 - NICHT sync ohne danach `sync.log` zu prüfen
 - KEINE manuellen Änderungen in `.claude/agents/`
 - NIE in den managed block von CLAUDE.md schreiben
+- Bei Multi-Tool-Teams (Cursor, OpenAI, etc.): auf Symlink-Strategie hinweisen — `AGENTS.md` ↔ `CLAUDE.md` Symlink, nicht zwei separate Dateien pflegen

--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-manager
-version: "1.4.0"
+version: "1.4.1"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
@@ -83,19 +83,21 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten
+## 6. Projektspezifische Agenten & Regeln
 
 ```
-Zusätzliche Regeln/Wissen?    → Extension:  --create-ext <rolle>
-Komplett anderer Workflow?    → Override:   .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
+Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
 ```
 
 ```bash
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
 ```
 
-Extensions so kurz wie möglich halten.
+Extensions und Rules so kurz wie möglich halten.
 
 ---
 
@@ -146,3 +148,4 @@ der richtige Weg — nicht alles in CLAUDE.md packen).
 - NICHT sync ohne danach `sync.log` zu prüfen
 - KEINE manuellen Änderungen in `.claude/agents/`
 - NIE in den managed block von CLAUDE.md schreiben
+- Bei Multi-Tool-Teams (Cursor, OpenAI, etc.): auf Symlink-Strategie hinweisen — `AGENTS.md` ↔ `CLAUDE.md` Symlink, nicht zwei separate Dateien pflegen

--- a/howto/features/rules-preset-optimization.md
+++ b/howto/features/rules-preset-optimization.md
@@ -1,0 +1,126 @@
+# Rules-Preset Optimierung für platform-heavy Projekte
+
+> Für Projekte mit vielen Platform Rules die bei jedem Request Token-Overhead erzeugen.
+
+---
+
+## Problem: Zu viele alwaysApply Rules
+
+Jede Rule in `.claude/rules/` mit `alwaysApply: true` (Standard) wird in **jeden Agenten-Request** geladen — egal ob relevant. Bei Platform-heavy Projekten (Home Assistant, Sharkord) kann das schnell 3.000–8.000 Token pro Request kosten.
+
+**Signale dass Rules zu viel Last erzeugen:**
+- Platform Rules > 400 Wörter (`wc -w <datei>`)
+- Rules enthalten Migration-Tabellen, Troubleshooting-Workflows oder Copy-Paste-Code-Templates
+- Inhalte sind nur bei konkreter Implementierung relevant (nicht bei jedem Request)
+
+---
+
+## Lösung: rules-preset + gezielte alwaysApply: false
+
+### Schritt 1 — Preset wählen
+
+In `.meta-config/project.yaml`:
+
+```yaml
+# Empfehlung für platform-heavy Projekte
+rules-preset: minimal
+```
+
+Verfügbare Presets:
+
+| Preset | Verhalten | Wann |
+|--------|-----------|------|
+| `default` | Alle Rules immer aktiv | Kleine Projekte, wenige Rules |
+| `minimal` | Situative Rules on-demand | Platform-heavy Projekte (empfohlen) |
+| `silent` | Nur Kern-Rules immer aktiv | Rapid-Prototyping, Token-Budget kritisch |
+
+### Schritt 2 — Große Platform Rules identifizieren
+
+```bash
+# Wort-Zahl aller Rules prüfen
+wc -w .claude/rules/*.md | sort -n
+```
+
+Faustregeln:
+
+| Wörter | Empfehlung |
+|--------|------------|
+| < 200 | `alwaysApply: true` — kein Problem |
+| 200–400 | Prüfen ob Inhalt wirklich immer relevant |
+| > 400 | `alwaysApply: false` empfohlen |
+| > 800 | Lazy-Load Pattern erwägen (siehe unten) |
+
+### Schritt 3 — Projekt-Override für einzelne Rules
+
+```yaml
+# .meta-config/project.yaml
+rules-preset: minimal
+
+rules:
+  homeassistant-package-structure:
+    alwaysApply: false   # ~900 Wörter, nur bei Package-Arbeit relevant
+  homeassistant-energy-abstraction:
+    alwaysApply: false   # ~480 Wörter, nur bei Energy-Features relevant
+  homeassistant-entity-data:
+    alwaysApply: false   # ~560 Wörter, situational
+```
+
+Nach sync: Diese Rules werden nur geladen wenn Claude Code sie für den aktuellen Request
+als relevant erkennt (Keyword-Match im Kontext).
+
+---
+
+## Lazy-Load Pattern für sehr große Rules
+
+Analog zum `_wf-*.md` Pattern bei Agenten: Kern-Rule + ausgelagertes Workflow-Dokument.
+
+**Vorher:** Eine große Rule mit allem:
+```
+homeassistant-package-structure.md   ← 900 Wörter, alwaysApply: true
+  → Core-Direktiven (100W) + Migration-Tabellen (400W) + Troubleshooting (400W)
+```
+
+**Nachher:** Schlanke Core-Rule + lazy-geladenes Workflow-Doc:
+```
+homeassistant-package-structure.md   ← ~150 Wörter, alwaysApply: true
+  → Nur Kern-Direktiven + Verweis auf Workflow
+_wf-ha-package-migration.md          ← ~750 Wörter, alwaysApply: false
+  → Migration-Workflow, Troubleshooting (nur bei Bedarf geladen)
+```
+
+**Namens-Konvention:** `_wf-<platform>-<thema>.md` (Unterstrich-Prefix = Workflow-Datei)
+
+**Verweis in der Core-Rule:**
+```markdown
+# HA Package Structure
+
+[Kern-Direktiven hier — kurz, imperativ]
+
+Für Migration-Workflow und Troubleshooting:
+→ Lies `_wf-ha-package-migration.md` (Claude Code lädt bei Bedarf)
+```
+
+---
+
+## Wann NICHT optimieren
+
+- Wenn eine Rule bei wirklich jedem Task relevant ist (z.B. `commit-conventions.md`) → `alwaysApply: true` behalten
+- Wenn das Projekt wenige Rules hat (< 5) → overhead vernachlässigbar
+- Wenn Token-Budget keine Rolle spielt → Standard-Preset reicht
+
+---
+
+## Checkliste: Rules-Preset-Optimierung
+
+- [ ] `wc -w .claude/rules/*.md` ausgeführt — Rules > 400W identifiziert
+- [ ] `rules-preset: minimal` oder `silent` in project.yaml gesetzt
+- [ ] Große Platform Rules auf `alwaysApply: false` gesetzt
+- [ ] Sync ausgeführt: `py .agent-meta/scripts/sync.py`
+- [ ] Getestet: Agenten erhalten bei typischen Requests noch die wichtigsten Rules
+
+---
+
+## Verwandte Dokumente
+
+- [howto/features/rules.md](rules.md) — Rules-System Übersicht
+- [config/rules-presets.yaml](../../config/rules-presets.yaml) — Preset-Definitionen

--- a/howto/features/sync-concept.md
+++ b/howto/features/sync-concept.md
@@ -55,6 +55,8 @@ agent-meta/
   CLAUDE.md                  ← bei "Claude" in ai-providers automatisch erstellt, danach manuell gepflegt
                                ├─ managed block (auto-aktualisiert bei jedem sync)
                                └─ handgeschriebener Rest (nie überschrieben)
+  src/backend/CLAUDE.md      ← optional: ordnerspezifischer Kontext (nie von sync.py berührt)
+  src/frontend/CLAUDE.md     ← optional: ordnerspezifischer Kontext (nie von sync.py berührt)
   CLAUDE.personal.md         ← persönliche Präferenzen (gitignored, nie committen)
   .claude/                   ← Claude Code (immer wenn "Claude" in ai-providers)
     settings.json            ← Team-Permissions (committed ins Repo)
@@ -338,6 +340,64 @@ Logfile: sync.log
 
 > **Multi-Provider Dokumentation:** [docs/providers/multi-provider.md](multi-provider.md) — vollständige Beschreibung
 > aller Provider (Claude, Gemini, Continue), Frontmatter-Unterschiede, Stale-Tracking, Troubleshooting.
+
+---
+
+## Ordner-level CLAUDE.md
+
+Claude Code lädt CLAUDE.md-Dateien **aus allen Unterordnern** automatisch wenn man sich in diesem Verzeichnis befindet. Das ist ein nativer Claude Code Feature — agent-meta berührt diese Dateien nicht.
+
+**Einsatz:** Wenn ein Unterordner eigene, spezifische Konventionen braucht die im Haupt-CLAUDE.md zu viel Platz wären.
+
+```
+src/
+  backend/
+    CLAUDE.md    ← Nur für Backend-Dateien: DB-Konventionen, API-Patterns
+  frontend/
+    CLAUDE.md    ← Nur für Frontend: Component-Struktur, CSS-Konventionen
+scripts/
+  CLAUDE.md      ← Script-spezifische Hinweise (z.B. Shell-Konventionen)
+```
+
+**Abgrenzung:**
+
+| Mechanismus | Scope | Geladen von |
+|-------------|-------|-------------|
+| `CLAUDE.md` (Root) | Gesamtprojekt | Claude Code automatisch |
+| `<ordner>/CLAUDE.md` | Nur dieser Ordner | Claude Code automatisch (wenn im Ordner) |
+| `.claude/3-project/*-ext.md` | Nur ein Agenten-Typ | Agent selbst per Read-Hook |
+
+Ordner-level CLAUDE.md eignet sich für allgemeine Konventionen. Für agentenspezifisches Wissen → Extension (`-ext.md`).
+
+---
+
+## Multi-Tool Strategie (AGENTS.md)
+
+Verschiedene AI-Tools nutzen verschiedene Konfigurationsdateinamen:
+- `CLAUDE.md` → Claude Code
+- `AGENTS.md` → OpenAI / generisch
+- `.cursor/rules/` → Cursor
+
+**Empfohlene Strategie für Multi-Tool-Teams:**
+
+```bash
+# AGENTS.md als primäre Datei, CLAUDE.md als Symlink
+mv CLAUDE.md AGENTS.md
+ln -s AGENTS.md CLAUDE.md          # Unix/macOS
+# mklink CLAUDE.md AGENTS.md       # Windows (als Admin)
+```
+
+Oder umgekehrt: CLAUDE.md primär (von agent-meta verwaltet), AGENTS.md als Symlink:
+```bash
+ln -s CLAUDE.md AGENTS.md
+```
+
+**Einschränkungen:**
+- Windows: Symlinks benötigen Admin-Rechte oder Developer Mode
+- agent-meta generiert immer `CLAUDE.md` als primäre Datei — der managed block wird nur in `CLAUDE.md` eingefügt
+- `AGENTS.md` wird von sync.py nicht verwaltet — manuell oder als Symlink pflegen
+
+**Wann sinnvoll:** Teams die Claude Code + andere Tools (Cursor, Copilot, OpenAI API) parallel nutzen.
 
 ---
 

--- a/platform-configs/homeassistant.defaults.yaml
+++ b/platform-configs/homeassistant.defaults.yaml
@@ -58,6 +58,15 @@ platform:
     # InfluxDB organization name
     influxdb_org: ""
 
+    # Measurement schema used by this HA instance
+    # "by_unit"   → measurements are unit names ("W", "°C", "kWh") — uncommon but valid
+    # "by_entity" → measurements are entity names ("sensor.living_room_temp") — default HA behavior
+    influxdb_measurement_schema: "by_entity"
+
+    # Local timezone of the HA instance (InfluxDB stores UTC, queries need offset)
+    # Example: "Europe/Berlin", "America/New_York", "UTC"
+    influxdb_timezone: "UTC"
+
     # -------------------------------------------------------------------------
     # Entity data / CSV export
     # -------------------------------------------------------------------------

--- a/rules/2-platform/_wf-ha-mcp-local.md
+++ b/rules/2-platform/_wf-ha-mcp-local.md
@@ -26,7 +26,10 @@ User: "Mein Sensor springt ständig zwischen Werten."
 - **Protokoll**: InfluxDB OSS API v2 (Flux-Queries)
 - **Bucket**: `{{platform.homeassistant.influxdb_bucket}}`
 - **Organisation**: `{{platform.homeassistant.influxdb_org}}`
-- **Datenstruktur**: Measurements basieren auf Einheit (z.B. "W"), nicht "state"
+- **Measurement-Schema**: `{{platform.homeassistant.influxdb_measurement_schema}}`
+  - `by_entity` → Measurements = Entity-Namen (Standard-HA-Verhalten)
+  - `by_unit` → Measurements = Einheiten ("W", "°C", "kWh") — unüblich, aber möglich
+- **Timezone**: `{{platform.homeassistant.influxdb_timezone}}` — InfluxDB speichert UTC, Abfragefenster entsprechend anpassen
 - **Entity-IDs**: Ohne "sensor."-Prefix, können vom HA-Namen abweichen
 
 **Erlaubt:** Flux-Queries lesen, Wertebereich-Analysen, Pattern-Erkennung, Vergleiche.


### PR DESCRIPTION
## Summary

- **#9** `.claude/rules/` documented: `--create-rule` added to agent-meta-manager section 6; abgrenzung to extensions/commands
- **#7** Folder-level CLAUDE.md: added to sync-concept.md with use cases and comparison table
- **#11** AGENTS.md multi-tool strategy: new section in sync-concept.md with symlink pattern and platform limitations
- **#56** rules-preset optimization: new `howto/features/rules-preset-optimization.md` with word-count thresholds, preset selection guide, and lazy-load pattern
- **#53** InfluxDB config: `influxdb_measurement_schema` and `influxdb_timezone` added to `homeassistant.defaults.yaml`; `_wf-ha-mcp-local.md` updated with schema and timezone context

## Issues
Closes #7, #9, #11, #53, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)