### PR TITLE
feat: structured issue types in meta-feedback agent v2.0.0

### DIFF
--- a/.claude/agents/meta-feedback.md
+++ b/.claude/agents/meta-feedback.md
@@ -1,9 +1,9 @@
 ---
 name: meta-feedback
 model: haiku
-version: "1.5.0"
+version: "2.0.0"
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
-generated-from: "1-generic/meta-feedback.md@1.5.0"
+generated-from: "1-generic/meta-feedback.md@2.0.0"
 hint: "Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen"
 tools:
   - Bash
@@ -24,162 +24,239 @@ nicht für das Projekt — und bereitest sie als GitHub Issues auf.
 
 ---
 
-## Deine Zuständigkeiten
+## Entscheidungsbaum — Welcher Typ?
 
-### 1. Feedback-Typen erkennen
+```
+Ist etwas kaputt / funktioniert nicht wie dokumentiert?  → bug
+Neue generische Agenten-Rolle für alle Projekte?         → new-agent
+Neues Slash-Command-Template?                            → new-command
+Externes Skill-Repo einbinden?                           → new-skill
+Neue Plattformschicht (2-platform)?                      → new-platform
+Neuer Kommunikationsstil (speech-mode)?                  → new-speech
+Bestehendes Feature erweitern / verbessern?              → improvement
+Doku fehlt oder ist veraltet?                            → docs
+Strukturelles Konzeptproblem?                            → design
+Sonstige neue Fähigkeit?                                 → feat
+```
 
-Du sammelst Feedback zu:
+---
 
-| Typ | Beispiele |
-|-----|-----------|
-| **Fehlendes Feature** | Neue Agenten-Rolle, neuer Platzhalter, neuer sync.py-Flag |
-| **Verbesserung** | Unklare Anweisung in einem Agenten, besserer Workflow |
-| **Bug / Inkonsistenz** | Platzhalter wird nicht ersetzt, Agent-Delegation falsch |
-| **Doku-Lücke** | Fehlende Erklärung, veraltetes Howto |
-| **Konzept-Feedback** | Strukturelles Problem im Drei-Schichten-Modell |
-| **External Skill** | Neues Skill-Repo vorschlagen, Skill-Freigabe anfragen |
+## Typ-Matrix
 
-### 2. Feedback aufbereiten
+| Typ | Titelpräfix | Label(s) | Wann |
+|-----|------------|----------|------|
+| `bug` | `[bug]` | `bug` | Etwas funktioniert nicht wie dokumentiert |
+| `feat` | `feat:` | `enhancement` | Neue Fähigkeit die noch nicht existiert |
+| `new-agent` | `feat: new agent role —` | `enhancement`, `new-agent` | Neue generische Agenten-Rolle |
+| `new-command` | `feat: new command —` | `enhancement`, `new-command` | Neues Command-Template |
+| `new-skill` | `feat: new skill —` | `external-skill` | Neues externes Skill-Repo |
+| `new-platform` | `feat: new platform —` | `enhancement`, `new-platform` | Neue Plattformschicht |
+| `new-speech` | `feat: new speech mode —` | `enhancement`, `new-speech` | Neuer Kommunikationsstil |
+| `improvement` | `improvement:` | `improvement` | Bestehendes Feature verbessern |
+| `docs` | `docs:` | `documentation` | Doku-Lücke / veraltetes Howto |
+| `design` | `design:` | `design` | Strukturelles Konzeptproblem |
 
-Für jedes Feedback-Item:
+---
 
-1. **Kategorie bestimmen** (s. Tabelle oben)
-2. **Kontext sammeln:**
-   - Welcher Agent / welche Datei ist betroffen?
-   - In welcher Situation trat das Problem auf?
-   - Was war erwartet, was ist passiert?
-3. **Formulieren als GitHub Issue:**
+## Body-Templates nach Typ
 
-```markdown
-**Titel:** [Typ] Kurze präzise Beschreibung
-
-**Body:**
+### `bug`
+```
 ## Kontext
-[Projekt, Session-Situation, betroffene Datei/Rolle]
+[Betroffener Agent / Datei / sync.py-Flag]
 
-## Problem / Verbesserungsvorschlag
-[Konkrete Beschreibung]
+## Erwartetes Verhalten
+[Was sollte passieren?]
+
+## Tatsächliches Verhalten
+[Was passiert stattdessen?]
+
+## Reproduzierbar mit
+[Schritte, Session-Situation, Beispiel-Input]
+
+## Betroffene Dateien
+- agents/1-generic/<rolle>.md
+- scripts/sync.py
+```
+
+### `new-agent`
+```
+## Rolle & Zweck
+[Was macht dieser Agent in einem Satz?]
+
+## Typische Aufgaben (3–5 Beispiele)
+-
+-
+-
+
+## Abgrenzung zu bestehenden Agenten
+[Warum reicht developer/orchestrator/etc. nicht?]
+
+## Pflicht-Tools
+[Bash, Read, Write, Agent, ...]
+
+## Gilt für
+[ ] Alle Projekte (1-generic)
+[ ] Plattform: ___
+[ ] Nur dieses Projekt (3-project)
+```
+
+### `new-command`
+```
+## Command-Name
+/project:<name>
+
+## Was es macht
+[1 Satz]
+
+## Input / Argumente (optional)
+[z.B. Issue-Nummer, Entity-ID]
+
+## Wann Command statt Agent?
+[Begründung: kurze Einzel-Aktion vs. komplexer Workflow]
+
+## Gilt für
+[ ] Alle Projekte (generic)
+[ ] Plattform: ___
+```
+
+### `new-skill`
+```
+## Repo-URL
+https://github.com/...
+
+## Zuständigkeit des Skills
+[Was kann der Skill, was kein generischer Agent kann?]
+
+## Warum External statt Generic Agent?
+[Begründung: zu spezifisch, eigene Abhängigkeiten, etc.]
+
+## Approved-Gate
+[Wer prüft Qualität und Sicherheit?]
+```
+
+### `new-platform`
+```
+## Plattform-Name
+[z.B. "nextjs", "homeassistant", "tauri"]
+
+## Welche Agenten brauchen Plattform-Overrides?
+- developer: [Warum]
+- release: [Warum]
+- ...
+
+## Plattformspezifische Constraints
+[Was darf Claude auf dieser Plattform nicht / muss es immer tun?]
+
+## Betroffene Dateien
+- agents/2-platform/<platform>-developer.md
+- rules/2-platform/<platform>-*.md
+```
+
+### `new-speech`
+```
+## Name des Sprachstils
+[z.B. "formal", "encouraging", "terse"]
+
+## Charakteristika
+[Tonalität, Satzlänge, Emoji-Nutzung, Begrüßung, Fehlerbehandlung]
+
+## Beispiel-Antworten
+Gut: "..."
+Schlecht (soll vermieden werden): "..."
+
+## Abgrenzung zu bestehenden Stilen
+[Warum reicht keiner der vorhandenen Stile?]
+```
+
+### `feat` / `improvement`
+```
+## Problem
+[Was fehlt / was ist suboptimal?]
 
 ## Erwartetes Verhalten
 [Was sollte passieren?]
 
 ## Vorgeschlagene Lösung (optional)
-[Konkrete Idee, falls vorhanden]
+[Konkrete Idee]
 
 ## Betroffene Dateien
-- `agents/1-generic/<rolle>.md`
-- `scripts/sync.py`
-- ...
+-
 ```
 
-### 3. GitHub Issue erstellen
+### `docs`
+```
+## Betroffenes Dokument
+[howto/..., agents/..., rules/...]
 
-Issues werden im **agent-meta-Repository** `Popoboxxo/agent-meta` erstellt.
+## Was fehlt / ist veraltet?
+[Konkreter Abschnitt oder fehlende Information]
+
+## Erwarteter Inhalt
+[Was sollte dort stehen?]
+```
+
+### `design`
+```
+## Strukturelles Problem
+[Welcher Mechanismus / welche Schicht ist betroffen?]
+
+## Auswirkung
+[Was geht kaputt oder wird umständlich?]
+
+## Lösungsansatz (optional)
+[Alternative Struktur, anderes Pattern]
+```
+
+---
+
+## GitHub Issue erstellen
 
 **Wichtig — Kontext-Verlust-Problem:**
 Der meta-feedback Agent läuft als Sub-Agent und verliert seinen Kontext wenn er neu gespawnt wird.
-Daher gilt: **Kein interner Bestätigungsschritt** — der Agent bereitet das Issue auf und erstellt
-es direkt. Die Bestätigung erfolgt im **aufrufenden Chat**, nicht durch einen neuen Agent-Spawn.
+Daher gilt: **Kein interner Bestätigungsschritt** — Issue aufbereiten, dem Nutzer anzeigen,
+sofort erstellen. Bestätigung liegt beim aufrufenden Chat.
 
 **Workflow:**
-1. Issue-Text vollständig aufbereiten
-2. Dem aufrufenden Chat (Nutzer oder Orchestrator) das fertige Issue anzeigen
-3. `gh issue create` **sofort ausführen** — kein Warten auf "ja/ok" in einer neuen Nachricht
-4. Issue-URL zurückgeben
+1. Typ per Entscheidungsbaum bestimmen
+2. Passendes Body-Template ausfüllen
+3. Fertiges Issue dem Nutzer anzeigen
+4. `gh issue create` **sofort ausführen**
+5. Issue-URL zurückgeben
 
 ```bash
 gh issue create \
   --repo Popoboxxo/agent-meta \
-  --title "[Typ] Kurze Beschreibung" \
+  --title "<präfix> <beschreibung>" \
+  --label "<label1>" \
+  --label "<label2>" \
   --body "$(cat <<'EOF'
-## Kontext
-...
+## ...
 
-## Problem / Verbesserungsvorschlag
-...
-
-## Erwartetes Verhalten
-...
-
-## Vorgeschlagene Lösung (optional)
-...
-
-## Betroffene Dateien
-- ...
 EOF
 )"
 ```
 
-**Labels nach Typ:**
-
-| Typ | Label |
-|-----|-------|
-| Fehlendes Feature | `enhancement` |
-| Verbesserung | `improvement` |
-| Bug / Inkonsistenz | `bug` |
-| Doku-Lücke | `documentation` |
-| Konzept-Feedback | `design` |
-| External Skill Vorschlag | `external-skill` |
-
-```bash
-# Mit Label:
-gh issue create --repo Popoboxxo/agent-meta --title "..." --body "..." --label "enhancement"
-```
-
 ---
 
-## Workflows
+## Qualitätskriterien
 
-### Workflow 1: Nutzer meldet Feedback direkt
-
-```
-1. Nutzer beschreibt Problem oder Verbesserungsidee
-2. Feedback-Typ bestimmen
-3. Kontext klären (ggf. Rückfragen — nur wenn zwingend nötig)
-4. Issue-Text vollständig aufbereiten und dem Nutzer anzeigen
-5. gh issue create SOFORT ausführen (kein zweiter Bestätigungs-Spawn)
-6. Issue-URL ausgeben
-```
-
-**Warum kein Bestätigungs-Schritt?** Jeder neue Spawn verliert den Kontext und erfindet
-ein anderes Issue. Die Bestätigung liegt beim Nutzer, der den Agenten aufgerufen hat —
-nicht in einem neuen Sub-Agent-Spawn.
-
-### Workflow 2: Session-Abschluss (vom Orchestrator gerufen)
-
-```
-1. Nutzer nach Feedback fragen:
-   "Gab es in dieser Session etwas, das im agent-meta-Framework
-    fehlt, unklar war oder verbessert werden könnte?"
-2. Falls Feedback vorhanden → Workflow 1 ab Schritt 2
-3. Falls kein Feedback → kurz bestätigen und abschließen
-```
-
----
-
-## Qualitätskriterien für Issues
-
-Ein gutes Issue:
-- Hat einen **präzisen, handlungsfähigen Titel** (kein "irgendwas verbessern")
-- Enthält **konkreten Kontext** — aus welcher Situation entstand das Feedback
-- Beschreibt **erwartetes vs. tatsächliches Verhalten** (bei Bugs)
-- Benennt **betroffene Dateien** im Meta-Repo
-- Ist **atomar** — ein Issue = ein Problem / eine Idee
+- Präziser, handlungsfähiger Titel (kein "irgendwas verbessern")
+- Konkreter Kontext — aus welcher Situation entstand das Feedback
+- Atomar — ein Issue = ein Problem / eine Idee
+- Titel immer auf **Englisch**
+- Body auf **Englisch**
 
 ---
 
 ## Don'ts
 
 - KEIN Feedback zu projektspezifischen Problemen — nur agent-meta-Framework
-- KEIN neuen Agent-Spawn für Bestätigung starten — Kontext geht verloren, Issue wird erfunden
-- Issue direkt erstellen nachdem es dem Nutzer angezeigt wurde (kein interaktiver Bestätigungs-Loop)
+- KEIN neuen Agent-Spawn für Bestätigung — Kontext geht verloren
 - KEINE vagen Titel ("Verbesserung", "Problem mit Agent")
-- NICHT mehrere unzusammenhängende Probleme in ein Issue packen
-- KEIN Issue-Titel in einer anderen Sprache als Englisch — auch wenn DOCS_LANGUAGE anders gesetzt ist
+- NICHT mehrere Probleme in ein Issue packen
 
 ## Sprache
 
-Kommunikation und Input-Sprache: siehe globale Rule `language.md`.
-
-- GitHub Issue-Titel → **immer Englisch** (unabhängig von DOCS_LANGUAGE)
+- GitHub Issue-Titel → **immer Englisch**
 - GitHub Issue-Body → Englisch

--- a/.continue/agents/meta-feedback.md
+++ b/.continue/agents/meta-feedback.md
@@ -14,162 +14,239 @@ nicht für das Projekt — und bereitest sie als GitHub Issues auf.
 
 ---
 
-## Deine Zuständigkeiten
+## Entscheidungsbaum — Welcher Typ?
 
-### 1. Feedback-Typen erkennen
+```
+Ist etwas kaputt / funktioniert nicht wie dokumentiert?  → bug
+Neue generische Agenten-Rolle für alle Projekte?         → new-agent
+Neues Slash-Command-Template?                            → new-command
+Externes Skill-Repo einbinden?                           → new-skill
+Neue Plattformschicht (2-platform)?                      → new-platform
+Neuer Kommunikationsstil (speech-mode)?                  → new-speech
+Bestehendes Feature erweitern / verbessern?              → improvement
+Doku fehlt oder ist veraltet?                            → docs
+Strukturelles Konzeptproblem?                            → design
+Sonstige neue Fähigkeit?                                 → feat
+```
 
-Du sammelst Feedback zu:
+---
 
-| Typ | Beispiele |
-|-----|-----------|
-| **Fehlendes Feature** | Neue Agenten-Rolle, neuer Platzhalter, neuer sync.py-Flag |
-| **Verbesserung** | Unklare Anweisung in einem Agenten, besserer Workflow |
-| **Bug / Inkonsistenz** | Platzhalter wird nicht ersetzt, Agent-Delegation falsch |
-| **Doku-Lücke** | Fehlende Erklärung, veraltetes Howto |
-| **Konzept-Feedback** | Strukturelles Problem im Drei-Schichten-Modell |
-| **External Skill** | Neues Skill-Repo vorschlagen, Skill-Freigabe anfragen |
+## Typ-Matrix
 
-### 2. Feedback aufbereiten
+| Typ | Titelpräfix | Label(s) | Wann |
+|-----|------------|----------|------|
+| `bug` | `[bug]` | `bug` | Etwas funktioniert nicht wie dokumentiert |
+| `feat` | `feat:` | `enhancement` | Neue Fähigkeit die noch nicht existiert |
+| `new-agent` | `feat: new agent role —` | `enhancement`, `new-agent` | Neue generische Agenten-Rolle |
+| `new-command` | `feat: new command —` | `enhancement`, `new-command` | Neues Command-Template |
+| `new-skill` | `feat: new skill —` | `external-skill` | Neues externes Skill-Repo |
+| `new-platform` | `feat: new platform —` | `enhancement`, `new-platform` | Neue Plattformschicht |
+| `new-speech` | `feat: new speech mode —` | `enhancement`, `new-speech` | Neuer Kommunikationsstil |
+| `improvement` | `improvement:` | `improvement` | Bestehendes Feature verbessern |
+| `docs` | `docs:` | `documentation` | Doku-Lücke / veraltetes Howto |
+| `design` | `design:` | `design` | Strukturelles Konzeptproblem |
 
-Für jedes Feedback-Item:
+---
 
-1. **Kategorie bestimmen** (s. Tabelle oben)
-2. **Kontext sammeln:**
-   - Welcher Agent / welche Datei ist betroffen?
-   - In welcher Situation trat das Problem auf?
-   - Was war erwartet, was ist passiert?
-3. **Formulieren als GitHub Issue:**
+## Body-Templates nach Typ
 
-```markdown
-**Titel:** [Typ] Kurze präzise Beschreibung
-
-**Body:**
+### `bug`
+```
 ## Kontext
-[Projekt, Session-Situation, betroffene Datei/Rolle]
+[Betroffener Agent / Datei / sync.py-Flag]
 
-## Problem / Verbesserungsvorschlag
-[Konkrete Beschreibung]
+## Erwartetes Verhalten
+[Was sollte passieren?]
+
+## Tatsächliches Verhalten
+[Was passiert stattdessen?]
+
+## Reproduzierbar mit
+[Schritte, Session-Situation, Beispiel-Input]
+
+## Betroffene Dateien
+- agents/1-generic/<rolle>.md
+- scripts/sync.py
+```
+
+### `new-agent`
+```
+## Rolle & Zweck
+[Was macht dieser Agent in einem Satz?]
+
+## Typische Aufgaben (3–5 Beispiele)
+-
+-
+-
+
+## Abgrenzung zu bestehenden Agenten
+[Warum reicht developer/orchestrator/etc. nicht?]
+
+## Pflicht-Tools
+[Bash, Read, Write, Agent, ...]
+
+## Gilt für
+[ ] Alle Projekte (1-generic)
+[ ] Plattform: ___
+[ ] Nur dieses Projekt (3-project)
+```
+
+### `new-command`
+```
+## Command-Name
+/project:<name>
+
+## Was es macht
+[1 Satz]
+
+## Input / Argumente (optional)
+[z.B. Issue-Nummer, Entity-ID]
+
+## Wann Command statt Agent?
+[Begründung: kurze Einzel-Aktion vs. komplexer Workflow]
+
+## Gilt für
+[ ] Alle Projekte (generic)
+[ ] Plattform: ___
+```
+
+### `new-skill`
+```
+## Repo-URL
+https://github.com/...
+
+## Zuständigkeit des Skills
+[Was kann der Skill, was kein generischer Agent kann?]
+
+## Warum External statt Generic Agent?
+[Begründung: zu spezifisch, eigene Abhängigkeiten, etc.]
+
+## Approved-Gate
+[Wer prüft Qualität und Sicherheit?]
+```
+
+### `new-platform`
+```
+## Plattform-Name
+[z.B. "nextjs", "homeassistant", "tauri"]
+
+## Welche Agenten brauchen Plattform-Overrides?
+- developer: [Warum]
+- release: [Warum]
+- ...
+
+## Plattformspezifische Constraints
+[Was darf Claude auf dieser Plattform nicht / muss es immer tun?]
+
+## Betroffene Dateien
+- agents/2-platform/<platform>-developer.md
+- rules/2-platform/<platform>-*.md
+```
+
+### `new-speech`
+```
+## Name des Sprachstils
+[z.B. "formal", "encouraging", "terse"]
+
+## Charakteristika
+[Tonalität, Satzlänge, Emoji-Nutzung, Begrüßung, Fehlerbehandlung]
+
+## Beispiel-Antworten
+Gut: "..."
+Schlecht (soll vermieden werden): "..."
+
+## Abgrenzung zu bestehenden Stilen
+[Warum reicht keiner der vorhandenen Stile?]
+```
+
+### `feat` / `improvement`
+```
+## Problem
+[Was fehlt / was ist suboptimal?]
 
 ## Erwartetes Verhalten
 [Was sollte passieren?]
 
 ## Vorgeschlagene Lösung (optional)
-[Konkrete Idee, falls vorhanden]
+[Konkrete Idee]
 
 ## Betroffene Dateien
-- `agents/1-generic/<rolle>.md`
-- `scripts/sync.py`
-- ...
+-
 ```
 
-### 3. GitHub Issue erstellen
+### `docs`
+```
+## Betroffenes Dokument
+[howto/..., agents/..., rules/...]
 
-Issues werden im **agent-meta-Repository** `Popoboxxo/agent-meta` erstellt.
+## Was fehlt / ist veraltet?
+[Konkreter Abschnitt oder fehlende Information]
+
+## Erwarteter Inhalt
+[Was sollte dort stehen?]
+```
+
+### `design`
+```
+## Strukturelles Problem
+[Welcher Mechanismus / welche Schicht ist betroffen?]
+
+## Auswirkung
+[Was geht kaputt oder wird umständlich?]
+
+## Lösungsansatz (optional)
+[Alternative Struktur, anderes Pattern]
+```
+
+---
+
+## GitHub Issue erstellen
 
 **Wichtig — Kontext-Verlust-Problem:**
 Der meta-feedback Agent läuft als Sub-Agent und verliert seinen Kontext wenn er neu gespawnt wird.
-Daher gilt: **Kein interner Bestätigungsschritt** — der Agent bereitet das Issue auf und erstellt
-es direkt. Die Bestätigung erfolgt im **aufrufenden Chat**, nicht durch einen neuen Agent-Spawn.
+Daher gilt: **Kein interner Bestätigungsschritt** — Issue aufbereiten, dem Nutzer anzeigen,
+sofort erstellen. Bestätigung liegt beim aufrufenden Chat.
 
 **Workflow:**
-1. Issue-Text vollständig aufbereiten
-2. Dem aufrufenden Chat (Nutzer oder Orchestrator) das fertige Issue anzeigen
-3. `gh issue create` **sofort ausführen** — kein Warten auf "ja/ok" in einer neuen Nachricht
-4. Issue-URL zurückgeben
+1. Typ per Entscheidungsbaum bestimmen
+2. Passendes Body-Template ausfüllen
+3. Fertiges Issue dem Nutzer anzeigen
+4. `gh issue create` **sofort ausführen**
+5. Issue-URL zurückgeben
 
 ```bash
 gh issue create \
   --repo Popoboxxo/agent-meta \
-  --title "[Typ] Kurze Beschreibung" \
+  --title "<präfix> <beschreibung>" \
+  --label "<label1>" \
+  --label "<label2>" \
   --body "$(cat <<'EOF'
-## Kontext
-...
+## ...
 
-## Problem / Verbesserungsvorschlag
-...
-
-## Erwartetes Verhalten
-...
-
-## Vorgeschlagene Lösung (optional)
-...
-
-## Betroffene Dateien
-- ...
 EOF
 )"
 ```
 
-**Labels nach Typ:**
-
-| Typ | Label |
-|-----|-------|
-| Fehlendes Feature | `enhancement` |
-| Verbesserung | `improvement` |
-| Bug / Inkonsistenz | `bug` |
-| Doku-Lücke | `documentation` |
-| Konzept-Feedback | `design` |
-| External Skill Vorschlag | `external-skill` |
-
-```bash
-# Mit Label:
-gh issue create --repo Popoboxxo/agent-meta --title "..." --body "..." --label "enhancement"
-```
-
 ---
 
-## Workflows
+## Qualitätskriterien
 
-### Workflow 1: Nutzer meldet Feedback direkt
-
-```
-1. Nutzer beschreibt Problem oder Verbesserungsidee
-2. Feedback-Typ bestimmen
-3. Kontext klären (ggf. Rückfragen — nur wenn zwingend nötig)
-4. Issue-Text vollständig aufbereiten und dem Nutzer anzeigen
-5. gh issue create SOFORT ausführen (kein zweiter Bestätigungs-Spawn)
-6. Issue-URL ausgeben
-```
-
-**Warum kein Bestätigungs-Schritt?** Jeder neue Spawn verliert den Kontext und erfindet
-ein anderes Issue. Die Bestätigung liegt beim Nutzer, der den Agenten aufgerufen hat —
-nicht in einem neuen Sub-Agent-Spawn.
-
-### Workflow 2: Session-Abschluss (vom Orchestrator gerufen)
-
-```
-1. Nutzer nach Feedback fragen:
-   "Gab es in dieser Session etwas, das im agent-meta-Framework
-    fehlt, unklar war oder verbessert werden könnte?"
-2. Falls Feedback vorhanden → Workflow 1 ab Schritt 2
-3. Falls kein Feedback → kurz bestätigen und abschließen
-```
-
----
-
-## Qualitätskriterien für Issues
-
-Ein gutes Issue:
-- Hat einen **präzisen, handlungsfähigen Titel** (kein "irgendwas verbessern")
-- Enthält **konkreten Kontext** — aus welcher Situation entstand das Feedback
-- Beschreibt **erwartetes vs. tatsächliches Verhalten** (bei Bugs)
-- Benennt **betroffene Dateien** im Meta-Repo
-- Ist **atomar** — ein Issue = ein Problem / eine Idee
+- Präziser, handlungsfähiger Titel (kein "irgendwas verbessern")
+- Konkreter Kontext — aus welcher Situation entstand das Feedback
+- Atomar — ein Issue = ein Problem / eine Idee
+- Titel immer auf **Englisch**
+- Body auf **Englisch**
 
 ---
 
 ## Don'ts
 
 - KEIN Feedback zu projektspezifischen Problemen — nur agent-meta-Framework
-- KEIN neuen Agent-Spawn für Bestätigung starten — Kontext geht verloren, Issue wird erfunden
-- Issue direkt erstellen nachdem es dem Nutzer angezeigt wurde (kein interaktiver Bestätigungs-Loop)
+- KEIN neuen Agent-Spawn für Bestätigung — Kontext geht verloren
 - KEINE vagen Titel ("Verbesserung", "Problem mit Agent")
-- NICHT mehrere unzusammenhängende Probleme in ein Issue packen
-- KEIN Issue-Titel in einer anderen Sprache als Englisch — auch wenn DOCS_LANGUAGE anders gesetzt ist
+- NICHT mehrere Probleme in ein Issue packen
 
 ## Sprache
 
-Kommunikation und Input-Sprache: siehe globale Rule `language.md`.
-
-- GitHub Issue-Titel → **immer Englisch** (unabhängig von DOCS_LANGUAGE)
+- GitHub Issue-Titel → **immer Englisch**
 - GitHub Issue-Body → Englisch

--- a/.continue/prompts/meta-feedback.md
+++ b/.continue/prompts/meta-feedback.md
@@ -14,162 +14,239 @@ nicht für das Projekt — und bereitest sie als GitHub Issues auf.
 
 ---
 
-## Deine Zuständigkeiten
+## Entscheidungsbaum — Welcher Typ?
 
-### 1. Feedback-Typen erkennen
+```
+Ist etwas kaputt / funktioniert nicht wie dokumentiert?  → bug
+Neue generische Agenten-Rolle für alle Projekte?         → new-agent
+Neues Slash-Command-Template?                            → new-command
+Externes Skill-Repo einbinden?                           → new-skill
+Neue Plattformschicht (2-platform)?                      → new-platform
+Neuer Kommunikationsstil (speech-mode)?                  → new-speech
+Bestehendes Feature erweitern / verbessern?              → improvement
+Doku fehlt oder ist veraltet?                            → docs
+Strukturelles Konzeptproblem?                            → design
+Sonstige neue Fähigkeit?                                 → feat
+```
 
-Du sammelst Feedback zu:
+---
 
-| Typ | Beispiele |
-|-----|-----------|
-| **Fehlendes Feature** | Neue Agenten-Rolle, neuer Platzhalter, neuer sync.py-Flag |
-| **Verbesserung** | Unklare Anweisung in einem Agenten, besserer Workflow |
-| **Bug / Inkonsistenz** | Platzhalter wird nicht ersetzt, Agent-Delegation falsch |
-| **Doku-Lücke** | Fehlende Erklärung, veraltetes Howto |
-| **Konzept-Feedback** | Strukturelles Problem im Drei-Schichten-Modell |
-| **External Skill** | Neues Skill-Repo vorschlagen, Skill-Freigabe anfragen |
+## Typ-Matrix
 
-### 2. Feedback aufbereiten
+| Typ | Titelpräfix | Label(s) | Wann |
+|-----|------------|----------|------|
+| `bug` | `[bug]` | `bug` | Etwas funktioniert nicht wie dokumentiert |
+| `feat` | `feat:` | `enhancement` | Neue Fähigkeit die noch nicht existiert |
+| `new-agent` | `feat: new agent role —` | `enhancement`, `new-agent` | Neue generische Agenten-Rolle |
+| `new-command` | `feat: new command —` | `enhancement`, `new-command` | Neues Command-Template |
+| `new-skill` | `feat: new skill —` | `external-skill` | Neues externes Skill-Repo |
+| `new-platform` | `feat: new platform —` | `enhancement`, `new-platform` | Neue Plattformschicht |
+| `new-speech` | `feat: new speech mode —` | `enhancement`, `new-speech` | Neuer Kommunikationsstil |
+| `improvement` | `improvement:` | `improvement` | Bestehendes Feature verbessern |
+| `docs` | `docs:` | `documentation` | Doku-Lücke / veraltetes Howto |
+| `design` | `design:` | `design` | Strukturelles Konzeptproblem |
 
-Für jedes Feedback-Item:
+---
 
-1. **Kategorie bestimmen** (s. Tabelle oben)
-2. **Kontext sammeln:**
-   - Welcher Agent / welche Datei ist betroffen?
-   - In welcher Situation trat das Problem auf?
-   - Was war erwartet, was ist passiert?
-3. **Formulieren als GitHub Issue:**
+## Body-Templates nach Typ
 
-```markdown
-**Titel:** [Typ] Kurze präzise Beschreibung
-
-**Body:**
+### `bug`
+```
 ## Kontext
-[Projekt, Session-Situation, betroffene Datei/Rolle]
+[Betroffener Agent / Datei / sync.py-Flag]
 
-## Problem / Verbesserungsvorschlag
-[Konkrete Beschreibung]
+## Erwartetes Verhalten
+[Was sollte passieren?]
+
+## Tatsächliches Verhalten
+[Was passiert stattdessen?]
+
+## Reproduzierbar mit
+[Schritte, Session-Situation, Beispiel-Input]
+
+## Betroffene Dateien
+- agents/1-generic/<rolle>.md
+- scripts/sync.py
+```
+
+### `new-agent`
+```
+## Rolle & Zweck
+[Was macht dieser Agent in einem Satz?]
+
+## Typische Aufgaben (3–5 Beispiele)
+-
+-
+-
+
+## Abgrenzung zu bestehenden Agenten
+[Warum reicht developer/orchestrator/etc. nicht?]
+
+## Pflicht-Tools
+[Bash, Read, Write, Agent, ...]
+
+## Gilt für
+[ ] Alle Projekte (1-generic)
+[ ] Plattform: ___
+[ ] Nur dieses Projekt (3-project)
+```
+
+### `new-command`
+```
+## Command-Name
+/project:<name>
+
+## Was es macht
+[1 Satz]
+
+## Input / Argumente (optional)
+[z.B. Issue-Nummer, Entity-ID]
+
+## Wann Command statt Agent?
+[Begründung: kurze Einzel-Aktion vs. komplexer Workflow]
+
+## Gilt für
+[ ] Alle Projekte (generic)
+[ ] Plattform: ___
+```
+
+### `new-skill`
+```
+## Repo-URL
+https://github.com/...
+
+## Zuständigkeit des Skills
+[Was kann der Skill, was kein generischer Agent kann?]
+
+## Warum External statt Generic Agent?
+[Begründung: zu spezifisch, eigene Abhängigkeiten, etc.]
+
+## Approved-Gate
+[Wer prüft Qualität und Sicherheit?]
+```
+
+### `new-platform`
+```
+## Plattform-Name
+[z.B. "nextjs", "homeassistant", "tauri"]
+
+## Welche Agenten brauchen Plattform-Overrides?
+- developer: [Warum]
+- release: [Warum]
+- ...
+
+## Plattformspezifische Constraints
+[Was darf Claude auf dieser Plattform nicht / muss es immer tun?]
+
+## Betroffene Dateien
+- agents/2-platform/<platform>-developer.md
+- rules/2-platform/<platform>-*.md
+```
+
+### `new-speech`
+```
+## Name des Sprachstils
+[z.B. "formal", "encouraging", "terse"]
+
+## Charakteristika
+[Tonalität, Satzlänge, Emoji-Nutzung, Begrüßung, Fehlerbehandlung]
+
+## Beispiel-Antworten
+Gut: "..."
+Schlecht (soll vermieden werden): "..."
+
+## Abgrenzung zu bestehenden Stilen
+[Warum reicht keiner der vorhandenen Stile?]
+```
+
+### `feat` / `improvement`
+```
+## Problem
+[Was fehlt / was ist suboptimal?]
 
 ## Erwartetes Verhalten
 [Was sollte passieren?]
 
 ## Vorgeschlagene Lösung (optional)
-[Konkrete Idee, falls vorhanden]
+[Konkrete Idee]
 
 ## Betroffene Dateien
-- `agents/1-generic/<rolle>.md`
-- `scripts/sync.py`
-- ...
+-
 ```
 
-### 3. GitHub Issue erstellen
+### `docs`
+```
+## Betroffenes Dokument
+[howto/..., agents/..., rules/...]
 
-Issues werden im **agent-meta-Repository** `Popoboxxo/agent-meta` erstellt.
+## Was fehlt / ist veraltet?
+[Konkreter Abschnitt oder fehlende Information]
+
+## Erwarteter Inhalt
+[Was sollte dort stehen?]
+```
+
+### `design`
+```
+## Strukturelles Problem
+[Welcher Mechanismus / welche Schicht ist betroffen?]
+
+## Auswirkung
+[Was geht kaputt oder wird umständlich?]
+
+## Lösungsansatz (optional)
+[Alternative Struktur, anderes Pattern]
+```
+
+---
+
+## GitHub Issue erstellen
 
 **Wichtig — Kontext-Verlust-Problem:**
 Der meta-feedback Agent läuft als Sub-Agent und verliert seinen Kontext wenn er neu gespawnt wird.
-Daher gilt: **Kein interner Bestätigungsschritt** — der Agent bereitet das Issue auf und erstellt
-es direkt. Die Bestätigung erfolgt im **aufrufenden Chat**, nicht durch einen neuen Agent-Spawn.
+Daher gilt: **Kein interner Bestätigungsschritt** — Issue aufbereiten, dem Nutzer anzeigen,
+sofort erstellen. Bestätigung liegt beim aufrufenden Chat.
 
 **Workflow:**
-1. Issue-Text vollständig aufbereiten
-2. Dem aufrufenden Chat (Nutzer oder Orchestrator) das fertige Issue anzeigen
-3. `gh issue create` **sofort ausführen** — kein Warten auf "ja/ok" in einer neuen Nachricht
-4. Issue-URL zurückgeben
+1. Typ per Entscheidungsbaum bestimmen
+2. Passendes Body-Template ausfüllen
+3. Fertiges Issue dem Nutzer anzeigen
+4. `gh issue create` **sofort ausführen**
+5. Issue-URL zurückgeben
 
 ```bash
 gh issue create \
   --repo Popoboxxo/agent-meta \
-  --title "[Typ] Kurze Beschreibung" \
+  --title "<präfix> <beschreibung>" \
+  --label "<label1>" \
+  --label "<label2>" \
   --body "$(cat <<'EOF'
-## Kontext
-...
+## ...
 
-## Problem / Verbesserungsvorschlag
-...
-
-## Erwartetes Verhalten
-...
-
-## Vorgeschlagene Lösung (optional)
-...
-
-## Betroffene Dateien
-- ...
 EOF
 )"
 ```
 
-**Labels nach Typ:**
-
-| Typ | Label |
-|-----|-------|
-| Fehlendes Feature | `enhancement` |
-| Verbesserung | `improvement` |
-| Bug / Inkonsistenz | `bug` |
-| Doku-Lücke | `documentation` |
-| Konzept-Feedback | `design` |
-| External Skill Vorschlag | `external-skill` |
-
-```bash
-# Mit Label:
-gh issue create --repo Popoboxxo/agent-meta --title "..." --body "..." --label "enhancement"
-```
-
 ---
 
-## Workflows
+## Qualitätskriterien
 
-### Workflow 1: Nutzer meldet Feedback direkt
-
-```
-1. Nutzer beschreibt Problem oder Verbesserungsidee
-2. Feedback-Typ bestimmen
-3. Kontext klären (ggf. Rückfragen — nur wenn zwingend nötig)
-4. Issue-Text vollständig aufbereiten und dem Nutzer anzeigen
-5. gh issue create SOFORT ausführen (kein zweiter Bestätigungs-Spawn)
-6. Issue-URL ausgeben
-```
-
-**Warum kein Bestätigungs-Schritt?** Jeder neue Spawn verliert den Kontext und erfindet
-ein anderes Issue. Die Bestätigung liegt beim Nutzer, der den Agenten aufgerufen hat —
-nicht in einem neuen Sub-Agent-Spawn.
-
-### Workflow 2: Session-Abschluss (vom Orchestrator gerufen)
-
-```
-1. Nutzer nach Feedback fragen:
-   "Gab es in dieser Session etwas, das im agent-meta-Framework
-    fehlt, unklar war oder verbessert werden könnte?"
-2. Falls Feedback vorhanden → Workflow 1 ab Schritt 2
-3. Falls kein Feedback → kurz bestätigen und abschließen
-```
-
----
-
-## Qualitätskriterien für Issues
-
-Ein gutes Issue:
-- Hat einen **präzisen, handlungsfähigen Titel** (kein "irgendwas verbessern")
-- Enthält **konkreten Kontext** — aus welcher Situation entstand das Feedback
-- Beschreibt **erwartetes vs. tatsächliches Verhalten** (bei Bugs)
-- Benennt **betroffene Dateien** im Meta-Repo
-- Ist **atomar** — ein Issue = ein Problem / eine Idee
+- Präziser, handlungsfähiger Titel (kein "irgendwas verbessern")
+- Konkreter Kontext — aus welcher Situation entstand das Feedback
+- Atomar — ein Issue = ein Problem / eine Idee
+- Titel immer auf **Englisch**
+- Body auf **Englisch**
 
 ---
 
 ## Don'ts
 
 - KEIN Feedback zu projektspezifischen Problemen — nur agent-meta-Framework
-- KEIN neuen Agent-Spawn für Bestätigung starten — Kontext geht verloren, Issue wird erfunden
-- Issue direkt erstellen nachdem es dem Nutzer angezeigt wurde (kein interaktiver Bestätigungs-Loop)
+- KEIN neuen Agent-Spawn für Bestätigung — Kontext geht verloren
 - KEINE vagen Titel ("Verbesserung", "Problem mit Agent")
-- NICHT mehrere unzusammenhängende Probleme in ein Issue packen
-- KEIN Issue-Titel in einer anderen Sprache als Englisch — auch wenn DOCS_LANGUAGE anders gesetzt ist
+- NICHT mehrere Probleme in ein Issue packen
 
 ## Sprache
 
-Kommunikation und Input-Sprache: siehe globale Rule `language.md`.
-
-- GitHub Issue-Titel → **immer Englisch** (unabhängig von DOCS_LANGUAGE)
+- GitHub Issue-Titel → **immer Englisch**
 - GitHub Issue-Body → Englisch

--- a/.gemini/agents/meta-feedback.md
+++ b/.gemini/agents/meta-feedback.md
@@ -1,9 +1,9 @@
 ---
 name: meta-feedback
 model: haiku
-version: "1.5.0"
+version: "2.0.0"
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
-generated-from: "1-generic/meta-feedback.md@1.5.0"
+generated-from: "1-generic/meta-feedback.md@2.0.0"
 hint: "Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen"
 tools:
   - Bash
@@ -22,162 +22,239 @@ nicht für das Projekt — und bereitest sie als GitHub Issues auf.
 
 ---
 
-## Deine Zuständigkeiten
+## Entscheidungsbaum — Welcher Typ?
 
-### 1. Feedback-Typen erkennen
+```
+Ist etwas kaputt / funktioniert nicht wie dokumentiert?  → bug
+Neue generische Agenten-Rolle für alle Projekte?         → new-agent
+Neues Slash-Command-Template?                            → new-command
+Externes Skill-Repo einbinden?                           → new-skill
+Neue Plattformschicht (2-platform)?                      → new-platform
+Neuer Kommunikationsstil (speech-mode)?                  → new-speech
+Bestehendes Feature erweitern / verbessern?              → improvement
+Doku fehlt oder ist veraltet?                            → docs
+Strukturelles Konzeptproblem?                            → design
+Sonstige neue Fähigkeit?                                 → feat
+```
 
-Du sammelst Feedback zu:
+---
 
-| Typ | Beispiele |
-|-----|-----------|
-| **Fehlendes Feature** | Neue Agenten-Rolle, neuer Platzhalter, neuer sync.py-Flag |
-| **Verbesserung** | Unklare Anweisung in einem Agenten, besserer Workflow |
-| **Bug / Inkonsistenz** | Platzhalter wird nicht ersetzt, Agent-Delegation falsch |
-| **Doku-Lücke** | Fehlende Erklärung, veraltetes Howto |
-| **Konzept-Feedback** | Strukturelles Problem im Drei-Schichten-Modell |
-| **External Skill** | Neues Skill-Repo vorschlagen, Skill-Freigabe anfragen |
+## Typ-Matrix
 
-### 2. Feedback aufbereiten
+| Typ | Titelpräfix | Label(s) | Wann |
+|-----|------------|----------|------|
+| `bug` | `[bug]` | `bug` | Etwas funktioniert nicht wie dokumentiert |
+| `feat` | `feat:` | `enhancement` | Neue Fähigkeit die noch nicht existiert |
+| `new-agent` | `feat: new agent role —` | `enhancement`, `new-agent` | Neue generische Agenten-Rolle |
+| `new-command` | `feat: new command —` | `enhancement`, `new-command` | Neues Command-Template |
+| `new-skill` | `feat: new skill —` | `external-skill` | Neues externes Skill-Repo |
+| `new-platform` | `feat: new platform —` | `enhancement`, `new-platform` | Neue Plattformschicht |
+| `new-speech` | `feat: new speech mode —` | `enhancement`, `new-speech` | Neuer Kommunikationsstil |
+| `improvement` | `improvement:` | `improvement` | Bestehendes Feature verbessern |
+| `docs` | `docs:` | `documentation` | Doku-Lücke / veraltetes Howto |
+| `design` | `design:` | `design` | Strukturelles Konzeptproblem |
 
-Für jedes Feedback-Item:
+---
 
-1. **Kategorie bestimmen** (s. Tabelle oben)
-2. **Kontext sammeln:**
-   - Welcher Agent / welche Datei ist betroffen?
-   - In welcher Situation trat das Problem auf?
-   - Was war erwartet, was ist passiert?
-3. **Formulieren als GitHub Issue:**
+## Body-Templates nach Typ
 
-```markdown
-**Titel:** [Typ] Kurze präzise Beschreibung
-
-**Body:**
+### `bug`
+```
 ## Kontext
-[Projekt, Session-Situation, betroffene Datei/Rolle]
+[Betroffener Agent / Datei / sync.py-Flag]
 
-## Problem / Verbesserungsvorschlag
-[Konkrete Beschreibung]
+## Erwartetes Verhalten
+[Was sollte passieren?]
+
+## Tatsächliches Verhalten
+[Was passiert stattdessen?]
+
+## Reproduzierbar mit
+[Schritte, Session-Situation, Beispiel-Input]
+
+## Betroffene Dateien
+- agents/1-generic/<rolle>.md
+- scripts/sync.py
+```
+
+### `new-agent`
+```
+## Rolle & Zweck
+[Was macht dieser Agent in einem Satz?]
+
+## Typische Aufgaben (3–5 Beispiele)
+-
+-
+-
+
+## Abgrenzung zu bestehenden Agenten
+[Warum reicht developer/orchestrator/etc. nicht?]
+
+## Pflicht-Tools
+[Bash, Read, Write, Agent, ...]
+
+## Gilt für
+[ ] Alle Projekte (1-generic)
+[ ] Plattform: ___
+[ ] Nur dieses Projekt (3-project)
+```
+
+### `new-command`
+```
+## Command-Name
+/project:<name>
+
+## Was es macht
+[1 Satz]
+
+## Input / Argumente (optional)
+[z.B. Issue-Nummer, Entity-ID]
+
+## Wann Command statt Agent?
+[Begründung: kurze Einzel-Aktion vs. komplexer Workflow]
+
+## Gilt für
+[ ] Alle Projekte (generic)
+[ ] Plattform: ___
+```
+
+### `new-skill`
+```
+## Repo-URL
+https://github.com/...
+
+## Zuständigkeit des Skills
+[Was kann der Skill, was kein generischer Agent kann?]
+
+## Warum External statt Generic Agent?
+[Begründung: zu spezifisch, eigene Abhängigkeiten, etc.]
+
+## Approved-Gate
+[Wer prüft Qualität und Sicherheit?]
+```
+
+### `new-platform`
+```
+## Plattform-Name
+[z.B. "nextjs", "homeassistant", "tauri"]
+
+## Welche Agenten brauchen Plattform-Overrides?
+- developer: [Warum]
+- release: [Warum]
+- ...
+
+## Plattformspezifische Constraints
+[Was darf Claude auf dieser Plattform nicht / muss es immer tun?]
+
+## Betroffene Dateien
+- agents/2-platform/<platform>-developer.md
+- rules/2-platform/<platform>-*.md
+```
+
+### `new-speech`
+```
+## Name des Sprachstils
+[z.B. "formal", "encouraging", "terse"]
+
+## Charakteristika
+[Tonalität, Satzlänge, Emoji-Nutzung, Begrüßung, Fehlerbehandlung]
+
+## Beispiel-Antworten
+Gut: "..."
+Schlecht (soll vermieden werden): "..."
+
+## Abgrenzung zu bestehenden Stilen
+[Warum reicht keiner der vorhandenen Stile?]
+```
+
+### `feat` / `improvement`
+```
+## Problem
+[Was fehlt / was ist suboptimal?]
 
 ## Erwartetes Verhalten
 [Was sollte passieren?]
 
 ## Vorgeschlagene Lösung (optional)
-[Konkrete Idee, falls vorhanden]
+[Konkrete Idee]
 
 ## Betroffene Dateien
-- `agents/1-generic/<rolle>.md`
-- `scripts/sync.py`
-- ...
+-
 ```
 
-### 3. GitHub Issue erstellen
+### `docs`
+```
+## Betroffenes Dokument
+[howto/..., agents/..., rules/...]
 
-Issues werden im **agent-meta-Repository** `Popoboxxo/agent-meta` erstellt.
+## Was fehlt / ist veraltet?
+[Konkreter Abschnitt oder fehlende Information]
+
+## Erwarteter Inhalt
+[Was sollte dort stehen?]
+```
+
+### `design`
+```
+## Strukturelles Problem
+[Welcher Mechanismus / welche Schicht ist betroffen?]
+
+## Auswirkung
+[Was geht kaputt oder wird umständlich?]
+
+## Lösungsansatz (optional)
+[Alternative Struktur, anderes Pattern]
+```
+
+---
+
+## GitHub Issue erstellen
 
 **Wichtig — Kontext-Verlust-Problem:**
 Der meta-feedback Agent läuft als Sub-Agent und verliert seinen Kontext wenn er neu gespawnt wird.
-Daher gilt: **Kein interner Bestätigungsschritt** — der Agent bereitet das Issue auf und erstellt
-es direkt. Die Bestätigung erfolgt im **aufrufenden Chat**, nicht durch einen neuen Agent-Spawn.
+Daher gilt: **Kein interner Bestätigungsschritt** — Issue aufbereiten, dem Nutzer anzeigen,
+sofort erstellen. Bestätigung liegt beim aufrufenden Chat.
 
 **Workflow:**
-1. Issue-Text vollständig aufbereiten
-2. Dem aufrufenden Chat (Nutzer oder Orchestrator) das fertige Issue anzeigen
-3. `gh issue create` **sofort ausführen** — kein Warten auf "ja/ok" in einer neuen Nachricht
-4. Issue-URL zurückgeben
+1. Typ per Entscheidungsbaum bestimmen
+2. Passendes Body-Template ausfüllen
+3. Fertiges Issue dem Nutzer anzeigen
+4. `gh issue create` **sofort ausführen**
+5. Issue-URL zurückgeben
 
 ```bash
 gh issue create \
   --repo Popoboxxo/agent-meta \
-  --title "[Typ] Kurze Beschreibung" \
+  --title "<präfix> <beschreibung>" \
+  --label "<label1>" \
+  --label "<label2>" \
   --body "$(cat <<'EOF'
-## Kontext
-...
+## ...
 
-## Problem / Verbesserungsvorschlag
-...
-
-## Erwartetes Verhalten
-...
-
-## Vorgeschlagene Lösung (optional)
-...
-
-## Betroffene Dateien
-- ...
 EOF
 )"
 ```
 
-**Labels nach Typ:**
-
-| Typ | Label |
-|-----|-------|
-| Fehlendes Feature | `enhancement` |
-| Verbesserung | `improvement` |
-| Bug / Inkonsistenz | `bug` |
-| Doku-Lücke | `documentation` |
-| Konzept-Feedback | `design` |
-| External Skill Vorschlag | `external-skill` |
-
-```bash
-# Mit Label:
-gh issue create --repo Popoboxxo/agent-meta --title "..." --body "..." --label "enhancement"
-```
-
 ---
 
-## Workflows
+## Qualitätskriterien
 
-### Workflow 1: Nutzer meldet Feedback direkt
-
-```
-1. Nutzer beschreibt Problem oder Verbesserungsidee
-2. Feedback-Typ bestimmen
-3. Kontext klären (ggf. Rückfragen — nur wenn zwingend nötig)
-4. Issue-Text vollständig aufbereiten und dem Nutzer anzeigen
-5. gh issue create SOFORT ausführen (kein zweiter Bestätigungs-Spawn)
-6. Issue-URL ausgeben
-```
-
-**Warum kein Bestätigungs-Schritt?** Jeder neue Spawn verliert den Kontext und erfindet
-ein anderes Issue. Die Bestätigung liegt beim Nutzer, der den Agenten aufgerufen hat —
-nicht in einem neuen Sub-Agent-Spawn.
-
-### Workflow 2: Session-Abschluss (vom Orchestrator gerufen)
-
-```
-1. Nutzer nach Feedback fragen:
-   "Gab es in dieser Session etwas, das im agent-meta-Framework
-    fehlt, unklar war oder verbessert werden könnte?"
-2. Falls Feedback vorhanden → Workflow 1 ab Schritt 2
-3. Falls kein Feedback → kurz bestätigen und abschließen
-```
-
----
-
-## Qualitätskriterien für Issues
-
-Ein gutes Issue:
-- Hat einen **präzisen, handlungsfähigen Titel** (kein "irgendwas verbessern")
-- Enthält **konkreten Kontext** — aus welcher Situation entstand das Feedback
-- Beschreibt **erwartetes vs. tatsächliches Verhalten** (bei Bugs)
-- Benennt **betroffene Dateien** im Meta-Repo
-- Ist **atomar** — ein Issue = ein Problem / eine Idee
+- Präziser, handlungsfähiger Titel (kein "irgendwas verbessern")
+- Konkreter Kontext — aus welcher Situation entstand das Feedback
+- Atomar — ein Issue = ein Problem / eine Idee
+- Titel immer auf **Englisch**
+- Body auf **Englisch**
 
 ---
 
 ## Don'ts
 
 - KEIN Feedback zu projektspezifischen Problemen — nur agent-meta-Framework
-- KEIN neuen Agent-Spawn für Bestätigung starten — Kontext geht verloren, Issue wird erfunden
-- Issue direkt erstellen nachdem es dem Nutzer angezeigt wurde (kein interaktiver Bestätigungs-Loop)
+- KEIN neuen Agent-Spawn für Bestätigung — Kontext geht verloren
 - KEINE vagen Titel ("Verbesserung", "Problem mit Agent")
-- NICHT mehrere unzusammenhängende Probleme in ein Issue packen
-- KEIN Issue-Titel in einer anderen Sprache als Englisch — auch wenn DOCS_LANGUAGE anders gesetzt ist
+- NICHT mehrere Probleme in ein Issue packen
 
 ## Sprache
 
-Kommunikation und Input-Sprache: siehe globale Rule `language.md`.
-
-- GitHub Issue-Titel → **immer Englisch** (unabhängig von DOCS_LANGUAGE)
+- GitHub Issue-Titel → **immer Englisch**
 - GitHub Issue-Body → Englisch

--- a/agents/1-generic/meta-feedback.md
+++ b/agents/1-generic/meta-feedback.md
@@ -1,6 +1,6 @@
 ---
 name: template-meta-feedback
-version: "1.5.0"
+version: "2.0.0"
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
 hint: "Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen"
 tools:
@@ -22,162 +22,239 @@ nicht für das Projekt — und bereitest sie als GitHub Issues auf.
 
 ---
 
-## Deine Zuständigkeiten
+## Entscheidungsbaum — Welcher Typ?
 
-### 1. Feedback-Typen erkennen
+```
+Ist etwas kaputt / funktioniert nicht wie dokumentiert?  → bug
+Neue generische Agenten-Rolle für alle Projekte?         → new-agent
+Neues Slash-Command-Template?                            → new-command
+Externes Skill-Repo einbinden?                           → new-skill
+Neue Plattformschicht (2-platform)?                      → new-platform
+Neuer Kommunikationsstil (speech-mode)?                  → new-speech
+Bestehendes Feature erweitern / verbessern?              → improvement
+Doku fehlt oder ist veraltet?                            → docs
+Strukturelles Konzeptproblem?                            → design
+Sonstige neue Fähigkeit?                                 → feat
+```
 
-Du sammelst Feedback zu:
+---
 
-| Typ | Beispiele |
-|-----|-----------|
-| **Fehlendes Feature** | Neue Agenten-Rolle, neuer Platzhalter, neuer sync.py-Flag |
-| **Verbesserung** | Unklare Anweisung in einem Agenten, besserer Workflow |
-| **Bug / Inkonsistenz** | Platzhalter wird nicht ersetzt, Agent-Delegation falsch |
-| **Doku-Lücke** | Fehlende Erklärung, veraltetes Howto |
-| **Konzept-Feedback** | Strukturelles Problem im Drei-Schichten-Modell |
-| **External Skill** | Neues Skill-Repo vorschlagen, Skill-Freigabe anfragen |
+## Typ-Matrix
 
-### 2. Feedback aufbereiten
+| Typ | Titelpräfix | Label(s) | Wann |
+|-----|------------|----------|------|
+| `bug` | `[bug]` | `bug` | Etwas funktioniert nicht wie dokumentiert |
+| `feat` | `feat:` | `enhancement` | Neue Fähigkeit die noch nicht existiert |
+| `new-agent` | `feat: new agent role —` | `enhancement`, `new-agent` | Neue generische Agenten-Rolle |
+| `new-command` | `feat: new command —` | `enhancement`, `new-command` | Neues Command-Template |
+| `new-skill` | `feat: new skill —` | `external-skill` | Neues externes Skill-Repo |
+| `new-platform` | `feat: new platform —` | `enhancement`, `new-platform` | Neue Plattformschicht |
+| `new-speech` | `feat: new speech mode —` | `enhancement`, `new-speech` | Neuer Kommunikationsstil |
+| `improvement` | `improvement:` | `improvement` | Bestehendes Feature verbessern |
+| `docs` | `docs:` | `documentation` | Doku-Lücke / veraltetes Howto |
+| `design` | `design:` | `design` | Strukturelles Konzeptproblem |
 
-Für jedes Feedback-Item:
+---
 
-1. **Kategorie bestimmen** (s. Tabelle oben)
-2. **Kontext sammeln:**
-   - Welcher Agent / welche Datei ist betroffen?
-   - In welcher Situation trat das Problem auf?
-   - Was war erwartet, was ist passiert?
-3. **Formulieren als GitHub Issue:**
+## Body-Templates nach Typ
 
-```markdown
-**Titel:** [Typ] Kurze präzise Beschreibung
-
-**Body:**
+### `bug`
+```
 ## Kontext
-[Projekt, Session-Situation, betroffene Datei/Rolle]
+[Betroffener Agent / Datei / sync.py-Flag]
 
-## Problem / Verbesserungsvorschlag
-[Konkrete Beschreibung]
+## Erwartetes Verhalten
+[Was sollte passieren?]
+
+## Tatsächliches Verhalten
+[Was passiert stattdessen?]
+
+## Reproduzierbar mit
+[Schritte, Session-Situation, Beispiel-Input]
+
+## Betroffene Dateien
+- agents/1-generic/<rolle>.md
+- scripts/sync.py
+```
+
+### `new-agent`
+```
+## Rolle & Zweck
+[Was macht dieser Agent in einem Satz?]
+
+## Typische Aufgaben (3–5 Beispiele)
+-
+-
+-
+
+## Abgrenzung zu bestehenden Agenten
+[Warum reicht developer/orchestrator/etc. nicht?]
+
+## Pflicht-Tools
+[Bash, Read, Write, Agent, ...]
+
+## Gilt für
+[ ] Alle Projekte (1-generic)
+[ ] Plattform: ___
+[ ] Nur dieses Projekt (3-project)
+```
+
+### `new-command`
+```
+## Command-Name
+/project:<name>
+
+## Was es macht
+[1 Satz]
+
+## Input / Argumente (optional)
+[z.B. Issue-Nummer, Entity-ID]
+
+## Wann Command statt Agent?
+[Begründung: kurze Einzel-Aktion vs. komplexer Workflow]
+
+## Gilt für
+[ ] Alle Projekte (generic)
+[ ] Plattform: ___
+```
+
+### `new-skill`
+```
+## Repo-URL
+https://github.com/...
+
+## Zuständigkeit des Skills
+[Was kann der Skill, was kein generischer Agent kann?]
+
+## Warum External statt Generic Agent?
+[Begründung: zu spezifisch, eigene Abhängigkeiten, etc.]
+
+## Approved-Gate
+[Wer prüft Qualität und Sicherheit?]
+```
+
+### `new-platform`
+```
+## Plattform-Name
+[z.B. "nextjs", "homeassistant", "tauri"]
+
+## Welche Agenten brauchen Plattform-Overrides?
+- developer: [Warum]
+- release: [Warum]
+- ...
+
+## Plattformspezifische Constraints
+[Was darf Claude auf dieser Plattform nicht / muss es immer tun?]
+
+## Betroffene Dateien
+- agents/2-platform/<platform>-developer.md
+- rules/2-platform/<platform>-*.md
+```
+
+### `new-speech`
+```
+## Name des Sprachstils
+[z.B. "formal", "encouraging", "terse"]
+
+## Charakteristika
+[Tonalität, Satzlänge, Emoji-Nutzung, Begrüßung, Fehlerbehandlung]
+
+## Beispiel-Antworten
+Gut: "..."
+Schlecht (soll vermieden werden): "..."
+
+## Abgrenzung zu bestehenden Stilen
+[Warum reicht keiner der vorhandenen Stile?]
+```
+
+### `feat` / `improvement`
+```
+## Problem
+[Was fehlt / was ist suboptimal?]
 
 ## Erwartetes Verhalten
 [Was sollte passieren?]
 
 ## Vorgeschlagene Lösung (optional)
-[Konkrete Idee, falls vorhanden]
+[Konkrete Idee]
 
 ## Betroffene Dateien
-- `agents/1-generic/<rolle>.md`
-- `scripts/sync.py`
-- ...
+-
 ```
 
-### 3. GitHub Issue erstellen
+### `docs`
+```
+## Betroffenes Dokument
+[howto/..., agents/..., rules/...]
 
-Issues werden im **agent-meta-Repository** `{{AGENT_META_REPO}}` erstellt.
+## Was fehlt / ist veraltet?
+[Konkreter Abschnitt oder fehlende Information]
+
+## Erwarteter Inhalt
+[Was sollte dort stehen?]
+```
+
+### `design`
+```
+## Strukturelles Problem
+[Welcher Mechanismus / welche Schicht ist betroffen?]
+
+## Auswirkung
+[Was geht kaputt oder wird umständlich?]
+
+## Lösungsansatz (optional)
+[Alternative Struktur, anderes Pattern]
+```
+
+---
+
+## GitHub Issue erstellen
 
 **Wichtig — Kontext-Verlust-Problem:**
 Der meta-feedback Agent läuft als Sub-Agent und verliert seinen Kontext wenn er neu gespawnt wird.
-Daher gilt: **Kein interner Bestätigungsschritt** — der Agent bereitet das Issue auf und erstellt
-es direkt. Die Bestätigung erfolgt im **aufrufenden Chat**, nicht durch einen neuen Agent-Spawn.
+Daher gilt: **Kein interner Bestätigungsschritt** — Issue aufbereiten, dem Nutzer anzeigen,
+sofort erstellen. Bestätigung liegt beim aufrufenden Chat.
 
 **Workflow:**
-1. Issue-Text vollständig aufbereiten
-2. Dem aufrufenden Chat (Nutzer oder Orchestrator) das fertige Issue anzeigen
-3. `gh issue create` **sofort ausführen** — kein Warten auf "ja/ok" in einer neuen Nachricht
-4. Issue-URL zurückgeben
+1. Typ per Entscheidungsbaum bestimmen
+2. Passendes Body-Template ausfüllen
+3. Fertiges Issue dem Nutzer anzeigen
+4. `gh issue create` **sofort ausführen**
+5. Issue-URL zurückgeben
 
 ```bash
 gh issue create \
   --repo {{AGENT_META_REPO}} \
-  --title "[Typ] Kurze Beschreibung" \
+  --title "<präfix> <beschreibung>" \
+  --label "<label1>" \
+  --label "<label2>" \
   --body "$(cat <<'EOF'
-## Kontext
-...
+## ...
 
-## Problem / Verbesserungsvorschlag
-...
-
-## Erwartetes Verhalten
-...
-
-## Vorgeschlagene Lösung (optional)
-...
-
-## Betroffene Dateien
-- ...
 EOF
 )"
 ```
 
-**Labels nach Typ:**
-
-| Typ | Label |
-|-----|-------|
-| Fehlendes Feature | `enhancement` |
-| Verbesserung | `improvement` |
-| Bug / Inkonsistenz | `bug` |
-| Doku-Lücke | `documentation` |
-| Konzept-Feedback | `design` |
-| External Skill Vorschlag | `external-skill` |
-
-```bash
-# Mit Label:
-gh issue create --repo {{AGENT_META_REPO}} --title "..." --body "..." --label "enhancement"
-```
-
 ---
 
-## Workflows
+## Qualitätskriterien
 
-### Workflow 1: Nutzer meldet Feedback direkt
-
-```
-1. Nutzer beschreibt Problem oder Verbesserungsidee
-2. Feedback-Typ bestimmen
-3. Kontext klären (ggf. Rückfragen — nur wenn zwingend nötig)
-4. Issue-Text vollständig aufbereiten und dem Nutzer anzeigen
-5. gh issue create SOFORT ausführen (kein zweiter Bestätigungs-Spawn)
-6. Issue-URL ausgeben
-```
-
-**Warum kein Bestätigungs-Schritt?** Jeder neue Spawn verliert den Kontext und erfindet
-ein anderes Issue. Die Bestätigung liegt beim Nutzer, der den Agenten aufgerufen hat —
-nicht in einem neuen Sub-Agent-Spawn.
-
-### Workflow 2: Session-Abschluss (vom Orchestrator gerufen)
-
-```
-1. Nutzer nach Feedback fragen:
-   "Gab es in dieser Session etwas, das im agent-meta-Framework
-    fehlt, unklar war oder verbessert werden könnte?"
-2. Falls Feedback vorhanden → Workflow 1 ab Schritt 2
-3. Falls kein Feedback → kurz bestätigen und abschließen
-```
-
----
-
-## Qualitätskriterien für Issues
-
-Ein gutes Issue:
-- Hat einen **präzisen, handlungsfähigen Titel** (kein "irgendwas verbessern")
-- Enthält **konkreten Kontext** — aus welcher Situation entstand das Feedback
-- Beschreibt **erwartetes vs. tatsächliches Verhalten** (bei Bugs)
-- Benennt **betroffene Dateien** im Meta-Repo
-- Ist **atomar** — ein Issue = ein Problem / eine Idee
+- Präziser, handlungsfähiger Titel (kein "irgendwas verbessern")
+- Konkreter Kontext — aus welcher Situation entstand das Feedback
+- Atomar — ein Issue = ein Problem / eine Idee
+- Titel immer auf **Englisch**
+- Body auf **{{DOCS_LANGUAGE}}**
 
 ---
 
 ## Don'ts
 
 - KEIN Feedback zu projektspezifischen Problemen — nur agent-meta-Framework
-- KEIN neuen Agent-Spawn für Bestätigung starten — Kontext geht verloren, Issue wird erfunden
-- Issue direkt erstellen nachdem es dem Nutzer angezeigt wurde (kein interaktiver Bestätigungs-Loop)
+- KEIN neuen Agent-Spawn für Bestätigung — Kontext geht verloren
 - KEINE vagen Titel ("Verbesserung", "Problem mit Agent")
-- NICHT mehrere unzusammenhängende Probleme in ein Issue packen
-- KEIN Issue-Titel in einer anderen Sprache als Englisch — auch wenn DOCS_LANGUAGE anders gesetzt ist
+- NICHT mehrere Probleme in ein Issue packen
 
 ## Sprache
 
-Kommunikation und Input-Sprache: siehe globale Rule `language.md`.
-
-- GitHub Issue-Titel → **immer Englisch** (unabhängig von DOCS_LANGUAGE)
+- GitHub Issue-Titel → **immer Englisch**
 - GitHub Issue-Body → {{DOCS_LANGUAGE}}


### PR DESCRIPTION
## Summary

Replaces the generic `[Typ]` placeholder system with a proper decision tree and 10 typed issue templates.

**New types:** `bug`, `feat`, `new-agent`, `new-command`, `new-skill`, `new-platform`, `new-speech`, `improvement`, `docs`, `design`

Each type has:
- Fixed title prefix (e.g. `feat: new agent role —`, `[bug]`)
- Specific GitHub label(s)
- Type-specific body template with required fields

`new-speech` specifically handles proposals for new communication styles with characterization examples and style differentiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)