### PR TITLE
fix: add missing name field to Opencode agent frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .claude/settings.local.json
 .input/
+.local/
 CLAUDE.personal.md
 sync.log
 

--- a/.opencode/agents/agent-meta-manager.md
+++ b/.opencode/agents/agent-meta-manager.md
@@ -1,4 +1,5 @@
 ---
+name: agent-meta-manager
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 mode: subagent
 model: anthropic/claude-sonnet-4-6

--- a/.opencode/agents/agent-meta-scout.md
+++ b/.opencode/agents/agent-meta-scout.md
@@ -1,4 +1,5 @@
 ---
+name: agent-meta-scout
 description: "Scoutet das Claude-Ökosystem auf neue Skills, Agenten-Patterns, Rules und Workflows. Bewertet Kandidaten und macht konkrete Erweiterungsvorschläge für agent-meta."
 mode: subagent
 model: anthropic/claude-sonnet-4-6

--- a/.opencode/agents/developer.md
+++ b/.opencode/agents/developer.md
@@ -1,4 +1,5 @@
 ---
+name: developer
 description: "Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen"
 mode: subagent
 generated-from: "2-platform/agent-meta-developer.md@1.0.0"

--- a/.opencode/agents/documenter.md
+++ b/.opencode/agents/documenter.md
@@ -1,4 +1,5 @@
 ---
+name: documenter
 description: "Pflegt CODEBASE_OVERVIEW.md, ARCHITECTURE.md, README.md und Session-Erkenntnisse."
 mode: subagent
 model: anthropic/claude-sonnet-4-6

--- a/.opencode/agents/feature.md
+++ b/.opencode/agents/feature.md
@@ -1,4 +1,5 @@
 ---
+name: feature
 description: "Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR."
 mode: subagent
 generated-from: "1-generic/feature.md@1.3.0"

--- a/.opencode/agents/git.md
+++ b/.opencode/agents/git.md
@@ -1,4 +1,5 @@
 ---
+name: git
 description: "Git-Operationen: Commits, Branches, Merges, Tags, Push/Pull und Commit-Messages — plattformunabhängig (GitHub, GitLab, Gitea)."
 mode: subagent
 model: anthropic/claude-haiku-4-5-20251001

--- a/.opencode/agents/ideation.md
+++ b/.opencode/agents/ideation.md
@@ -1,4 +1,5 @@
 ---
+name: ideation
 description: "Ideenfindung, Visions-Schärfung und Konzept-Konkretisierung — stellt Fragen, denkt Ecken, übergibt reife Ideen an Requirements."
 mode: subagent
 generated-from: "1-generic/ideation.md@1.2.2"

--- a/.opencode/agents/meta-feedback.md
+++ b/.opencode/agents/meta-feedback.md
@@ -1,4 +1,5 @@
 ---
+name: meta-feedback
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
 mode: subagent
 model: anthropic/claude-haiku-4-5-20251001

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -1,4 +1,5 @@
 ---
+name: orchestrator
 description: "Koordiniert alle Agenten durch den Entwicklungsprozess: Requirements → Development → Testing → Validation → Documentation."
 mode: subagent
 generated-from: "1-generic/orchestrator.md@2.5.0"

--- a/.opencode/agents/release.md
+++ b/.opencode/agents/release.md
@@ -1,4 +1,5 @@
 ---
+name: release
 description: "Versioning, Changelogs, Build-Prozesse und GitHub-Releases verwalten."
 mode: subagent
 model: anthropic/claude-sonnet-4-6

--- a/.opencode/agents/requirements.md
+++ b/.opencode/agents/requirements.md
@@ -1,4 +1,5 @@
 ---
+name: requirements
 description: "Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen und Traceability prüfen."
 mode: subagent
 generated-from: "1-generic/requirements.md@1.3.2"

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -713,7 +713,7 @@ def sync_agents_for_provider(
                     src = 'project override' if is_override else 'meta default'
                     log.info(str(target_path.relative_to(project_root)), f'model: {model} (from {src})')
                 content = _transform_frontmatter_for_opencode(
-                    content, description, model, generated_from
+                    content, name, description, model, generated_from
                 )
 
         if debug_mode:
@@ -800,6 +800,7 @@ def inject_debug_block(content: str, agent_name: str) -> str:
 
 def _transform_frontmatter_for_opencode(
     content: str,
+    name: str,
     description: str,
     model: str,
     generated_from: str,
@@ -807,6 +808,7 @@ def _transform_frontmatter_for_opencode(
     """Build opencode-native agent frontmatter.
 
     opencode frontmatter schema (all others stripped):
+      name: <role>             (required — used to invoke the agent)
       description: "..."       (required)
       mode: subagent           (all agent-meta agents are subagents)
       model: provider/model-id (optional — only when tier maps to a model ID)
@@ -815,7 +817,7 @@ def _transform_frontmatter_for_opencode(
     body = _strip_frontmatter(content)
     body = _strip_claude_specific_lines(body)
 
-    lines = [f'description: "{description}"', 'mode: subagent']
+    lines = [f'name: {name}', f'description: "{description}"', 'mode: subagent']
     if model:
         lines.append(f'model: {model}')
     if generated_from:

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -304,8 +304,6 @@ def main():
             init_claude_personal(agent_meta_root, project_root, log, args.dry_run)
             init_settings_json(project_root, log, args.dry_run)
             init_settings_local_json(project_root, log, args.dry_run)
-        if args.init:
-            init_secrets_template(agent_meta_root, project_root, config, log, args.dry_run)
             claude_pc = provider_config.get("Claude", {})
             gitignore_cfg = config.get("gitignore", {})
             # local: true (default) — personal/local files are gitignored
@@ -341,6 +339,8 @@ def main():
                         base_gitignore_entries.append(_ctx)
             # Skill gitignore entries are collected after skills are processed (below)
             # and merged via exact_entries so stale entries are removed automatically.
+        if args.init:
+            init_secrets_template(agent_meta_root, project_root, config, log, args.dry_run)
         # Per-provider sync
         debug_mode = config.get("debug-mode", False)
         if debug_mode:


### PR DESCRIPTION
## Summary

- Fixes `_transform_frontmatter_for_opencode()` in `scripts/lib/agents.py` to include the required `name:` field in Opencode agent frontmatter
- The `name` field is inserted as the first entry (before `description`), matching Opencode convention
- Also fixes a regression in `sync.py` where `base_gitignore_entries` was scoped inside `if args.init:` instead of `if args.init or is_claude:`, causing an `UnboundLocalError` on regular sync runs

## Test plan

- [ ] Run `sync.py` — no `UnboundLocalError`
- [ ] Verify all `.opencode/agents/*.md` contain `name: <role>` as the first frontmatter field
- [ ] Invoke an Opencode agent by name to confirm it is discoverable

Closes #74

🤖 Generated with [Claude Code](https://claude.ai/claude-code)