### PR TITLE
feat: add provider isolation for multi-provider projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .claude/settings.local.json
 .input/
+.local/
 CLAUDE.personal.md
 sync.log
 

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -3,6 +3,11 @@
 
 agent-meta-version: 0.34.2
 
+# agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
+# Provider isolation must be disabled here — the meta-repo intentionally
+# reads and writes all provider directories during sync.
+provider-isolation: disabled
+
 ai-providers:
   - Claude
   - Continue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,11 +142,39 @@ Nur auf Grep/Glob/Read zurückfallen wenn der Graph nicht ausreicht.
 
 ---
 
+## Provider-Isolation (Framework-Feature)
+
+Wenn mehrere AI-Provider in einem Projekt aktiv sind, generiert `sync.py` automatisch Hard-Blocks die verhindern dass ein Provider die Verzeichnisse eines anderen liest oder schreibt.
+
+### Aktivierung
+
+Automatisch aktiv wenn `>1 Provider` in `ai-providers` konfiguriert ist. Keine explizite Aktivierung nötig.
+
+### Deaktivieren (Opt-out)
+
+```yaml
+# .meta-config/project.yaml
+provider-isolation: disabled
+```
+
+Sinnvoll für das agent-meta Meta-Repository selbst, das alle Provider-Verzeichnisse verwalten muss.
+
+### Generierte Artefakte pro Provider
+
+| Provider | Mechanismus | Datei |
+|---|---|---|
+| Claude | `permissions.deny` (Glob) | `.claude/settings.json` |
+| Opencode | `permission.read/edit` deny (Glob) | `opencode.json` |
+| Gemini | TOML-Policy-Rules (Regex) | `.gemini/policies/provider-isolation.toml` |
+| Continue | Soft-Rule (kein nativer Hard-Block in IDE-Extensions) | `.continue/rules/provider-isolation.md` |
+
+---
+
 <!-- agent-meta:managed-begin -->
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.34.2 — `2026-05-08`
+Generiert von agent-meta v0.35.0 — `2026-05-08`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -11,6 +11,7 @@ providers:
     settings_file: .claude/settings.json
     isolation-dirs:
       - .claude/
+      - CLAUDE.md
     gitignore_entries:
       - .claude/settings.local.json
       - .claude/agent-memory-local/

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -9,6 +9,8 @@ providers:
     has_commands: true
     has_settings: true
     settings_file: .claude/settings.json
+    isolation-dirs:
+      - .claude/
     gitignore_entries:
       - .claude/settings.local.json
       - .claude/agent-memory-local/
@@ -50,6 +52,8 @@ providers:
     has_settings: true
     settings_file: .gemini/settings.json
     settings_template: howto/configs/GEMINI.settings-template.json
+    isolation-dirs:
+      - .gemini/
     gitignore_entries:
       - .gemini/settings.local.json
     mcp-config:
@@ -76,6 +80,10 @@ providers:
     has_settings: true
     settings_file: opencode.json
     settings_template: howto/configs/OPENCODE.settings-template.json
+    isolation-dirs:
+      - .opencode/
+      - opencode.json
+      - AGENTS.md
     gitignore_entries:
       - AGENTS.personal.md
       - .opencode/settings.local.json
@@ -108,6 +116,8 @@ providers:
     has_settings: true
     settings_file: .continue/config.yaml
     settings_template: howto/configs/CONTINUE.config-template.yaml
+    isolation-dirs:
+      - .continue/
     gitignore_entries:
       - .continue/settings.local.yaml
     mcp-config:

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -447,6 +447,11 @@
       },
       "uniqueItems": true
     },
+    "provider-isolation": {
+      "type": "string",
+      "enum": ["disabled"],
+      "description": "Set to 'disabled' to skip provider isolation generation (e.g. in the agent-meta meta-repo itself, which intentionally manages all provider directories)."
+    },
     "allow-committed-secrets": {
       "type": "boolean",
       "description": "Allow sync.py to write files containing detected secrets to committed (non-gitignored) paths. Default: false — sync aborts with an error when a secret is detected in a committed file. Set to true only when you deliberately commit secret-looking values (e.g. static demo tokens). NOT recommended for production projects.",

--- a/scripts/lib/isolation.py
+++ b/scripts/lib/isolation.py
@@ -21,11 +21,13 @@ from pathlib import Path
 from .io import safe_path, write_checked
 from .log import SyncLog
 
-# Marker keys used to track agent-meta-managed isolation entries in JSON configs.
-# These allow the managed entries to be replaced cleanly on subsequent syncs.
-_CLAUDE_ISOLATION_KEY = "_agent-meta-isolation"
-_OPENCODE_ISOLATION_READ_KEY = "_agent-meta-isolation-read"
-_OPENCODE_ISOLATION_EDIT_KEY = "_agent-meta-isolation-edit"
+# Companion state files — store agent-meta tracking data outside tool JSON schemas.
+# Both Claude Code and Opencode use strict schema validation (Zod .strict() /
+# JSON Schema) and reject unknown root keys, making the entire config file invalid.
+# Tracking data is therefore stored in separate companion files that are not
+# subject to those schemas.
+_CLAUDE_STATE_FILE = ".claude/agent-meta-state.json"
+_OPENCODE_STATE_FILE = ".opencode/agent-meta-state.json"
 
 _GEMINI_POLICIES_DIR = ".gemini/policies"
 _GEMINI_ISOLATION_FILE = ".gemini/policies/provider-isolation.toml"
@@ -88,21 +90,49 @@ def sync_provider_isolation(
 # JSON helpers (shared by Claude and Opencode)
 # ---------------------------------------------------------------------------
 
-def _read_json_lenient(path: Path) -> dict | None:
+def _read_json_safe(path: Path, log: SyncLog | None = None) -> dict | None:
     """Read a JSON file, tolerating JSONC-style // line comments.
 
-    Returns None if the file does not exist or cannot be parsed.
+    Returns None if the file does not exist.
+    Returns None (with a warning) if the file exists but cannot be parsed —
+    callers must skip their update to avoid silent data loss.
     """
     if not path.exists():
         return None
     text = path.read_text(encoding="utf-8")
-    # Strip // line comments (not inside strings — sufficient for settings files)
     stripped = re.sub(r'(?m)^\s*//.*$', '', text)
     stripped = re.sub(r'\s*//[^"]*$', '', stripped, flags=re.MULTILINE)
     try:
         return json.loads(stripped)
     except (json.JSONDecodeError, ValueError):
+        if log:
+            log.warn(f"{path.name}: could not parse JSON — skipping isolation update to avoid data loss")
         return None
+
+
+def _read_state(state_path: Path) -> list[str]:
+    """Read previously managed isolation glob patterns from a companion state file.
+
+    Returns an empty list when the file does not exist or cannot be parsed.
+    """
+    if not state_path.exists():
+        return []
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+        return data.get("isolation-deny", [])
+    except (json.JSONDecodeError, ValueError, KeyError):
+        return []
+
+
+def _write_state(state_path: Path, managed_patterns: list[str], dry_run: bool) -> None:
+    """Write managed isolation patterns to a companion state file."""
+    if dry_run:
+        return
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"isolation-deny": managed_patterns}, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _dir_to_glob(directory: str) -> str:
@@ -130,47 +160,47 @@ def _sync_claude_isolation(
 ) -> None:
     """Inject/replace provider isolation entries in .claude/settings.json.
 
+    Tracking data (previously managed patterns) is stored in a companion file
+    .claude/agent-meta-state.json to avoid polluting settings.json with unknown
+    root keys — Claude Code rejects the entire file when unknown root keys are present.
+
     Strategy:
-    - Read existing settings.json (create skeleton when absent).
-    - Remove previously managed isolation entries tracked under _CLAUDE_ISOLATION_KEY.
-    - Build new deny patterns from foreign_dirs.
-    - Merge with existing user deny entries (those not in previous managed list).
-    - Write back with write_checked().
+    - Read previously managed patterns from companion state file.
+    - Read existing settings.json; skip on parse error (data-loss guard).
+    - Remove old managed deny entries from permissions.deny.
+    - Append new managed entries; write settings.json + state file.
     """
     settings_path = safe_path(project_root, ".claude", "settings.json")
+    state_path = safe_path(project_root, _CLAUDE_STATE_FILE)
 
-    existing = _read_json_lenient(settings_path) or {}
-
-    # Retrieve previously managed isolation deny patterns
-    prev_managed: list[str] = existing.pop(_CLAUDE_ISOLATION_KEY, [])
-
-    # Build new managed patterns
+    prev_managed = _read_state(state_path)
     new_managed: list[str] = [_dir_to_glob(d) for d in foreign_dirs]
 
-    # Current user deny list (anything NOT in the previous managed set)
+    existing = _read_json_safe(settings_path, log)
+    if existing is None and settings_path.exists():
+        return  # parse error — warning already emitted, skip to avoid data loss
+    existing = existing or {}
+
     permissions = existing.setdefault("permissions", {})
     current_deny: list[str] = permissions.get("deny", [])
     user_deny = [p for p in current_deny if p not in prev_managed]
+    permissions["deny"] = user_deny + new_managed
 
-    # Merge: user entries first, then managed isolation entries
-    merged_deny = user_deny + new_managed
-
-    permissions["deny"] = merged_deny
-    # Store managed patterns for future sync runs (allows clean replacement)
-    existing[_CLAUDE_ISOLATION_KEY] = new_managed
-
-    content = json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
-    rel = ".claude/settings.json"
+    settings_content = json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
+    rel_settings = ".claude/settings.json"
+    rel_state = _CLAUDE_STATE_FILE
 
     if dry_run:
-        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed)}")
+        log.action("WRITE", rel_settings, f"provider-isolation deny: {', '.join(new_managed)}")
+        log.action("WRITE", rel_state, "provider-isolation state")
         return
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    if write_checked(settings_path, content, log, rel):
-        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed)}")
+    if write_checked(settings_path, settings_content, log, rel_settings):
+        log.action("WRITE", rel_settings, f"provider-isolation deny: {', '.join(new_managed)}")
     else:
-        log.skip(rel, "provider-isolation unchanged")
+        log.skip(rel_settings, "provider-isolation unchanged")
+    _write_state(state_path, new_managed, dry_run)
 
 
 # ---------------------------------------------------------------------------
@@ -185,60 +215,49 @@ def _sync_opencode_isolation(
 ) -> None:
     """Inject/replace provider isolation entries in opencode.json.
 
+    Tracking data is stored in .opencode/agent-meta-state.json to avoid
+    polluting opencode.json with unknown root keys — Opencode uses Zod .strict()
+    validation and rejects the entire config when unknown root keys are present.
+
     opencode uses last-match-wins glob permission rules.
-    We add deny entries under permission.read and permission.edit for each
-    foreign directory. Previously managed entries (tracked via special keys)
-    are replaced cleanly on each sync.
     """
     settings_path = safe_path(project_root, "opencode.json")
+    state_path = safe_path(project_root, _OPENCODE_STATE_FILE)
 
-    existing = _read_json_lenient(settings_path) or {}
+    prev_managed = _read_state(state_path)
+    new_entries: dict[str, str] = {_dir_to_glob(d): "deny" for d in foreign_dirs}
+    new_managed_keys = list(new_entries.keys())
 
-    # Retrieve previously managed keys
-    prev_read_keys: list[str] = existing.pop(_OPENCODE_ISOLATION_READ_KEY, [])
-    prev_edit_keys: list[str] = existing.pop(_OPENCODE_ISOLATION_EDIT_KEY, [])
+    existing = _read_json_safe(settings_path, log)
+    if existing is None and settings_path.exists():
+        return  # parse error — warning already emitted, skip to avoid data loss
+    existing = existing or {}
 
-    # Build new managed glob→deny entries
-    new_entries: dict[str, str] = {}
-    for d in foreign_dirs:
-        glob_key = _dir_to_glob(d)
-        new_entries[glob_key] = "deny"
-
-    # Clean previously managed entries from permission.read and permission.edit
     permission = existing.setdefault("permission", {})
-
-    read_perms: dict[str, str] = dict(permission.get("read", {}))
-    edit_perms: dict[str, str] = dict(permission.get("edit", {}))
-
-    for k in prev_read_keys:
-        read_perms.pop(k, None)
-    for k in prev_edit_keys:
-        edit_perms.pop(k, None)
-
-    # Append new managed entries (last-match-wins — place at end)
+    read_perms: dict[str, str] = {k: v for k, v in permission.get("read", {}).items()
+                                   if k not in prev_managed}
+    edit_perms: dict[str, str] = {k: v for k, v in permission.get("edit", {}).items()
+                                   if k not in prev_managed}
     read_perms.update(new_entries)
     edit_perms.update(new_entries)
-
     permission["read"] = read_perms
     permission["edit"] = edit_perms
 
-    # Track managed keys for next sync
-    new_managed_keys = list(new_entries.keys())
-    existing[_OPENCODE_ISOLATION_READ_KEY] = new_managed_keys
-    existing[_OPENCODE_ISOLATION_EDIT_KEY] = new_managed_keys
-
-    content = json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
-    rel = "opencode.json"
+    settings_content = json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
+    rel_settings = "opencode.json"
+    rel_state = _OPENCODE_STATE_FILE
 
     if dry_run:
-        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed_keys)}")
+        log.action("WRITE", rel_settings, f"provider-isolation deny: {', '.join(new_managed_keys)}")
+        log.action("WRITE", rel_state, "provider-isolation state")
         return
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    if write_checked(settings_path, content, log, rel):
-        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed_keys)}")
+    if write_checked(settings_path, settings_content, log, rel_settings):
+        log.action("WRITE", rel_settings, f"provider-isolation deny: {', '.join(new_managed_keys)}")
     else:
-        log.skip(rel, "provider-isolation unchanged")
+        log.skip(rel_settings, "provider-isolation unchanged")
+    _write_state(state_path, new_managed_keys, dry_run)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/isolation.py
+++ b/scripts/lib/isolation.py
@@ -1,0 +1,369 @@
+"""Provider isolation: prevent AI providers from reading each other's directories.
+
+When multiple providers are active (e.g. Claude + Gemini + Opencode), sync.py
+generates hard-block configurations so each provider cannot read or write files
+managed by other providers.
+
+Mechanisms per provider:
+  Claude   — permissions.deny in .claude/settings.json (glob patterns)
+  Opencode — permission.read + permission.edit in opencode.json (glob patterns, last-match-wins)
+  Gemini   — TOML policy file .gemini/policies/provider-isolation.toml (regex on tool arguments)
+  Continue — soft rule .continue/rules/provider-isolation.md (no native hard block available)
+
+Trigger: only when len(active_providers) > 1 AND project.yaml does not have
+provider-isolation: disabled.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from .io import safe_path, write_checked
+from .log import SyncLog
+
+# Marker keys used to track agent-meta-managed isolation entries in JSON configs.
+# These allow the managed entries to be replaced cleanly on subsequent syncs.
+_CLAUDE_ISOLATION_KEY = "_agent-meta-isolation"
+_OPENCODE_ISOLATION_READ_KEY = "_agent-meta-isolation-read"
+_OPENCODE_ISOLATION_EDIT_KEY = "_agent-meta-isolation-edit"
+
+_GEMINI_POLICIES_DIR = ".gemini/policies"
+_GEMINI_ISOLATION_FILE = ".gemini/policies/provider-isolation.toml"
+_CONTINUE_ISOLATION_FILE = ".continue/rules/provider-isolation.md"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def sync_provider_isolation(
+    project_root: Path,
+    providers: list[str],
+    provider_config: dict,
+    log: SyncLog,
+    dry_run: bool,
+) -> None:
+    """Generate provider isolation blocks for all active providers.
+
+    Does nothing when fewer than 2 providers are active (no cross-provider
+    isolation needed).
+    """
+    if len(providers) < 2:
+        log.skip("provider-isolation", f"only {len(providers)} provider active — skipping")
+        return
+
+    log.info("provider-isolation", f"generating isolation for: {', '.join(providers)}")
+
+    for provider in providers:
+        pc = provider_config.get(provider, {})
+        own_dirs: list[str] = pc.get("isolation-dirs", [])
+
+        # foreign_dirs = isolation-dirs of all OTHER active providers
+        foreign_dirs: list[str] = []
+        for other in providers:
+            if other == provider:
+                continue
+            other_pc = provider_config.get(other, {})
+            for d in other_pc.get("isolation-dirs", []):
+                if d not in foreign_dirs:
+                    foreign_dirs.append(d)
+
+        if not foreign_dirs:
+            log.skip(f"provider-isolation/{provider}", "no foreign dirs found")
+            continue
+
+        if provider == "Claude":
+            _sync_claude_isolation(project_root, foreign_dirs, log, dry_run)
+        elif provider == "Opencode":
+            _sync_opencode_isolation(project_root, foreign_dirs, log, dry_run)
+        elif provider == "Gemini":
+            _sync_gemini_isolation(project_root, foreign_dirs, log, dry_run)
+        elif provider == "Continue":
+            _sync_continue_isolation(project_root, foreign_dirs, log, dry_run)
+        else:
+            log.skip(f"provider-isolation/{provider}", "no isolation mechanism defined for this provider")
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers (shared by Claude and Opencode)
+# ---------------------------------------------------------------------------
+
+def _read_json_lenient(path: Path) -> dict | None:
+    """Read a JSON file, tolerating JSONC-style // line comments.
+
+    Returns None if the file does not exist or cannot be parsed.
+    """
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    # Strip // line comments (not inside strings — sufficient for settings files)
+    stripped = re.sub(r'(?m)^\s*//.*$', '', text)
+    stripped = re.sub(r'\s*//[^"]*$', '', stripped, flags=re.MULTILINE)
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _dir_to_glob(directory: str) -> str:
+    """Convert an isolation-dir path to a glob pattern.
+
+    Examples:
+      '.claude/'    → '.claude/**'
+      'opencode.json' → 'opencode.json'   (exact file, no ** needed)
+      'AGENTS.md'   → 'AGENTS.md'
+    """
+    if directory.endswith("/"):
+        return directory + "**"
+    return directory
+
+
+# ---------------------------------------------------------------------------
+# Claude: permissions.deny in .claude/settings.json
+# ---------------------------------------------------------------------------
+
+def _sync_claude_isolation(
+    project_root: Path,
+    foreign_dirs: list[str],
+    log: SyncLog,
+    dry_run: bool,
+) -> None:
+    """Inject/replace provider isolation entries in .claude/settings.json.
+
+    Strategy:
+    - Read existing settings.json (create skeleton when absent).
+    - Remove previously managed isolation entries tracked under _CLAUDE_ISOLATION_KEY.
+    - Build new deny patterns from foreign_dirs.
+    - Merge with existing user deny entries (those not in previous managed list).
+    - Write back with write_checked().
+    """
+    settings_path = safe_path(project_root, ".claude", "settings.json")
+
+    existing = _read_json_lenient(settings_path) or {}
+
+    # Retrieve previously managed isolation deny patterns
+    prev_managed: list[str] = existing.pop(_CLAUDE_ISOLATION_KEY, [])
+
+    # Build new managed patterns
+    new_managed: list[str] = [_dir_to_glob(d) for d in foreign_dirs]
+
+    # Current user deny list (anything NOT in the previous managed set)
+    permissions = existing.setdefault("permissions", {})
+    current_deny: list[str] = permissions.get("deny", [])
+    user_deny = [p for p in current_deny if p not in prev_managed]
+
+    # Merge: user entries first, then managed isolation entries
+    merged_deny = user_deny + new_managed
+
+    permissions["deny"] = merged_deny
+    # Store managed patterns for future sync runs (allows clean replacement)
+    existing[_CLAUDE_ISOLATION_KEY] = new_managed
+
+    content = json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
+    rel = ".claude/settings.json"
+
+    if dry_run:
+        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed)}")
+        return
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    if write_checked(settings_path, content, log, rel):
+        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed)}")
+    else:
+        log.skip(rel, "provider-isolation unchanged")
+
+
+# ---------------------------------------------------------------------------
+# Opencode: permission.read + permission.edit in opencode.json
+# ---------------------------------------------------------------------------
+
+def _sync_opencode_isolation(
+    project_root: Path,
+    foreign_dirs: list[str],
+    log: SyncLog,
+    dry_run: bool,
+) -> None:
+    """Inject/replace provider isolation entries in opencode.json.
+
+    opencode uses last-match-wins glob permission rules.
+    We add deny entries under permission.read and permission.edit for each
+    foreign directory. Previously managed entries (tracked via special keys)
+    are replaced cleanly on each sync.
+    """
+    settings_path = safe_path(project_root, "opencode.json")
+
+    existing = _read_json_lenient(settings_path) or {}
+
+    # Retrieve previously managed keys
+    prev_read_keys: list[str] = existing.pop(_OPENCODE_ISOLATION_READ_KEY, [])
+    prev_edit_keys: list[str] = existing.pop(_OPENCODE_ISOLATION_EDIT_KEY, [])
+
+    # Build new managed glob→deny entries
+    new_entries: dict[str, str] = {}
+    for d in foreign_dirs:
+        glob_key = _dir_to_glob(d)
+        new_entries[glob_key] = "deny"
+
+    # Clean previously managed entries from permission.read and permission.edit
+    permission = existing.setdefault("permission", {})
+
+    read_perms: dict[str, str] = dict(permission.get("read", {}))
+    edit_perms: dict[str, str] = dict(permission.get("edit", {}))
+
+    for k in prev_read_keys:
+        read_perms.pop(k, None)
+    for k in prev_edit_keys:
+        edit_perms.pop(k, None)
+
+    # Append new managed entries (last-match-wins — place at end)
+    read_perms.update(new_entries)
+    edit_perms.update(new_entries)
+
+    permission["read"] = read_perms
+    permission["edit"] = edit_perms
+
+    # Track managed keys for next sync
+    new_managed_keys = list(new_entries.keys())
+    existing[_OPENCODE_ISOLATION_READ_KEY] = new_managed_keys
+    existing[_OPENCODE_ISOLATION_EDIT_KEY] = new_managed_keys
+
+    content = json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
+    rel = "opencode.json"
+
+    if dry_run:
+        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed_keys)}")
+        return
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    if write_checked(settings_path, content, log, rel):
+        log.action("WRITE", rel, f"provider-isolation deny: {', '.join(new_managed_keys)}")
+    else:
+        log.skip(rel, "provider-isolation unchanged")
+
+
+# ---------------------------------------------------------------------------
+# Gemini: TOML policy file .gemini/policies/provider-isolation.toml
+# ---------------------------------------------------------------------------
+
+def _build_gemini_toml_rule(directory: str, priority_offset: int) -> str:
+    """Build a single [[rule]] TOML block for a foreign directory.
+
+    Gemini policy rules match on tool argument patterns (regex on JSON-serialised
+    arguments). The argsPattern targets file_path and path keys commonly used by
+    file-reading and file-writing tools.
+    """
+    # Escape the directory path for use as a TOML inline string and regex literal
+    # Dots must be escaped in regex; slashes are literal
+    pattern_dir = re.escape(directory).replace("/", "/")
+
+    # Build the deny message — strip trailing slash for readability
+    display_dir = directory.rstrip("/")
+    provider_name = _guess_provider_name_from_dir(directory)
+
+    priority = 900 + priority_offset
+
+    lines = [
+        "[[rule]]",
+        'toolName = ["read_file", "write_file", "replace", "list_directory"]',
+        f'argsPattern = \'"(?:file_path|path)":"[^"]*{pattern_dir}\'',
+        'decision = "deny"',
+        f"priority = {priority}",
+        f'denyMessage = "Provider isolation: {display_dir} is managed by {provider_name} only."',
+    ]
+    return "\n".join(lines)
+
+
+def _guess_provider_name_from_dir(directory: str) -> str:
+    """Infer the owning provider name from the directory path."""
+    d = directory.lower().rstrip("/")
+    if ".claude" in d:
+        return "Claude Code"
+    if ".gemini" in d:
+        return "Gemini CLI"
+    if ".opencode" in d or "opencode" in d or "agents.md" in d:
+        return "Opencode"
+    if ".continue" in d:
+        return "Continue"
+    return "another provider"
+
+
+def _sync_gemini_isolation(
+    project_root: Path,
+    foreign_dirs: list[str],
+    log: SyncLog,
+    dry_run: bool,
+) -> None:
+    """Generate .gemini/policies/provider-isolation.toml with one rule per foreign dir."""
+    target_path = safe_path(project_root, _GEMINI_ISOLATION_FILE)
+    rel = _GEMINI_ISOLATION_FILE
+
+    rule_blocks = []
+    for idx, d in enumerate(foreign_dirs):
+        rule_blocks.append(_build_gemini_toml_rule(d, idx))
+
+    content_lines = [
+        "# agent-meta managed — do not edit manually",
+        "# Generated by sync.py — provider isolation rules for Gemini CLI",
+        "# One [[rule]] block per foreign provider directory.",
+        "",
+    ]
+    content_lines.extend("\n".join(rule_blocks[i:i+1]) for i in range(len(rule_blocks)))
+    content = "\n\n".join(content_lines[:4] + rule_blocks) + "\n"
+
+    if dry_run:
+        log.action("WRITE", rel, f"provider-isolation ({len(foreign_dirs)} rule(s))")
+        return
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    if write_checked(target_path, content, log, rel):
+        log.action("WRITE", rel, f"provider-isolation ({len(foreign_dirs)} rule(s))")
+    else:
+        log.skip(rel, "provider-isolation unchanged")
+
+
+# ---------------------------------------------------------------------------
+# Continue: soft rule .continue/rules/provider-isolation.md
+# ---------------------------------------------------------------------------
+
+def _sync_continue_isolation(
+    project_root: Path,
+    foreign_dirs: list[str],
+    log: SyncLog,
+    dry_run: bool,
+) -> None:
+    """Generate .continue/rules/provider-isolation.md (soft guidance, no native hard block)."""
+    target_path = safe_path(project_root, _CONTINUE_ISOLATION_FILE)
+    rel = _CONTINUE_ISOLATION_FILE
+
+    # Build list items grouped by provider
+    dir_lines = []
+    for d in foreign_dirs:
+        provider_name = _guess_provider_name_from_dir(d)
+        display = d.rstrip("/")
+        dir_lines.append(f"- `{display}` — {provider_name} only")
+
+    dirs_block = "\n".join(dir_lines)
+
+    content = (
+        "# Provider Isolation\n"
+        "\n"
+        "This project uses multiple AI providers. Do not read or write files in directories\n"
+        "managed by other providers:\n"
+        "\n"
+        f"{dirs_block}\n"
+        "\n"
+        "Only read files in your own provider directory (`.continue/`) unless explicitly\n"
+        "asked by the user to inspect another provider's configuration.\n"
+        "\n"
+        "<!-- agent-meta managed — do not edit manually -->\n"
+    )
+
+    if dry_run:
+        log.action("WRITE", rel, f"provider-isolation ({len(foreign_dirs)} dir(s))")
+        return
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    if write_checked(target_path, content, log, rel):
+        log.action("WRITE", rel, f"provider-isolation ({len(foreign_dirs)} dir(s))")
+    else:
+        log.skip(rel, "provider-isolation unchanged")

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -64,6 +64,7 @@ from lib.skills import (
 )
 from lib.extensions import create_extension, update_extensions
 from lib.mcp import generate_mcp_artifacts, resolve_active_mcp_servers, init_secrets_template
+from lib.isolation import sync_provider_isolation
 from lib.io import SyncError
 from lib.context import (
     sync_context_for_provider, init_claude_personal, init_opencode_personal,
@@ -389,6 +390,12 @@ def main():
                                            provider_config=provider_config,
                                            variables=variables)
         sync_snippets(agent_meta_root, project_root, config, log, args.dry_run)
+        # Provider isolation: hard-block cross-provider directory access
+        isolation_mode = config.get("provider-isolation")
+        if isolation_mode != "disabled":
+            sync_provider_isolation(project_root, providers, provider_config, log, args.dry_run)
+        else:
+            log.skip("provider-isolation", "disabled in project.yaml")
         # Check pinned commits + warn for unknown/unapproved skills in project config
         ext_config = load_external_skills_config(agent_meta_root)
         check_pinned_commits(ext_config, agent_meta_root, log)


### PR DESCRIPTION
## Summary

- When multiple AI providers are active in a project, sync.py now automatically generates hard-block configurations to prevent each provider from reading other providers' directories
- New module `scripts/lib/isolation.py` with provider-specific implementations
- `provider-isolation: disabled` flag in `project.yaml` to opt out (used by agent-meta itself)

## Mechanism per provider

| Provider | Hard-Block | Where |
|---|---|---|
| Claude | `permissions.deny` (glob) | `.claude/settings.json` |
| Opencode | `permission.read` + `permission.edit` deny (glob) | `opencode.json` |
| Gemini | TOML policy rules (regex on tool args) | `.gemini/policies/provider-isolation.toml` |
| Continue | Soft rule (no native hard block in IDE extensions) | `.continue/rules/provider-isolation.md` |

## Managed block strategy

Previously generated isolation entries are tracked via marker keys (`_agent-meta-isolation`) in JSON configs, so they can be cleanly replaced on each subsequent sync without touching user-defined entries.

## Test plan

- [ ] Project with 1 provider: isolation skipped
- [ ] Project with 2+ providers: all provider-specific artifacts generated
- [ ] `provider-isolation: disabled`: skip message logged, no artifacts generated
- [ ] Re-running sync: idempotent (no unnecessary writes)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)