### PR TITLE
chore: add .local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .claude/settings.local.json
 .input/
+.local/
 CLAUDE.personal.md
 sync.log
 


### PR DESCRIPTION
Adds `.local/` to the manual gitignore block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)