### PR TITLE
fix: switch Opencode model tiers to opencode-go provider (closes #87)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .claude/settings.local.json
 .input/
+.local/
 CLAUDE.personal.md
 sync.log
 

--- a/.opencode/agents/agent-meta-manager.md
+++ b/.opencode/agents/agent-meta-manager.md
@@ -1,7 +1,7 @@
 ---
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 mode: subagent
-model: anthropic/claude-sonnet-4-6
+model: opencode-go/qwen3.6-plus
 generated-from: "1-generic/agent-meta-manager.md@1.4.2"
 ---
 # Agent-Meta-Manager — agent-meta

--- a/.opencode/agents/agent-meta-scout.md
+++ b/.opencode/agents/agent-meta-scout.md
@@ -1,7 +1,7 @@
 ---
 description: "Scoutet das Claude-Ökosystem auf neue Skills, Agenten-Patterns, Rules und Workflows. Bewertet Kandidaten und macht konkrete Erweiterungsvorschläge für agent-meta."
 mode: subagent
-model: anthropic/claude-sonnet-4-6
+model: opencode-go/qwen3.6-plus
 generated-from: "1-generic/agent-meta-scout.md@1.0.1"
 ---
 # Agent-Meta Scout — agent-meta

--- a/.opencode/agents/documenter.md
+++ b/.opencode/agents/documenter.md
@@ -1,7 +1,7 @@
 ---
 description: "Pflegt CODEBASE_OVERVIEW.md, ARCHITECTURE.md, README.md und Session-Erkenntnisse."
 mode: subagent
-model: anthropic/claude-sonnet-4-6
+model: opencode-go/qwen3.6-plus
 generated-from: "1-generic/documenter.md@1.3.2"
 ---
 # Documenter — agent-meta

--- a/.opencode/agents/git.md
+++ b/.opencode/agents/git.md
@@ -1,7 +1,7 @@
 ---
 description: "Git-Operationen: Commits, Branches, Merges, Tags, Push/Pull und Commit-Messages — plattformunabhängig (GitHub, GitLab, Gitea)."
 mode: subagent
-model: anthropic/claude-haiku-4-5-20251001
+model: opencode-go/deepseek-v4-flash
 generated-from: "1-generic/git.md@2.2.0"
 ---
 # Git Agent — agent-meta

--- a/.opencode/agents/meta-feedback.md
+++ b/.opencode/agents/meta-feedback.md
@@ -1,7 +1,7 @@
 ---
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
 mode: subagent
-model: anthropic/claude-haiku-4-5-20251001
+model: opencode-go/deepseek-v4-flash
 generated-from: "1-generic/meta-feedback.md@2.0.0"
 ---
 # Meta-Feedback — agent-meta

--- a/.opencode/agents/release.md
+++ b/.opencode/agents/release.md
@@ -1,7 +1,7 @@
 ---
 description: "Versioning, Changelogs, Build-Prozesse und GitHub-Releases verwalten."
 mode: subagent
-model: anthropic/claude-sonnet-4-6
+model: opencode-go/qwen3.6-plus
 generated-from: "1-generic/release.md@1.3.2"
 ---
 # Release Manager — agent-meta

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -83,17 +83,18 @@ providers:
       committed-file: opencode.json
       secrets-file: .opencode/mcp.local.json
       format: opencode-json
-    # opencode model IDs use "provider/model-id" format (AI SDK convention)
+    # opencode-go model IDs — format: opencode-go/<model-id>
+    # Full list: https://opencode.ai/docs/go/
     model-tiers:
-      nano:     anthropic/claude-haiku-4-5-20251001
-      fast:     anthropic/claude-haiku-4-5-20251001
-      balanced: anthropic/claude-sonnet-4-6
-      powerful: anthropic/claude-opus-4-7
-      max:      anthropic/claude-opus-4-7
+      nano:     opencode-go/deepseek-v4-flash   # fast & cheap: batch, throughput
+      fast:     opencode-go/deepseek-v4-flash   # quick ops: git, meta-feedback
+      balanced: opencode-go/qwen3.6-plus        # default workhorse: dev, docs, review
+      powerful: opencode-go/kimi-k2.5           # complex reasoning: architecture, security
+      max:      opencode-go/kimi-k2.6           # maximum capability
     model-aliases:
-      haiku:  anthropic/claude-haiku-4-5-20251001
-      sonnet: anthropic/claude-sonnet-4-6
-      opus:   anthropic/claude-opus-4-7
+      flash:  opencode-go/deepseek-v4-flash
+      qwen:   opencode-go/qwen3.6-plus
+      kimi:   opencode-go/kimi-k2.6
 
   Continue:
     agents_dir: .continue/agents

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -304,8 +304,6 @@ def main():
             init_claude_personal(agent_meta_root, project_root, log, args.dry_run)
             init_settings_json(project_root, log, args.dry_run)
             init_settings_local_json(project_root, log, args.dry_run)
-        if args.init:
-            init_secrets_template(agent_meta_root, project_root, config, log, args.dry_run)
             claude_pc = provider_config.get("Claude", {})
             gitignore_cfg = config.get("gitignore", {})
             # local: true (default) — personal/local files are gitignored
@@ -318,6 +316,8 @@ def main():
                 ]))
             else:
                 base_gitignore_entries = []
+        if args.init:
+            init_secrets_template(agent_meta_root, project_root, config, log, args.dry_run)
             # generated: false (default) — generated files are committed
             if gitignore_cfg.get("generated", False):
                 for _prov in providers:


### PR DESCRIPTION
## Summary

- Replaces all `anthropic/claude-*` model IDs in the Opencode provider with `opencode-go/*` equivalents — resolves `ProviderModelNotFoundError` when spawning subagents via the `task` tool (#87)
- Fixes a regression in `sync.py`: `base_gitignore_entries` was accidentally scoped into `if args.init:` instead of `if args.init or is_claude:`, causing `UnboundLocalError` on regular sync with Claude provider

## New model tier mapping (Opencode)

| Tier | Model | Used by |
|---|---|---|
| nano/fast | `opencode-go/deepseek-v4-flash` | git, meta-feedback |
| balanced | `opencode-go/qwen3.6-plus` | dev, docs, review |
| powerful | `opencode-go/kimi-k2.5` | architecture, security |
| max | `opencode-go/kimi-k2.6` | maximum capability |

🤖 Generated with [Claude Code](https://claude.com/claude-code)