### PR TITLE
fix: add missing gitignore entries for provider local settings (#84)

### DIFF
--- a/.continue/config.yaml
+++ b/.continue/config.yaml
@@ -1,5 +1,5 @@
 # agent-meta:managed-begin
-# Managed by agent-meta v0.34.2 — 2026-05-07
+# Managed by agent-meta v0.34.2 — 2026-05-08
 # Agents : .continue/agents/  (auto-discovered by Continue)
 # Rules  : .continue/rules/   (auto-discovered by Continue)
 # agent-meta:managed-end

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.34.2 — `2026-05-07`
+Generiert von agent-meta v0.34.2 — `2026-05-08`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ sync.log
 .claude/agent-memory-local/
 .claude/pending-tasks.md
 .claude/settings.local.json
+.continue/settings.local.yaml
+.gemini/settings.local.json
+.opencode/settings.local.json
 AGENTS.personal.md
 CLAUDE.personal.md
 sync.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.34.2 — `2026-05-07`
+Generiert von agent-meta v0.34.2 — `2026-05-08`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Nur auf Grep/Glob/Read zurückfallen wenn der Graph nicht ausreicht.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.34.2 — `2026-05-07`
+Generiert von agent-meta v0.34.2 — `2026-05-08`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -45,7 +45,8 @@ providers:
     has_settings: true
     settings_file: .gemini/settings.json
     settings_template: howto/configs/GEMINI.settings-template.json
-    gitignore_entries: []
+    gitignore_entries:
+      - .gemini/settings.local.json
     model-tiers:
       nano:     gemini-2.5-flash            # ultra-fast, low-cost tasks
       fast:     gemini-2.5-flash            # quick ops: git, formatting
@@ -68,6 +69,7 @@ providers:
     settings_template: howto/configs/OPENCODE.settings-template.json
     gitignore_entries:
       - AGENTS.personal.md
+      - .opencode/settings.local.json
     # opencode model IDs use "provider/model-id" format (AI SDK convention)
     model-tiers:
       nano:     anthropic/claude-haiku-4-5-20251001
@@ -92,7 +94,8 @@ providers:
     has_settings: true
     settings_file: .continue/config.yaml
     settings_template: howto/configs/CONTINUE.config-template.yaml
-    gitignore_entries: []
+    gitignore_entries:
+      - .continue/settings.local.yaml
     # Continue manages models centrally in .continue/config.yaml — no per-agent model.
     model-tiers: {}
     model-aliases: {}

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -386,6 +386,8 @@ def main():
             if _p == "Claude":
                 continue  # already in base_gitignore_entries
             _pc = provider_config.get(_p, {})
+            if _pc.get("has_settings") and not _pc.get("gitignore_entries"):
+                log.warn(f"provider '{_p}' has has_settings=true but no gitignore_entries — local settings may be accidentally committed")
             extra_provider_entries.extend(_pc.get("gitignore_entries", []))
         if is_claude:
             skill_gitignore_entries = _collect_skill_gitignore_entries(config, ext_config)


### PR DESCRIPTION
## Summary
- Adds `.gemini/settings.local.json`, `.opencode/settings.local.json`, `.continue/settings.local.yaml` to `gitignore_entries` in `config/ai-providers.yaml`
- `sync.py` now writes all three into the managed `.gitignore` block automatically
- Adds a validation warning in `sync.py` when a provider has `has_settings=true` but empty `gitignore_entries` — prevents the same oversight for future providers

Closes #84

## Test plan
- [x] `sync.py --dry-run` shows `[UPDATE] .gitignore — added: .continue/settings.local.yaml, .gemini/settings.local.json, .opencode/settings.local.json`
- [x] `sync.py` (real run) — managed block in `.gitignore` contains all three entries
- [x] No new warnings from the validation check (all providers now have entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)