### PR TITLE
feat: add /diagnose, /add-provider and /add-project-role commands

### DIFF
--- a/.claude/commands/add-mcp-server.md
+++ b/.claude/commands/add-mcp-server.md
@@ -1,0 +1,55 @@
+---
+description: Guided setup to activate an MCP server in this project
+allowed-tools: ["Bash", "Read", "Edit"]
+argument-hint: "<server-name from mcp-registry.yaml>"
+---
+
+Activate an MCP server for this project. $ARGUMENTS
+
+**Step 0 — Check for missing input**
+
+Read `.agent-meta/config/mcp-registry.yaml` and extract all server names (top-level keys under `servers:`).
+Read `.meta-config/project.yaml` and extract currently active `mcp-servers:` entries.
+
+Show the user:
+- Already active MCP servers (skip these)
+- Available servers from the registry with a one-line description each
+
+If $ARGUMENTS is empty or does not match any registry entry:
+> "Which MCP server would you like to activate? Available servers:"
+> [list available servers with descriptions]
+> "Please type the server name to continue."
+Stop here and wait for the user to respond. Do not proceed until a valid server name is provided.
+
+**Step 1 — Validate selection**
+
+Confirm the chosen server name exists in the registry. If not:
+> "Server '<name>' is not in the registry. Available: [list]. Did you mean one of these?"
+Stop and wait for correction.
+
+**Step 2 — Check secrets**
+
+Read the `secrets:` block for the chosen server in `mcp-registry.yaml`.
+If secrets are required:
+- Check if `.meta-config/secrets.local.yaml` exists
+- Show the user which environment variables or secrets need to be set:
+  > "This server requires the following secrets. Add them to `.meta-config/secrets.local.yaml`:"
+  > [list each secret key and its description]
+  > "Have you added the secrets? (yes/no)"
+- If no: stop and wait. Remind that `.meta-config/secrets.local.yaml` is gitignored and safe for credentials.
+- If yes: continue.
+
+**Step 3 — Activate**
+
+Add the server name to `mcp-servers:` in `.meta-config/project.yaml`.
+Run: `python .agent-meta/scripts/sync.py`
+
+**Step 4 — Report**
+
+Show which files were generated per active provider:
+- Rule files (e.g. `.claude/rules/mcp-<server>.md`)
+- Provider config updates (e.g. `mcpServers` entries in `.claude/settings.json`)
+- Any warnings from the sync log
+
+Finish with:
+> "MCP server '<name>' is now active. Restart your AI provider to pick up the new tools."

--- a/.claude/commands/add-project-role.md
+++ b/.claude/commands/add-project-role.md
@@ -1,0 +1,62 @@
+---
+description: Add a project-specific agent role (override or extension) to this project
+allowed-tools: ["Bash", "Read", "Edit"]
+argument-hint: "[role name, e.g. security-auditor]"
+---
+
+Add a project-specific agent role to this project. $ARGUMENTS
+
+**Step 1 — Identify the role**
+
+If $ARGUMENTS provides a role name, use it. Otherwise ask the user which role they want to add.
+
+Check which roles are already available:
+- Run `python .agent-meta/scripts/sync.py --dry-run` and look at generated agent files
+- Read `.meta-config/project.yaml` → `roles:` block to see active roles
+
+**Step 2 — Choose the mode**
+
+Ask the user:
+
+> Two modes are available:
+>
+> **Extension** (recommended): Adds project-specific content ON TOP of the generic agent.
+> The generic agent is still generated and updated by sync. Your additions live in
+> `.claude/3-project/<role>-ext.md` and are loaded automatically.
+> Use this for: adding project context, domain knowledge, additional instructions.
+>
+> **Override**: Replaces the generic agent entirely with your own version.
+> sync.py will NOT touch the file after creation. You own it fully.
+> Use this for: completely custom roles, or when the generic agent doesn't fit at all.
+
+**Step 3 — Create the file**
+
+For **Extension**:
+Run: `python .agent-meta/scripts/sync.py --create-ext <role>`
+This generates `.claude/3-project/<role>-ext.md` with a managed block showing what the base agent provides, and a free section for project additions.
+
+For **Override**:
+Run: `python .agent-meta/scripts/sync.py --create-ext <role>` first to see the base content,
+then create `.claude/3-project/<role>.md` (without `-ext`) with the full custom content.
+Inform the user: "This file is yours — sync.py will never overwrite it."
+
+**Step 4 — If the role doesn't exist in agent-meta at all**
+
+If the role name is not found in the generic agents:
+- Inform the user: "This role has no generic base in agent-meta."
+- For Override: create `.claude/3-project/<role>.md` with a starter template:
+  ```
+  ---
+  name: <role>
+  description: "<brief description>"
+  ---
+  # <Role>
+
+  <Instructions for this agent>
+  ```
+- For Extension: explain that an extension without a base agent has no effect — suggest Override instead or filing a feature request via `/meta-feedback`.
+
+**Step 5 — Sync and confirm**
+
+Run `python .agent-meta/scripts/sync.py` and confirm the new file is active.
+Show the user the file path and remind them: "Edit this file directly — it's yours to customize."

--- a/.claude/commands/add-provider.md
+++ b/.claude/commands/add-provider.md
@@ -1,0 +1,51 @@
+---
+description: Add an AI provider to this project or request a new one via GitHub issue
+allowed-tools: ["Bash", "Read", "Edit", "Agent"]
+argument-hint: "[provider name, e.g. Gemini]"
+---
+
+Add an AI provider to this project. $ARGUMENTS
+
+**Step 1 — Discover available providers**
+
+Read `.agent-meta/config/ai-providers.yaml` and extract all provider names listed under `providers:`.
+Read `.meta-config/project.yaml` and extract the `ai-providers:` list (currently active providers).
+
+Show the user:
+- Already active providers (skip these)
+- Available providers from the registry (can be added immediately)
+
+**Step 2 — User decision**
+
+If $ARGUMENTS names a known provider from the registry → proceed to Step 3.
+If $ARGUMENTS names an unknown provider (not in registry) → proceed to Step 4.
+If no $ARGUMENTS → ask the user which provider they want to add, showing the available list.
+
+**Step 3 — Add known provider**
+
+1. Add the provider name to `ai-providers:` in `.meta-config/project.yaml`
+2. Run sync: `python .agent-meta/scripts/sync.py`
+3. Check sync output for warnings
+4. Report: which new files were generated (agents, rules, settings, isolation artifacts)
+5. If the provider requires secrets (e.g. API keys): show the relevant gitignored local config file path and what needs to be filled in
+
+**Step 4 — Request new provider via GitHub issue**
+
+The requested provider is not yet in the agent-meta registry. Before filing the issue, do a brief pre-analysis:
+
+- What is the provider's name and tool/CLI name?
+- Does it have a known agents directory convention?
+- Does it support rules/hooks/commands natively?
+- Does it have a known permission/deny mechanism for file access?
+- What model IDs does it use?
+
+Then delegate to the `meta-feedback` agent with this task:
+
+File a GitHub issue titled: "feat: add [ProviderName] as a supported AI provider"
+
+Body should include:
+- Provider name and CLI/tool name
+- Pre-analysis findings from above
+- Links to official docs if known
+- Requested capabilities: agents_dir, context_file, has_rules, has_hooks, has_settings, model-tiers
+- Label: "enhancement", "new-provider"

--- a/.claude/commands/diagnose.md
+++ b/.claude/commands/diagnose.md
@@ -1,0 +1,41 @@
+---
+description: Health-check the agent-meta setup — versions, generated files, isolation state, gitignore
+allowed-tools: ["Bash", "Read", "Glob"]
+argument-hint: "[area to focus on: versions | isolation | gitignore | all]"
+---
+
+Run a health check of the agent-meta setup for this project. $ARGUMENTS
+
+Work through these checks in order and report findings as ✅ OK / ⚠️ Warning / ❌ Error:
+
+**1. Sync status**
+Run `python .agent-meta/scripts/sync.py --dry-run` and report:
+- How many files would be written (WRITE actions) vs skipped
+- Any warnings in the output
+- If 0 WRITEs: "Generated files are up to date"
+- If WRITEs exist: list them — these files are out of sync
+
+**2. Version check**
+- Read `.agent-meta/VERSION` (agent-meta version)
+- Read `CLAUDE.md` managed block — find "Generiert von agent-meta vX.Y.Z"
+- If versions differ: ⚠️ "CLAUDE.md was generated with an older version — run sync"
+
+**3. Provider isolation**
+For each active provider in `.meta-config/project.yaml`:
+- Claude: check `.claude/agent-meta-state.json` exists and contains `isolation-deny` entries
+- Opencode: check `.opencode/agent-meta-state.json` exists and contains `isolation-deny` entries
+- Gemini: check `.gemini/policies/provider-isolation.toml` exists
+- Continue: check `.continue/rules/provider-isolation.md` exists
+- If `provider-isolation: disabled` in project.yaml → report "isolation disabled (opt-out)"
+- If only 1 provider active → report "isolation not needed (single provider)"
+
+**4. Gitignore completeness**
+Read `.gitignore` and verify the `# --- agent-meta managed ---` block exists and is non-empty.
+Check that `.meta-config/secrets.local.yaml` is gitignored (if the file exists).
+
+**5. MCP state** (if mcp-servers configured in project.yaml)
+Check that for each active MCP server, the expected rule files exist per active provider.
+
+Finish with a summary: total checks, how many ✅/⚠️/❌.
+If all OK: "Setup is healthy."
+If issues found: list actionable next steps.

--- a/.claude/commands/set-preset.md
+++ b/.claude/commands/set-preset.md
@@ -1,0 +1,65 @@
+---
+description: Change the DoD preset or speech mode of this project
+allowed-tools: ["Read", "Edit", "Bash"]
+argument-hint: "<preset: rapid-prototyping | standard | strict> or <speech: off | professional | submissive>"
+---
+
+Change the project preset or speech mode. $ARGUMENTS
+
+**Step 0 — Check for missing input**
+
+If $ARGUMENTS is empty:
+> "What would you like to change? Options:"
+>
+> **DoD Preset** (Definition of Done strictness):
+> - `rapid-prototyping` — no tests, no docs, no security audit required
+> - `standard` — tests required, docs recommended
+> - `strict` — tests + docs + security audit required, full REQ-traceability
+>
+> **Speech mode** (how agents communicate):
+> - `off` — neutral, professional tone
+> - `professional` — structured, formal
+> - `submissive` — deferential style ("Wie Ihr wünscht", "Meister")
+>
+> "Please type what you want to change, e.g.: `standard` or `speech: off`"
+
+Stop here and wait for input. Do not proceed until the user specifies what to change.
+
+**Step 1 — Parse the input**
+
+Determine from $ARGUMENTS (or the user's follow-up):
+- Is it a DoD preset? → look for `rapid-prototyping`, `standard`, `strict`
+- Is it a speech mode? → look for `off`, `professional`, `submissive` (with or without `speech:` prefix)
+- Unknown value:
+  > "Unknown option '<value>'. Valid DoD presets: rapid-prototyping, standard, strict.
+  > Valid speech modes: off, professional, submissive."
+  Stop.
+
+**Step 2 — Show current value and confirm**
+
+Read `.meta-config/project.yaml` and show the current value of the field being changed.
+
+> "Current: `<field>: <current-value>`
+> New: `<field>: <new-value>`
+> Proceed? (yes/no)"
+
+If no: stop.
+
+**Step 3 — Apply**
+
+Update the relevant field in `.meta-config/project.yaml`:
+- DoD preset → `dod-preset: <value>`
+- Speech mode → `speech-mode: <value>`
+
+Run: `python .agent-meta/scripts/sync.py`
+
+**Step 4 — Confirm**
+
+> "Done. `<field>` is now `<new-value>`.
+> The change takes effect immediately in all generated agent files."
+
+For DoD preset changes, briefly explain what is now required/relaxed:
+e.g. "Tests are now required before closing a task."
+
+For speech mode changes:
+e.g. "Agents will now respond in neutral professional tone."

--- a/.claude/commands/update-extensions.md
+++ b/.claude/commands/update-extensions.md
@@ -1,0 +1,54 @@
+---
+description: Update managed blocks in project extension files after an agent-meta upgrade
+allowed-tools: ["Bash", "Read"]
+argument-hint: "[role-name to update a single extension, or empty for all]"
+---
+
+Update the managed blocks in project extension files. $ARGUMENTS
+
+**Step 0 — Check context**
+
+Check if any extension files exist:
+```bash
+ls .claude/3-project/*-ext.md 2>/dev/null || echo "none"
+```
+
+If none found:
+> "No extension files found in `.claude/3-project/`. Nothing to update.
+> Use `/add-project-role` to create your first project-specific agent extension."
+Stop.
+
+**Step 1 — Targeted or full update**
+
+If $ARGUMENTS provides a role name:
+- Update only that extension: `python .agent-meta/scripts/sync.py --update-ext`
+  (sync.py --update-ext updates all extensions; note which role the user asked about)
+- After update, show only the diff for that file.
+
+If $ARGUMENTS is empty:
+- Update all extensions: `python .agent-meta/scripts/sync.py --update-ext`
+
+**Step 2 — Report changes**
+
+After the sync, run:
+```bash
+git diff .claude/3-project/
+```
+
+For each changed extension file, show:
+- File name
+- What changed in the managed block (added/removed sections from the base agent)
+- Confirm that the user's custom content (outside the managed block) was preserved
+
+If no changes:
+> "All extension managed blocks are already up to date."
+
+If changes found:
+> "The following extensions were updated with new content from the base agents:"
+> [list files with summary of changes]
+> "Your custom content in each file was preserved. Review the changes and commit when ready."
+
+**Step 3 — Suggest next step**
+
+If changes were made:
+> "Run `/diagnose` to verify the overall setup is healthy after the update."

--- a/.claude/commands/what-is.md
+++ b/.claude/commands/what-is.md
@@ -1,0 +1,47 @@
+---
+description: Explain what an agent does — its role, tools, and boundaries
+allowed-tools: ["Read", "Glob", "Bash"]
+argument-hint: "<agent-name, e.g. developer>"
+---
+
+Explain what the specified agent does. $ARGUMENTS
+
+**Step 0 — Check for missing input**
+
+If $ARGUMENTS is empty:
+> "Which agent would you like to know about? Available agents:"
+
+List all `.md` files in `.claude/agents/` (strip `.md` extension for display).
+
+> "Please type an agent name to continue."
+
+Stop here and wait for the user to respond.
+
+**Step 1 — Find the agent file**
+
+Look for `.claude/agents/<name>.md`. If not found:
+- Try case-insensitive match
+- If still not found:
+  > "Agent '<name>' not found. Available agents: [list]"
+  Stop.
+
+**Step 2 — Summarize**
+
+Read the agent file and produce a concise summary in this structure:
+
+**[Agent Name]** — `<description from frontmatter>`
+
+**Zuständigkeit:** [1-2 sentences: what does this agent own, what decisions does it make]
+
+**Tools:** [list tools from frontmatter, with one-word explanation each if non-obvious]
+
+**Wann einsetzen:**
+- [2-3 concrete trigger examples from the agent's instructions]
+
+**Wann NICHT einsetzen / Grenzen:**
+- [1-2 explicit limitations or handoff points]
+
+**Typischer Aufruf:**
+> [one realistic example prompt that would invoke this agent]
+
+Keep the summary to ~15 lines. No wall of text. The goal is that someone unfamiliar with this agent knows exactly when and how to use it after reading.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .claude/settings.local.json
 .input/
+.local/
 CLAUDE.personal.md
 sync.log
 

--- a/commands/1-generic/add-mcp-server.md
+++ b/commands/1-generic/add-mcp-server.md
@@ -1,0 +1,55 @@
+---
+description: Guided setup to activate an MCP server in this project
+allowed-tools: ["Bash", "Read", "Edit"]
+argument-hint: "<server-name from mcp-registry.yaml>"
+---
+
+Activate an MCP server for this project. $ARGUMENTS
+
+**Step 0 — Check for missing input**
+
+Read `.agent-meta/config/mcp-registry.yaml` and extract all server names (top-level keys under `servers:`).
+Read `.meta-config/project.yaml` and extract currently active `mcp-servers:` entries.
+
+Show the user:
+- Already active MCP servers (skip these)
+- Available servers from the registry with a one-line description each
+
+If $ARGUMENTS is empty or does not match any registry entry:
+> "Which MCP server would you like to activate? Available servers:"
+> [list available servers with descriptions]
+> "Please type the server name to continue."
+Stop here and wait for the user to respond. Do not proceed until a valid server name is provided.
+
+**Step 1 — Validate selection**
+
+Confirm the chosen server name exists in the registry. If not:
+> "Server '<name>' is not in the registry. Available: [list]. Did you mean one of these?"
+Stop and wait for correction.
+
+**Step 2 — Check secrets**
+
+Read the `secrets:` block for the chosen server in `mcp-registry.yaml`.
+If secrets are required:
+- Check if `.meta-config/secrets.local.yaml` exists
+- Show the user which environment variables or secrets need to be set:
+  > "This server requires the following secrets. Add them to `.meta-config/secrets.local.yaml`:"
+  > [list each secret key and its description]
+  > "Have you added the secrets? (yes/no)"
+- If no: stop and wait. Remind that `.meta-config/secrets.local.yaml` is gitignored and safe for credentials.
+- If yes: continue.
+
+**Step 3 — Activate**
+
+Add the server name to `mcp-servers:` in `.meta-config/project.yaml`.
+Run: `python .agent-meta/scripts/sync.py`
+
+**Step 4 — Report**
+
+Show which files were generated per active provider:
+- Rule files (e.g. `.claude/rules/mcp-<server>.md`)
+- Provider config updates (e.g. `mcpServers` entries in `.claude/settings.json`)
+- Any warnings from the sync log
+
+Finish with:
+> "MCP server '<name>' is now active. Restart your AI provider to pick up the new tools."

--- a/commands/1-generic/add-project-role.md
+++ b/commands/1-generic/add-project-role.md
@@ -1,0 +1,62 @@
+---
+description: Add a project-specific agent role (override or extension) to this project
+allowed-tools: ["Bash", "Read", "Edit"]
+argument-hint: "[role name, e.g. security-auditor]"
+---
+
+Add a project-specific agent role to this project. $ARGUMENTS
+
+**Step 1 — Identify the role**
+
+If $ARGUMENTS provides a role name, use it. Otherwise ask the user which role they want to add.
+
+Check which roles are already available:
+- Run `python .agent-meta/scripts/sync.py --dry-run` and look at generated agent files
+- Read `.meta-config/project.yaml` → `roles:` block to see active roles
+
+**Step 2 — Choose the mode**
+
+Ask the user:
+
+> Two modes are available:
+>
+> **Extension** (recommended): Adds project-specific content ON TOP of the generic agent.
+> The generic agent is still generated and updated by sync. Your additions live in
+> `.claude/3-project/<role>-ext.md` and are loaded automatically.
+> Use this for: adding project context, domain knowledge, additional instructions.
+>
+> **Override**: Replaces the generic agent entirely with your own version.
+> sync.py will NOT touch the file after creation. You own it fully.
+> Use this for: completely custom roles, or when the generic agent doesn't fit at all.
+
+**Step 3 — Create the file**
+
+For **Extension**:
+Run: `python .agent-meta/scripts/sync.py --create-ext <role>`
+This generates `.claude/3-project/<role>-ext.md` with a managed block showing what the base agent provides, and a free section for project additions.
+
+For **Override**:
+Run: `python .agent-meta/scripts/sync.py --create-ext <role>` first to see the base content,
+then create `.claude/3-project/<role>.md` (without `-ext`) with the full custom content.
+Inform the user: "This file is yours — sync.py will never overwrite it."
+
+**Step 4 — If the role doesn't exist in agent-meta at all**
+
+If the role name is not found in the generic agents:
+- Inform the user: "This role has no generic base in agent-meta."
+- For Override: create `.claude/3-project/<role>.md` with a starter template:
+  ```
+  ---
+  name: <role>
+  description: "<brief description>"
+  ---
+  # <Role>
+
+  <Instructions for this agent>
+  ```
+- For Extension: explain that an extension without a base agent has no effect — suggest Override instead or filing a feature request via `/meta-feedback`.
+
+**Step 5 — Sync and confirm**
+
+Run `python .agent-meta/scripts/sync.py` and confirm the new file is active.
+Show the user the file path and remind them: "Edit this file directly — it's yours to customize."

--- a/commands/1-generic/add-provider.md
+++ b/commands/1-generic/add-provider.md
@@ -1,0 +1,51 @@
+---
+description: Add an AI provider to this project or request a new one via GitHub issue
+allowed-tools: ["Bash", "Read", "Edit", "Agent"]
+argument-hint: "[provider name, e.g. Gemini]"
+---
+
+Add an AI provider to this project. $ARGUMENTS
+
+**Step 1 — Discover available providers**
+
+Read `.agent-meta/config/ai-providers.yaml` and extract all provider names listed under `providers:`.
+Read `.meta-config/project.yaml` and extract the `ai-providers:` list (currently active providers).
+
+Show the user:
+- Already active providers (skip these)
+- Available providers from the registry (can be added immediately)
+
+**Step 2 — User decision**
+
+If $ARGUMENTS names a known provider from the registry → proceed to Step 3.
+If $ARGUMENTS names an unknown provider (not in registry) → proceed to Step 4.
+If no $ARGUMENTS → ask the user which provider they want to add, showing the available list.
+
+**Step 3 — Add known provider**
+
+1. Add the provider name to `ai-providers:` in `.meta-config/project.yaml`
+2. Run sync: `python .agent-meta/scripts/sync.py`
+3. Check sync output for warnings
+4. Report: which new files were generated (agents, rules, settings, isolation artifacts)
+5. If the provider requires secrets (e.g. API keys): show the relevant gitignored local config file path and what needs to be filled in
+
+**Step 4 — Request new provider via GitHub issue**
+
+The requested provider is not yet in the agent-meta registry. Before filing the issue, do a brief pre-analysis:
+
+- What is the provider's name and tool/CLI name?
+- Does it have a known agents directory convention?
+- Does it support rules/hooks/commands natively?
+- Does it have a known permission/deny mechanism for file access?
+- What model IDs does it use?
+
+Then delegate to the `meta-feedback` agent with this task:
+
+File a GitHub issue titled: "feat: add [ProviderName] as a supported AI provider"
+
+Body should include:
+- Provider name and CLI/tool name
+- Pre-analysis findings from above
+- Links to official docs if known
+- Requested capabilities: agents_dir, context_file, has_rules, has_hooks, has_settings, model-tiers
+- Label: "enhancement", "new-provider"

--- a/commands/1-generic/diagnose.md
+++ b/commands/1-generic/diagnose.md
@@ -1,0 +1,41 @@
+---
+description: Health-check the agent-meta setup — versions, generated files, isolation state, gitignore
+allowed-tools: ["Bash", "Read", "Glob"]
+argument-hint: "[area to focus on: versions | isolation | gitignore | all]"
+---
+
+Run a health check of the agent-meta setup for this project. $ARGUMENTS
+
+Work through these checks in order and report findings as ✅ OK / ⚠️ Warning / ❌ Error:
+
+**1. Sync status**
+Run `python .agent-meta/scripts/sync.py --dry-run` and report:
+- How many files would be written (WRITE actions) vs skipped
+- Any warnings in the output
+- If 0 WRITEs: "Generated files are up to date"
+- If WRITEs exist: list them — these files are out of sync
+
+**2. Version check**
+- Read `.agent-meta/VERSION` (agent-meta version)
+- Read `CLAUDE.md` managed block — find "Generiert von agent-meta vX.Y.Z"
+- If versions differ: ⚠️ "CLAUDE.md was generated with an older version — run sync"
+
+**3. Provider isolation**
+For each active provider in `.meta-config/project.yaml`:
+- Claude: check `.claude/agent-meta-state.json` exists and contains `isolation-deny` entries
+- Opencode: check `.opencode/agent-meta-state.json` exists and contains `isolation-deny` entries
+- Gemini: check `.gemini/policies/provider-isolation.toml` exists
+- Continue: check `.continue/rules/provider-isolation.md` exists
+- If `provider-isolation: disabled` in project.yaml → report "isolation disabled (opt-out)"
+- If only 1 provider active → report "isolation not needed (single provider)"
+
+**4. Gitignore completeness**
+Read `.gitignore` and verify the `# --- agent-meta managed ---` block exists and is non-empty.
+Check that `.meta-config/secrets.local.yaml` is gitignored (if the file exists).
+
+**5. MCP state** (if mcp-servers configured in project.yaml)
+Check that for each active MCP server, the expected rule files exist per active provider.
+
+Finish with a summary: total checks, how many ✅/⚠️/❌.
+If all OK: "Setup is healthy."
+If issues found: list actionable next steps.

--- a/commands/1-generic/set-preset.md
+++ b/commands/1-generic/set-preset.md
@@ -1,0 +1,65 @@
+---
+description: Change the DoD preset or speech mode of this project
+allowed-tools: ["Read", "Edit", "Bash"]
+argument-hint: "<preset: rapid-prototyping | standard | strict> or <speech: off | professional | submissive>"
+---
+
+Change the project preset or speech mode. $ARGUMENTS
+
+**Step 0 — Check for missing input**
+
+If $ARGUMENTS is empty:
+> "What would you like to change? Options:"
+>
+> **DoD Preset** (Definition of Done strictness):
+> - `rapid-prototyping` — no tests, no docs, no security audit required
+> - `standard` — tests required, docs recommended
+> - `strict` — tests + docs + security audit required, full REQ-traceability
+>
+> **Speech mode** (how agents communicate):
+> - `off` — neutral, professional tone
+> - `professional` — structured, formal
+> - `submissive` — deferential style ("Wie Ihr wünscht", "Meister")
+>
+> "Please type what you want to change, e.g.: `standard` or `speech: off`"
+
+Stop here and wait for input. Do not proceed until the user specifies what to change.
+
+**Step 1 — Parse the input**
+
+Determine from $ARGUMENTS (or the user's follow-up):
+- Is it a DoD preset? → look for `rapid-prototyping`, `standard`, `strict`
+- Is it a speech mode? → look for `off`, `professional`, `submissive` (with or without `speech:` prefix)
+- Unknown value:
+  > "Unknown option '<value>'. Valid DoD presets: rapid-prototyping, standard, strict.
+  > Valid speech modes: off, professional, submissive."
+  Stop.
+
+**Step 2 — Show current value and confirm**
+
+Read `.meta-config/project.yaml` and show the current value of the field being changed.
+
+> "Current: `<field>: <current-value>`
+> New: `<field>: <new-value>`
+> Proceed? (yes/no)"
+
+If no: stop.
+
+**Step 3 — Apply**
+
+Update the relevant field in `.meta-config/project.yaml`:
+- DoD preset → `dod-preset: <value>`
+- Speech mode → `speech-mode: <value>`
+
+Run: `python .agent-meta/scripts/sync.py`
+
+**Step 4 — Confirm**
+
+> "Done. `<field>` is now `<new-value>`.
+> The change takes effect immediately in all generated agent files."
+
+For DoD preset changes, briefly explain what is now required/relaxed:
+e.g. "Tests are now required before closing a task."
+
+For speech mode changes:
+e.g. "Agents will now respond in neutral professional tone."

--- a/commands/1-generic/update-extensions.md
+++ b/commands/1-generic/update-extensions.md
@@ -1,0 +1,54 @@
+---
+description: Update managed blocks in project extension files after an agent-meta upgrade
+allowed-tools: ["Bash", "Read"]
+argument-hint: "[role-name to update a single extension, or empty for all]"
+---
+
+Update the managed blocks in project extension files. $ARGUMENTS
+
+**Step 0 — Check context**
+
+Check if any extension files exist:
+```bash
+ls .claude/3-project/*-ext.md 2>/dev/null || echo "none"
+```
+
+If none found:
+> "No extension files found in `.claude/3-project/`. Nothing to update.
+> Use `/add-project-role` to create your first project-specific agent extension."
+Stop.
+
+**Step 1 — Targeted or full update**
+
+If $ARGUMENTS provides a role name:
+- Update only that extension: `python .agent-meta/scripts/sync.py --update-ext`
+  (sync.py --update-ext updates all extensions; note which role the user asked about)
+- After update, show only the diff for that file.
+
+If $ARGUMENTS is empty:
+- Update all extensions: `python .agent-meta/scripts/sync.py --update-ext`
+
+**Step 2 — Report changes**
+
+After the sync, run:
+```bash
+git diff .claude/3-project/
+```
+
+For each changed extension file, show:
+- File name
+- What changed in the managed block (added/removed sections from the base agent)
+- Confirm that the user's custom content (outside the managed block) was preserved
+
+If no changes:
+> "All extension managed blocks are already up to date."
+
+If changes found:
+> "The following extensions were updated with new content from the base agents:"
+> [list files with summary of changes]
+> "Your custom content in each file was preserved. Review the changes and commit when ready."
+
+**Step 3 — Suggest next step**
+
+If changes were made:
+> "Run `/diagnose` to verify the overall setup is healthy after the update."

--- a/commands/1-generic/what-is.md
+++ b/commands/1-generic/what-is.md
@@ -1,0 +1,47 @@
+---
+description: Explain what an agent does — its role, tools, and boundaries
+allowed-tools: ["Read", "Glob", "Bash"]
+argument-hint: "<agent-name, e.g. developer>"
+---
+
+Explain what the specified agent does. $ARGUMENTS
+
+**Step 0 — Check for missing input**
+
+If $ARGUMENTS is empty:
+> "Which agent would you like to know about? Available agents:"
+
+List all `.md` files in `.claude/agents/` (strip `.md` extension for display).
+
+> "Please type an agent name to continue."
+
+Stop here and wait for the user to respond.
+
+**Step 1 — Find the agent file**
+
+Look for `.claude/agents/<name>.md`. If not found:
+- Try case-insensitive match
+- If still not found:
+  > "Agent '<name>' not found. Available agents: [list]"
+  Stop.
+
+**Step 2 — Summarize**
+
+Read the agent file and produce a concise summary in this structure:
+
+**[Agent Name]** — `<description from frontmatter>`
+
+**Zuständigkeit:** [1-2 sentences: what does this agent own, what decisions does it make]
+
+**Tools:** [list tools from frontmatter, with one-word explanation each if non-obvious]
+
+**Wann einsetzen:**
+- [2-3 concrete trigger examples from the agent's instructions]
+
+**Wann NICHT einsetzen / Grenzen:**
+- [1-2 explicit limitations or handoff points]
+
+**Typischer Aufruf:**
+> [one realistic example prompt that would invoke this agent]
+
+Keep the summary to ~15 lines. No wall of text. The goal is that someone unfamiliar with this agent knows exactly when and how to use it after reading.


### PR DESCRIPTION
## Summary

Three new slash commands for day-to-day agent-meta project management:

- **`/diagnose`** — Health-check the entire setup: sync status, version match, provider isolation state, gitignore completeness, MCP state. Returns ✅/⚠️/❌ per check with actionable next steps.

- **`/add-provider`** — Guided wizard to activate a provider from the registry (updates `project.yaml`, runs sync, reports new artifacts + secret setup). If the requested provider is not in the registry, runs a brief pre-analysis and files a GitHub issue via the `meta-feedback` agent.

- **`/add-project-role`** — Creates a project-specific agent role as an **extension** (additive on top of the generic agent, sync keeps updating the base) or a full **override** (user-owned, sync never touches it). Handles the case where the role has no generic base in agent-meta.

## Test plan

- [ ] `/diagnose` on a freshly synced project → all green
- [ ] `/diagnose` after manually editing a generated agent → reports out-of-sync
- [ ] `/add-provider Gemini` on a Claude-only project → adds provider, runs sync
- [ ] `/add-provider Kiro` (unknown) → meta-feedback agent files a GitHub issue
- [ ] `/add-project-role developer` → prompts extension vs override, creates file
- [ ] `/add-project-role unknown-role` → explains no base exists, suggests override

🤖 Generated with [Claude Code](https://claude.ai/claude-code)