### PR TITLE
feat: configurable .gitignore behavior + commands support (#10, #54)

### DIFF
--- a/.claude/agents/agent-meta-manager.md
+++ b/.claude/agents/agent-meta-manager.md
@@ -1,9 +1,9 @@
 ---
 name: agent-meta-manager
 model: sonnet
-version: "1.4.1"
+version: "1.4.2"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
-generated-from: "1-generic/agent-meta-manager.md@1.4.1"
+generated-from: "1-generic/agent-meta-manager.md@1.4.2"
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
   - Bash
@@ -85,19 +85,24 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten & Regeln
+## 6. Projektspezifische Agenten, Regeln & Commands
 
 ```
-Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
-Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
-Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?   → Rule:     --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?     → Extension: --create-ext <rolle>
+Komplett anderer Workflow?           → Override:  .claude/3-project/<rolle>.md (manuell)
+Wiederkehrender Workflow im Hauptchat → Command:  --create-command <name>
 ```
 
 ```bash
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
+
+Commands (`/project:<name>`) laufen im **Haupt-Kontext** — kein isoliertes Context Window.
+Geeignet für schnelle, wiederkehrende Einzel-Aktionen. Für komplexe Aufgaben → Agent.
 
 Extensions und Rules so kurz wie möglich halten.
 

--- a/.continue/agents/agent-meta-manager.md
+++ b/.continue/agents/agent-meta-manager.md
@@ -70,19 +70,24 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten & Regeln
+## 6. Projektspezifische Agenten, Regeln & Commands
 
 ```
-Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
-Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
-Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?   → Rule:     --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?     → Extension: --create-ext <rolle>
+Komplett anderer Workflow?           → Override:  .claude/3-project/<rolle>.md (manuell)
+Wiederkehrender Workflow im Hauptchat → Command:  --create-command <name>
 ```
 
 ```bash
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
+
+Commands (`/project:<name>`) laufen im **Haupt-Kontext** — kein isoliertes Context Window.
+Geeignet für schnelle, wiederkehrende Einzel-Aktionen. Für komplexe Aufgaben → Agent.
 
 Extensions und Rules so kurz wie möglich halten.
 

--- a/.continue/prompts/agent-meta-manager.md
+++ b/.continue/prompts/agent-meta-manager.md
@@ -70,19 +70,24 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten & Regeln
+## 6. Projektspezifische Agenten, Regeln & Commands
 
 ```
-Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
-Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
-Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?   → Rule:     --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?     → Extension: --create-ext <rolle>
+Komplett anderer Workflow?           → Override:  .claude/3-project/<rolle>.md (manuell)
+Wiederkehrender Workflow im Hauptchat → Command:  --create-command <name>
 ```
 
 ```bash
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
+
+Commands (`/project:<name>`) laufen im **Haupt-Kontext** — kein isoliertes Context Window.
+Geeignet für schnelle, wiederkehrende Einzel-Aktionen. Für komplexe Aufgaben → Agent.
 
 Extensions und Rules so kurz wie möglich halten.
 

--- a/.gemini/agents/agent-meta-manager.md
+++ b/.gemini/agents/agent-meta-manager.md
@@ -1,9 +1,9 @@
 ---
 name: agent-meta-manager
 model: sonnet
-version: "1.4.1"
+version: "1.4.2"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
-generated-from: "1-generic/agent-meta-manager.md@1.4.1"
+generated-from: "1-generic/agent-meta-manager.md@1.4.2"
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
   - Bash
@@ -83,19 +83,24 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten & Regeln
+## 6. Projektspezifische Agenten, Regeln & Commands
 
 ```
-Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
-Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
-Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?   → Rule:     --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?     → Extension: --create-ext <rolle>
+Komplett anderer Workflow?           → Override:  .claude/3-project/<rolle>.md (manuell)
+Wiederkehrender Workflow im Hauptchat → Command:  --create-command <name>
 ```
 
 ```bash
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
+
+Commands (`/project:<name>`) laufen im **Haupt-Kontext** — kein isoliertes Context Window.
+Geeignet für schnelle, wiederkehrende Einzel-Aktionen. Für komplexe Aufgaben → Agent.
 
 Extensions und Rules so kurz wie möglich halten.
 

--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-manager
-version: "1.4.1"
+version: "1.4.2"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
@@ -83,19 +83,24 @@ Nur dieses Projekt?           → Projektspezifischer Override (Abschnitt 6)
 
 ---
 
-## 6. Projektspezifische Agenten & Regeln
+## 6. Projektspezifische Agenten, Regeln & Commands
 
 ```
-Gilt für alle Agenten + Hauptchat?  → Rule:      --create-rule <thema>
-Zusätzliches Wissen für 1 Agent?    → Extension: --create-ext <rolle>
-Komplett anderer Workflow?          → Override:  .claude/3-project/<rolle>.md (manuell)
+Gilt für alle Agenten + Hauptchat?   → Rule:     --create-rule <thema>
+Zusätzliches Wissen für 1 Agent?     → Extension: --create-ext <rolle>
+Komplett anderer Workflow?           → Override:  .claude/3-project/<rolle>.md (manuell)
+Wiederkehrender Workflow im Hauptchat → Command:  --create-command <name>
 ```
 
 ```bash
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-rule security-policy
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-ext <rolle>
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --update-ext
+py .agent-meta/scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
+
+Commands (`/project:<name>`) laufen im **Haupt-Kontext** — kein isoliertes Context Window.
+Geeignet für schnelle, wiederkehrende Einzel-Aktionen. Für komplexe Aufgaben → Agent.
 
 Extensions und Rules so kurz wie möglich halten.
 

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -374,6 +374,28 @@
       },
       "additionalProperties": false
     },
+    "gitignore": {
+      "type": "object",
+      "description": "Configurable .gitignore behavior for generated and settings files. Defaults match current behavior (local: true, generated: false, settings: false).",
+      "properties": {
+        "local": {
+          "type": "boolean",
+          "default": true,
+          "description": "Gitignore local/personal files (.claude/settings.local.json, CLAUDE.personal.md, sync.log). Default: true (gitignored)."
+        },
+        "generated": {
+          "type": "boolean",
+          "default": false,
+          "description": "Gitignore all generated directories (agents/, rules/, hooks/, commands/) for all active providers. Default: false (committed). Set true to follow 'generate, don't store' principle."
+        },
+        "settings": {
+          "type": "boolean",
+          "default": false,
+          "description": "Gitignore provider settings files (settings.json, GEMINI.md, config.yaml) for all active providers. Default: false (committed). Note: CLAUDE.md is never gitignored (contains handwritten sections)."
+        }
+      },
+      "additionalProperties": false
+    },
     "lifecycle-triggers": {
       "type": "object",
       "description": "Agent tasks to run automatically on git lifecycle events (commit, merge, version bump, release). Requires lifecycle-check hook to be enabled.",

--- a/howto/features/sync-concept.md
+++ b/howto/features/sync-concept.md
@@ -188,6 +188,7 @@ variables:
 | `project.name` | Vollständiger Projektname |
 | `project.prefix` | Kurzpräfix für Extension-Dateinamen (`vwf-developer-ext.md`) |
 | `project.short` | Kurzname (informativ) |
+| `gitignore` | Konfigurierbares .gitignore-Verhalten für generierte und Settings-Dateien |
 | `model-overrides` | Modell pro Rolle überschreiben (z.B. `"git": "haiku"`) |
 | `permission-mode-overrides` | permissionMode pro Rolle überschreiben (z.B. `"validator": "default"`) |
 | `memory-overrides` | Memory-Scope pro Rolle überschreiben (z.B. `"validator": "local"`) |
@@ -340,6 +341,32 @@ Logfile: sync.log
 
 > **Multi-Provider Dokumentation:** [docs/providers/multi-provider.md](multi-provider.md) — vollständige Beschreibung
 > aller Provider (Claude, Gemini, Continue), Frontmatter-Unterschiede, Stale-Tracking, Troubleshooting.
+
+---
+
+## .gitignore Konfiguration
+
+sync.py verwaltet einen managed block in `.gitignore`. Das Verhalten ist per `project.yaml` konfigurierbar:
+
+```yaml
+gitignore:
+  local: true       # Standard: persönliche Dateien sind gitignored (settings.local.json, CLAUDE.personal.md)
+  generated: false  # Standard: generierte Dateien sind committed (agents/, rules/, hooks/)
+  settings: false   # Standard: Settings-Dateien sind committed (settings.json, GEMINI.md)
+```
+
+| Flag | Standard | `true` bedeutet |
+|------|----------|-----------------|
+| `local` | `true` | `.claude/settings.local.json`, `CLAUDE.personal.md`, `sync.log` → gitignored |
+| `generated` | `false` | `agents/`, `rules/`, `hooks/`, `commands/` aller aktiven Provider → gitignored |
+| `settings` | `false` | `settings.json`, `GEMINI.md`, `config.yaml` der Provider → gitignored |
+
+**Hinweis:** `CLAUDE.md` wird nie gitignored — sie enthält handgeschriebene Sektionen außerhalb des managed blocks.
+
+**`generated: true` empfohlen wenn:**
+- Das Team sync.py bei jedem Checkout neu ausführt (CI/CD)
+- Diff-Noise bei Sync-Updates störend ist
+- Das Repo möglichst klein bleiben soll
 
 ---
 

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -303,12 +303,38 @@ def main():
             init_settings_json(project_root, log, args.dry_run)
             init_settings_local_json(project_root, log, args.dry_run)
             claude_pc = provider_config.get("Claude", {})
-            base_gitignore_entries = claude_pc.get("gitignore_entries", [
-                ".claude/settings.local.json",
-                ".claude/agent-memory-local/",
-                "CLAUDE.personal.md",
-                "sync.log",
-            ])
+            gitignore_cfg = config.get("gitignore", {})
+            # local: true (default) — personal/local files are gitignored
+            if gitignore_cfg.get("local", True):
+                base_gitignore_entries = list(claude_pc.get("gitignore_entries", [
+                    ".claude/settings.local.json",
+                    ".claude/agent-memory-local/",
+                    "CLAUDE.personal.md",
+                    "sync.log",
+                ]))
+            else:
+                base_gitignore_entries = []
+            # generated: false (default) — generated files are committed
+            if gitignore_cfg.get("generated", False):
+                for _prov in providers:
+                    _pc = provider_config.get(_prov, {})
+                    for _dir_key in ("agents_dir", "rules_dir", "hooks_dir"):
+                        _d = _pc.get(_dir_key)
+                        if _d:
+                            base_gitignore_entries.append(_d + "/")
+                    if _pc.get("has_commands") and _pc.get("commands_dir"):
+                        base_gitignore_entries.append(_pc["commands_dir"] + "/")
+            # settings: false (default) — settings files are committed
+            if gitignore_cfg.get("settings", False):
+                for _prov in providers:
+                    _pc = provider_config.get(_prov, {})
+                    _sf = _pc.get("settings_file")
+                    if _sf:
+                        base_gitignore_entries.append(_sf)
+                    _ctx = _pc.get("context_file")
+                    # CLAUDE.md is semi-manual (has handwritten sections) — skip
+                    if _ctx and _ctx != "CLAUDE.md":
+                        base_gitignore_entries.append(_ctx)
             # Skill gitignore entries are collected after skills are processed (below)
             # and merged via exact_entries so stale entries are removed automatically.
         # Per-provider sync


### PR DESCRIPTION
## Summary

- **#54** `gitignore` config in `project.yaml`: three boolean flags (`local`, `generated`, `settings`) control which files land in `.gitignore`. Defaults match current behavior — no breaking change. `generated: true` gitignores all provider agents/rules/hooks/commands dirs; `settings: true` gitignores provider settings files.
- **#10** `--create-command` documented in `agent-meta-manager.md` section 6 with Agent vs Command distinction. `.claude/commands/` already documented in sync-concept.md and instantiate-project.md.

## Files changed
- `scripts/sync.py`: gitignore config logic
- `config/project-config.schema.json`: new `gitignore` property
- `howto/features/sync-concept.md`: .gitignore config section + table entry
- `agents/1-generic/agent-meta-manager.md` v1.4.2: --create-command in section 6

## Issues
Closes #10, #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)