### PR TITLE
feat: add /commit, /merge and /report-bug commands

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,76 @@
+---
+description: Stage changes and create a conventional commit with a suggested message
+allowed-tools: ["Bash"]
+argument-hint: "[commit message or topic, e.g. 'fix login redirect']"
+---
+
+Create a git commit for the current changes. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ You are on `main`. Direct commits to main are not recommended.
+> Create a feature branch first with: `git checkout -b feat/<topic>`
+> Continue anyway? (yes/no)"
+If no: stop.
+
+**Step 2 — Show what will be committed**
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+If nothing to commit:
+> "Nothing to commit — working tree is clean."
+Stop.
+
+**Step 3 — Stage changes**
+
+If $ARGUMENTS is empty and no staged files exist:
+> "Which files should be committed? Options:
+> - `all` — stage everything (`git add -A`)
+> - List specific files or patterns
+>
+> What would you like to stage?"
+Wait for input.
+
+If $ARGUMENTS is provided or user responds: stage accordingly.
+
+Show staged diff summary after staging:
+```bash
+git diff --cached --stat
+```
+
+**Step 4 — Suggest commit message**
+
+If $ARGUMENTS provides a message or topic, use it as the basis.
+Otherwise analyze the staged diff to infer the change type and scope.
+
+Suggest a message following Conventional Commits format:
+```
+<type>: <description>
+```
+Types: `feat` | `fix` | `refactor` | `docs` | `chore` | `test` | `ci`
+
+Show the suggestion:
+> "Suggested commit message:
+> `<type>: <description>`
+>
+> Accept, edit, or type your own message?"
+
+Wait for confirmation or correction.
+
+**Step 5 — Commit**
+
+```bash
+git commit -m "<confirmed message>"
+```
+
+Report: commit hash + message.
+Suggest next step:
+> "Committed. Run `/merge` to create a PR, or keep working."

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,0 +1,78 @@
+---
+description: Create a PR for the current branch and merge it into main
+allowed-tools: ["Bash"]
+argument-hint: "[PR title or empty to auto-generate]"
+---
+
+Create a pull request for the current branch and merge it. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ Already on `main` — nothing to merge. Switch to a feature branch first."
+Stop.
+
+**Step 2 — Check for uncommitted changes**
+
+```bash
+git status --short
+```
+
+If uncommitted changes exist:
+> "There are uncommitted changes. Commit them first with `/commit`, or stash them.
+> Continue anyway (without uncommitted changes)? (yes/no)"
+If no: stop.
+
+**Step 3 — Push branch**
+
+```bash
+git push -u origin HEAD 2>&1
+```
+
+If push fails (hook or other error): report the error and stop.
+
+**Step 4 — Check for existing PR**
+
+```bash
+gh pr view --json number,title,state 2>/dev/null
+```
+
+If PR already exists and is open: skip to Step 6.
+
+**Step 5 — Compose PR**
+
+Gather context:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+If $ARGUMENTS provides a title, use it. Otherwise derive the title from the commits (first commit message or common theme).
+
+Compose:
+- **Title**: max 70 chars, imperative mood
+- **Body**: bullet summary of changes + test plan checklist
+
+Show draft to user:
+> "PR draft:
+> Title: `<title>`
+> Body: [summary]
+>
+> Create PR? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change.
+
+**Step 6 — Create & merge PR**
+
+```bash
+gh pr create --title "<title>" --body "<body>"
+gh pr merge --squash --delete-branch
+```
+
+Report: PR URL + merge confirmation.
+
+> "✅ Merged. Branch deleted. Run `git checkout main && git pull` to update your local main."

--- a/.claude/commands/report-bug.md
+++ b/.claude/commands/report-bug.md
@@ -1,0 +1,86 @@
+---
+description: Report a bug in this project by filing a GitHub issue in the target repository
+allowed-tools: ["Bash", "Read"]
+argument-hint: "[short bug description]"
+---
+
+File a bug report as a GitHub issue in this project's repository. $ARGUMENTS
+
+**Step 1 — Identify the target repository**
+
+```bash
+gh repo view --json nameWithOwner,url 2>/dev/null
+```
+
+If this fails (not a GitHub repo or gh not authenticated):
+> "Could not detect a GitHub repository. Make sure `gh` is authenticated and this project has a GitHub remote."
+Stop.
+
+Show the user:
+> "Filing bug report in: `<owner>/<repo>` (<url>)"
+> "Is this the correct repository? (yes/no)"
+If no: ask for the correct `owner/repo` to use.
+
+**Step 2 — Collect bug details**
+
+If $ARGUMENTS is empty:
+> "Please describe the bug briefly (one line):"
+Wait for input. Use it as the issue title.
+
+If $ARGUMENTS is provided: use it as the title basis.
+
+Then ask for details — one question at a time, wait for each answer:
+
+1. > "**What did you expect to happen?**"
+2. > "**What actually happened?** (include error messages if any)"
+3. > "**Steps to reproduce** (numbered list, or 'not sure'):"
+4. > "**Environment** (OS, tool version, branch — or press Enter to skip):"
+
+**Step 3 — Check for duplicates**
+
+```bash
+gh issue list --state open --search "<title keywords>" --limit 5
+```
+
+If similar issues found:
+> "Found potentially related open issues:"
+> [list with numbers and titles]
+> "Is this a new issue or related to one of these? (new / #<number>)"
+If related: suggest adding a comment instead of a new issue, show the command.
+
+**Step 4 — Compose and confirm**
+
+Build the issue body:
+
+```markdown
+## Description
+<what happened>
+
+## Expected behavior
+<what should have happened>
+
+## Steps to reproduce
+<steps>
+
+## Environment
+<environment info>
+```
+
+Show the full draft:
+> "Issue draft:
+> **Title:** `<title>`
+> **Body:** [formatted body]
+>
+> File this issue? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change and rebuild.
+
+**Step 5 — File the issue**
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "bug"
+```
+
+Report the issue URL.
+> "✅ Bug filed: <url>
+> The team has been notified. You can add more context or screenshots directly on GitHub."

--- a/.continue/prompts/commit.md
+++ b/.continue/prompts/commit.md
@@ -1,0 +1,77 @@
+---
+description: Stage changes and create a conventional commit with a suggested message
+allowed-tools: ["Bash"]
+argument-hint: "[commit message or topic, e.g. 'fix login redirect']"
+invokable: true
+---
+
+Create a git commit for the current changes. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ You are on `main`. Direct commits to main are not recommended.
+> Create a feature branch first with: `git checkout -b feat/<topic>`
+> Continue anyway? (yes/no)"
+If no: stop.
+
+**Step 2 — Show what will be committed**
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+If nothing to commit:
+> "Nothing to commit — working tree is clean."
+Stop.
+
+**Step 3 — Stage changes**
+
+If $ARGUMENTS is empty and no staged files exist:
+> "Which files should be committed? Options:
+> - `all` — stage everything (`git add -A`)
+> - List specific files or patterns
+>
+> What would you like to stage?"
+Wait for input.
+
+If $ARGUMENTS is provided or user responds: stage accordingly.
+
+Show staged diff summary after staging:
+```bash
+git diff --cached --stat
+```
+
+**Step 4 — Suggest commit message**
+
+If $ARGUMENTS provides a message or topic, use it as the basis.
+Otherwise analyze the staged diff to infer the change type and scope.
+
+Suggest a message following Conventional Commits format:
+```
+<type>: <description>
+```
+Types: `feat` | `fix` | `refactor` | `docs` | `chore` | `test` | `ci`
+
+Show the suggestion:
+> "Suggested commit message:
+> `<type>: <description>`
+>
+> Accept, edit, or type your own message?"
+
+Wait for confirmation or correction.
+
+**Step 5 — Commit**
+
+```bash
+git commit -m "<confirmed message>"
+```
+
+Report: commit hash + message.
+Suggest next step:
+> "Committed. Run `/merge` to create a PR, or keep working."

--- a/.continue/prompts/merge.md
+++ b/.continue/prompts/merge.md
@@ -1,0 +1,79 @@
+---
+description: Create a PR for the current branch and merge it into main
+allowed-tools: ["Bash"]
+argument-hint: "[PR title or empty to auto-generate]"
+invokable: true
+---
+
+Create a pull request for the current branch and merge it. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ Already on `main` — nothing to merge. Switch to a feature branch first."
+Stop.
+
+**Step 2 — Check for uncommitted changes**
+
+```bash
+git status --short
+```
+
+If uncommitted changes exist:
+> "There are uncommitted changes. Commit them first with `/commit`, or stash them.
+> Continue anyway (without uncommitted changes)? (yes/no)"
+If no: stop.
+
+**Step 3 — Push branch**
+
+```bash
+git push -u origin HEAD 2>&1
+```
+
+If push fails (hook or other error): report the error and stop.
+
+**Step 4 — Check for existing PR**
+
+```bash
+gh pr view --json number,title,state 2>/dev/null
+```
+
+If PR already exists and is open: skip to Step 6.
+
+**Step 5 — Compose PR**
+
+Gather context:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+If $ARGUMENTS provides a title, use it. Otherwise derive the title from the commits (first commit message or common theme).
+
+Compose:
+- **Title**: max 70 chars, imperative mood
+- **Body**: bullet summary of changes + test plan checklist
+
+Show draft to user:
+> "PR draft:
+> Title: `<title>`
+> Body: [summary]
+>
+> Create PR? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change.
+
+**Step 6 — Create & merge PR**
+
+```bash
+gh pr create --title "<title>" --body "<body>"
+gh pr merge --squash --delete-branch
+```
+
+Report: PR URL + merge confirmation.
+
+> "✅ Merged. Branch deleted. Run `git checkout main && git pull` to update your local main."

--- a/.continue/prompts/report-bug.md
+++ b/.continue/prompts/report-bug.md
@@ -1,0 +1,87 @@
+---
+description: Report a bug in this project by filing a GitHub issue in the target repository
+allowed-tools: ["Bash", "Read"]
+argument-hint: "[short bug description]"
+invokable: true
+---
+
+File a bug report as a GitHub issue in this project's repository. $ARGUMENTS
+
+**Step 1 — Identify the target repository**
+
+```bash
+gh repo view --json nameWithOwner,url 2>/dev/null
+```
+
+If this fails (not a GitHub repo or gh not authenticated):
+> "Could not detect a GitHub repository. Make sure `gh` is authenticated and this project has a GitHub remote."
+Stop.
+
+Show the user:
+> "Filing bug report in: `<owner>/<repo>` (<url>)"
+> "Is this the correct repository? (yes/no)"
+If no: ask for the correct `owner/repo` to use.
+
+**Step 2 — Collect bug details**
+
+If $ARGUMENTS is empty:
+> "Please describe the bug briefly (one line):"
+Wait for input. Use it as the issue title.
+
+If $ARGUMENTS is provided: use it as the title basis.
+
+Then ask for details — one question at a time, wait for each answer:
+
+1. > "**What did you expect to happen?**"
+2. > "**What actually happened?** (include error messages if any)"
+3. > "**Steps to reproduce** (numbered list, or 'not sure'):"
+4. > "**Environment** (OS, tool version, branch — or press Enter to skip):"
+
+**Step 3 — Check for duplicates**
+
+```bash
+gh issue list --state open --search "<title keywords>" --limit 5
+```
+
+If similar issues found:
+> "Found potentially related open issues:"
+> [list with numbers and titles]
+> "Is this a new issue or related to one of these? (new / #<number>)"
+If related: suggest adding a comment instead of a new issue, show the command.
+
+**Step 4 — Compose and confirm**
+
+Build the issue body:
+
+```markdown
+## Description
+<what happened>
+
+## Expected behavior
+<what should have happened>
+
+## Steps to reproduce
+<steps>
+
+## Environment
+<environment info>
+```
+
+Show the full draft:
+> "Issue draft:
+> **Title:** `<title>`
+> **Body:** [formatted body]
+>
+> File this issue? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change and rebuild.
+
+**Step 5 — File the issue**
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "bug"
+```
+
+Report the issue URL.
+> "✅ Bug filed: <url>
+> The team has been notified. You can add more context or screenshots directly on GitHub."

--- a/.gemini/commands/commit.toml
+++ b/.gemini/commands/commit.toml
@@ -1,0 +1,73 @@
+description = "Stage changes and create a conventional commit with a suggested message"
+prompt = """
+Create a git commit for the current changes. {{args}}
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ You are on `main`. Direct commits to main are not recommended.
+> Create a feature branch first with: `git checkout -b feat/<topic>`
+> Continue anyway? (yes/no)"
+If no: stop.
+
+**Step 2 — Show what will be committed**
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+If nothing to commit:
+> "Nothing to commit — working tree is clean."
+Stop.
+
+**Step 3 — Stage changes**
+
+If {{args}} is empty and no staged files exist:
+> "Which files should be committed? Options:
+> - `all` — stage everything (`git add -A`)
+> - List specific files or patterns
+>
+> What would you like to stage?"
+Wait for input.
+
+If {{args}} is provided or user responds: stage accordingly.
+
+Show staged diff summary after staging:
+```bash
+git diff --cached --stat
+```
+
+**Step 4 — Suggest commit message**
+
+If {{args}} provides a message or topic, use it as the basis.
+Otherwise analyze the staged diff to infer the change type and scope.
+
+Suggest a message following Conventional Commits format:
+```
+<type>: <description>
+```
+Types: `feat` | `fix` | `refactor` | `docs` | `chore` | `test` | `ci`
+
+Show the suggestion:
+> "Suggested commit message:
+> `<type>: <description>`
+>
+> Accept, edit, or type your own message?"
+
+Wait for confirmation or correction.
+
+**Step 5 — Commit**
+
+```bash
+git commit -m "<confirmed message>"
+```
+
+Report: commit hash + message.
+Suggest next step:
+> "Committed. Run `/merge` to create a PR, or keep working."
+"""

--- a/.gemini/commands/merge.toml
+++ b/.gemini/commands/merge.toml
@@ -1,0 +1,75 @@
+description = "Create a PR for the current branch and merge it into main"
+prompt = """
+Create a pull request for the current branch and merge it. {{args}}
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ Already on `main` — nothing to merge. Switch to a feature branch first."
+Stop.
+
+**Step 2 — Check for uncommitted changes**
+
+```bash
+git status --short
+```
+
+If uncommitted changes exist:
+> "There are uncommitted changes. Commit them first with `/commit`, or stash them.
+> Continue anyway (without uncommitted changes)? (yes/no)"
+If no: stop.
+
+**Step 3 — Push branch**
+
+```bash
+git push -u origin HEAD 2>&1
+```
+
+If push fails (hook or other error): report the error and stop.
+
+**Step 4 — Check for existing PR**
+
+```bash
+gh pr view --json number,title,state 2>/dev/null
+```
+
+If PR already exists and is open: skip to Step 6.
+
+**Step 5 — Compose PR**
+
+Gather context:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+If {{args}} provides a title, use it. Otherwise derive the title from the commits (first commit message or common theme).
+
+Compose:
+- **Title**: max 70 chars, imperative mood
+- **Body**: bullet summary of changes + test plan checklist
+
+Show draft to user:
+> "PR draft:
+> Title: `<title>`
+> Body: [summary]
+>
+> Create PR? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change.
+
+**Step 6 — Create & merge PR**
+
+```bash
+gh pr create --title "<title>" --body "<body>"
+gh pr merge --squash --delete-branch
+```
+
+Report: PR URL + merge confirmation.
+
+> "✅ Merged. Branch deleted. Run `git checkout main && git pull` to update your local main."
+"""

--- a/.gemini/commands/report-bug.toml
+++ b/.gemini/commands/report-bug.toml
@@ -1,0 +1,83 @@
+description = "Report a bug in this project by filing a GitHub issue in the target repository"
+prompt = """
+File a bug report as a GitHub issue in this project's repository. {{args}}
+
+**Step 1 — Identify the target repository**
+
+```bash
+gh repo view --json nameWithOwner,url 2>/dev/null
+```
+
+If this fails (not a GitHub repo or gh not authenticated):
+> "Could not detect a GitHub repository. Make sure `gh` is authenticated and this project has a GitHub remote."
+Stop.
+
+Show the user:
+> "Filing bug report in: `<owner>/<repo>` (<url>)"
+> "Is this the correct repository? (yes/no)"
+If no: ask for the correct `owner/repo` to use.
+
+**Step 2 — Collect bug details**
+
+If {{args}} is empty:
+> "Please describe the bug briefly (one line):"
+Wait for input. Use it as the issue title.
+
+If {{args}} is provided: use it as the title basis.
+
+Then ask for details — one question at a time, wait for each answer:
+
+1. > "**What did you expect to happen?**"
+2. > "**What actually happened?** (include error messages if any)"
+3. > "**Steps to reproduce** (numbered list, or 'not sure'):"
+4. > "**Environment** (OS, tool version, branch — or press Enter to skip):"
+
+**Step 3 — Check for duplicates**
+
+```bash
+gh issue list --state open --search "<title keywords>" --limit 5
+```
+
+If similar issues found:
+> "Found potentially related open issues:"
+> [list with numbers and titles]
+> "Is this a new issue or related to one of these? (new / #<number>)"
+If related: suggest adding a comment instead of a new issue, show the command.
+
+**Step 4 — Compose and confirm**
+
+Build the issue body:
+
+```markdown
+## Description
+<what happened>
+
+## Expected behavior
+<what should have happened>
+
+## Steps to reproduce
+<steps>
+
+## Environment
+<environment info>
+```
+
+Show the full draft:
+> "Issue draft:
+> **Title:** `<title>`
+> **Body:** [formatted body]
+>
+> File this issue? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change and rebuild.
+
+**Step 5 — File the issue**
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "bug"
+```
+
+Report the issue URL.
+> "✅ Bug filed: <url>
+> The team has been notified. You can add more context or screenshots directly on GitHub."
+"""

--- a/.opencode/commands/commit.md
+++ b/.opencode/commands/commit.md
@@ -1,0 +1,76 @@
+---
+description: Stage changes and create a conventional commit with a suggested message
+allowed-tools: ["Bash"]
+argument-hint: "[commit message or topic, e.g. 'fix login redirect']"
+---
+
+Create a git commit for the current changes. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ You are on `main`. Direct commits to main are not recommended.
+> Create a feature branch first with: `git checkout -b feat/<topic>`
+> Continue anyway? (yes/no)"
+If no: stop.
+
+**Step 2 — Show what will be committed**
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+If nothing to commit:
+> "Nothing to commit — working tree is clean."
+Stop.
+
+**Step 3 — Stage changes**
+
+If $ARGUMENTS is empty and no staged files exist:
+> "Which files should be committed? Options:
+> - `all` — stage everything (`git add -A`)
+> - List specific files or patterns
+>
+> What would you like to stage?"
+Wait for input.
+
+If $ARGUMENTS is provided or user responds: stage accordingly.
+
+Show staged diff summary after staging:
+```bash
+git diff --cached --stat
+```
+
+**Step 4 — Suggest commit message**
+
+If $ARGUMENTS provides a message or topic, use it as the basis.
+Otherwise analyze the staged diff to infer the change type and scope.
+
+Suggest a message following Conventional Commits format:
+```
+<type>: <description>
+```
+Types: `feat` | `fix` | `refactor` | `docs` | `chore` | `test` | `ci`
+
+Show the suggestion:
+> "Suggested commit message:
+> `<type>: <description>`
+>
+> Accept, edit, or type your own message?"
+
+Wait for confirmation or correction.
+
+**Step 5 — Commit**
+
+```bash
+git commit -m "<confirmed message>"
+```
+
+Report: commit hash + message.
+Suggest next step:
+> "Committed. Run `/merge` to create a PR, or keep working."

--- a/.opencode/commands/merge.md
+++ b/.opencode/commands/merge.md
@@ -1,0 +1,78 @@
+---
+description: Create a PR for the current branch and merge it into main
+allowed-tools: ["Bash"]
+argument-hint: "[PR title or empty to auto-generate]"
+---
+
+Create a pull request for the current branch and merge it. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ Already on `main` — nothing to merge. Switch to a feature branch first."
+Stop.
+
+**Step 2 — Check for uncommitted changes**
+
+```bash
+git status --short
+```
+
+If uncommitted changes exist:
+> "There are uncommitted changes. Commit them first with `/commit`, or stash them.
+> Continue anyway (without uncommitted changes)? (yes/no)"
+If no: stop.
+
+**Step 3 — Push branch**
+
+```bash
+git push -u origin HEAD 2>&1
+```
+
+If push fails (hook or other error): report the error and stop.
+
+**Step 4 — Check for existing PR**
+
+```bash
+gh pr view --json number,title,state 2>/dev/null
+```
+
+If PR already exists and is open: skip to Step 6.
+
+**Step 5 — Compose PR**
+
+Gather context:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+If $ARGUMENTS provides a title, use it. Otherwise derive the title from the commits (first commit message or common theme).
+
+Compose:
+- **Title**: max 70 chars, imperative mood
+- **Body**: bullet summary of changes + test plan checklist
+
+Show draft to user:
+> "PR draft:
+> Title: `<title>`
+> Body: [summary]
+>
+> Create PR? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change.
+
+**Step 6 — Create & merge PR**
+
+```bash
+gh pr create --title "<title>" --body "<body>"
+gh pr merge --squash --delete-branch
+```
+
+Report: PR URL + merge confirmation.
+
+> "✅ Merged. Branch deleted. Run `git checkout main && git pull` to update your local main."

--- a/.opencode/commands/report-bug.md
+++ b/.opencode/commands/report-bug.md
@@ -1,0 +1,86 @@
+---
+description: Report a bug in this project by filing a GitHub issue in the target repository
+allowed-tools: ["Bash", "Read"]
+argument-hint: "[short bug description]"
+---
+
+File a bug report as a GitHub issue in this project's repository. $ARGUMENTS
+
+**Step 1 — Identify the target repository**
+
+```bash
+gh repo view --json nameWithOwner,url 2>/dev/null
+```
+
+If this fails (not a GitHub repo or gh not authenticated):
+> "Could not detect a GitHub repository. Make sure `gh` is authenticated and this project has a GitHub remote."
+Stop.
+
+Show the user:
+> "Filing bug report in: `<owner>/<repo>` (<url>)"
+> "Is this the correct repository? (yes/no)"
+If no: ask for the correct `owner/repo` to use.
+
+**Step 2 — Collect bug details**
+
+If $ARGUMENTS is empty:
+> "Please describe the bug briefly (one line):"
+Wait for input. Use it as the issue title.
+
+If $ARGUMENTS is provided: use it as the title basis.
+
+Then ask for details — one question at a time, wait for each answer:
+
+1. > "**What did you expect to happen?**"
+2. > "**What actually happened?** (include error messages if any)"
+3. > "**Steps to reproduce** (numbered list, or 'not sure'):"
+4. > "**Environment** (OS, tool version, branch — or press Enter to skip):"
+
+**Step 3 — Check for duplicates**
+
+```bash
+gh issue list --state open --search "<title keywords>" --limit 5
+```
+
+If similar issues found:
+> "Found potentially related open issues:"
+> [list with numbers and titles]
+> "Is this a new issue or related to one of these? (new / #<number>)"
+If related: suggest adding a comment instead of a new issue, show the command.
+
+**Step 4 — Compose and confirm**
+
+Build the issue body:
+
+```markdown
+## Description
+<what happened>
+
+## Expected behavior
+<what should have happened>
+
+## Steps to reproduce
+<steps>
+
+## Environment
+<environment info>
+```
+
+Show the full draft:
+> "Issue draft:
+> **Title:** `<title>`
+> **Body:** [formatted body]
+>
+> File this issue? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change and rebuild.
+
+**Step 5 — File the issue**
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "bug"
+```
+
+Report the issue URL.
+> "✅ Bug filed: <url>
+> The team has been notified. You can add more context or screenshots directly on GitHub."

--- a/commands/1-generic/commit.md
+++ b/commands/1-generic/commit.md
@@ -1,0 +1,76 @@
+---
+description: Stage changes and create a conventional commit with a suggested message
+allowed-tools: ["Bash"]
+argument-hint: "[commit message or topic, e.g. 'fix login redirect']"
+---
+
+Create a git commit for the current changes. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ You are on `main`. Direct commits to main are not recommended.
+> Create a feature branch first with: `git checkout -b feat/<topic>`
+> Continue anyway? (yes/no)"
+If no: stop.
+
+**Step 2 — Show what will be committed**
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+If nothing to commit:
+> "Nothing to commit — working tree is clean."
+Stop.
+
+**Step 3 — Stage changes**
+
+If $ARGUMENTS is empty and no staged files exist:
+> "Which files should be committed? Options:
+> - `all` — stage everything (`git add -A`)
+> - List specific files or patterns
+>
+> What would you like to stage?"
+Wait for input.
+
+If $ARGUMENTS is provided or user responds: stage accordingly.
+
+Show staged diff summary after staging:
+```bash
+git diff --cached --stat
+```
+
+**Step 4 — Suggest commit message**
+
+If $ARGUMENTS provides a message or topic, use it as the basis.
+Otherwise analyze the staged diff to infer the change type and scope.
+
+Suggest a message following Conventional Commits format:
+```
+<type>: <description>
+```
+Types: `feat` | `fix` | `refactor` | `docs` | `chore` | `test` | `ci`
+
+Show the suggestion:
+> "Suggested commit message:
+> `<type>: <description>`
+>
+> Accept, edit, or type your own message?"
+
+Wait for confirmation or correction.
+
+**Step 5 — Commit**
+
+```bash
+git commit -m "<confirmed message>"
+```
+
+Report: commit hash + message.
+Suggest next step:
+> "Committed. Run `/merge` to create a PR, or keep working."

--- a/commands/1-generic/merge.md
+++ b/commands/1-generic/merge.md
@@ -1,0 +1,78 @@
+---
+description: Create a PR for the current branch and merge it into main
+allowed-tools: ["Bash"]
+argument-hint: "[PR title or empty to auto-generate]"
+---
+
+Create a pull request for the current branch and merge it. $ARGUMENTS
+
+**Step 1 — Check branch**
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`:
+> "⚠️ Already on `main` — nothing to merge. Switch to a feature branch first."
+Stop.
+
+**Step 2 — Check for uncommitted changes**
+
+```bash
+git status --short
+```
+
+If uncommitted changes exist:
+> "There are uncommitted changes. Commit them first with `/commit`, or stash them.
+> Continue anyway (without uncommitted changes)? (yes/no)"
+If no: stop.
+
+**Step 3 — Push branch**
+
+```bash
+git push -u origin HEAD 2>&1
+```
+
+If push fails (hook or other error): report the error and stop.
+
+**Step 4 — Check for existing PR**
+
+```bash
+gh pr view --json number,title,state 2>/dev/null
+```
+
+If PR already exists and is open: skip to Step 6.
+
+**Step 5 — Compose PR**
+
+Gather context:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+If $ARGUMENTS provides a title, use it. Otherwise derive the title from the commits (first commit message or common theme).
+
+Compose:
+- **Title**: max 70 chars, imperative mood
+- **Body**: bullet summary of changes + test plan checklist
+
+Show draft to user:
+> "PR draft:
+> Title: `<title>`
+> Body: [summary]
+>
+> Create PR? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change.
+
+**Step 6 — Create & merge PR**
+
+```bash
+gh pr create --title "<title>" --body "<body>"
+gh pr merge --squash --delete-branch
+```
+
+Report: PR URL + merge confirmation.
+
+> "✅ Merged. Branch deleted. Run `git checkout main && git pull` to update your local main."

--- a/commands/1-generic/report-bug.md
+++ b/commands/1-generic/report-bug.md
@@ -1,0 +1,86 @@
+---
+description: Report a bug in this project by filing a GitHub issue in the target repository
+allowed-tools: ["Bash", "Read"]
+argument-hint: "[short bug description]"
+---
+
+File a bug report as a GitHub issue in this project's repository. $ARGUMENTS
+
+**Step 1 — Identify the target repository**
+
+```bash
+gh repo view --json nameWithOwner,url 2>/dev/null
+```
+
+If this fails (not a GitHub repo or gh not authenticated):
+> "Could not detect a GitHub repository. Make sure `gh` is authenticated and this project has a GitHub remote."
+Stop.
+
+Show the user:
+> "Filing bug report in: `<owner>/<repo>` (<url>)"
+> "Is this the correct repository? (yes/no)"
+If no: ask for the correct `owner/repo` to use.
+
+**Step 2 — Collect bug details**
+
+If $ARGUMENTS is empty:
+> "Please describe the bug briefly (one line):"
+Wait for input. Use it as the issue title.
+
+If $ARGUMENTS is provided: use it as the title basis.
+
+Then ask for details — one question at a time, wait for each answer:
+
+1. > "**What did you expect to happen?**"
+2. > "**What actually happened?** (include error messages if any)"
+3. > "**Steps to reproduce** (numbered list, or 'not sure'):"
+4. > "**Environment** (OS, tool version, branch — or press Enter to skip):"
+
+**Step 3 — Check for duplicates**
+
+```bash
+gh issue list --state open --search "<title keywords>" --limit 5
+```
+
+If similar issues found:
+> "Found potentially related open issues:"
+> [list with numbers and titles]
+> "Is this a new issue or related to one of these? (new / #<number>)"
+If related: suggest adding a comment instead of a new issue, show the command.
+
+**Step 4 — Compose and confirm**
+
+Build the issue body:
+
+```markdown
+## Description
+<what happened>
+
+## Expected behavior
+<what should have happened>
+
+## Steps to reproduce
+<steps>
+
+## Environment
+<environment info>
+```
+
+Show the full draft:
+> "Issue draft:
+> **Title:** `<title>`
+> **Body:** [formatted body]
+>
+> File this issue? (yes/edit/no)"
+
+Wait for confirmation. If "edit": ask what to change and rebuild.
+
+**Step 5 — File the issue**
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "bug"
+```
+
+Report the issue URL.
+> "✅ Bug filed: <url>
+> The team has been notified. You can add more context or screenshots directly on GitHub."


### PR DESCRIPTION
## Summary

- **`/commit`** — Guided conventional commit: checks branch (warns on main), stages files interactively, analyzes diff to suggest message, confirms before committing
- **`/merge`** — End-to-end PR flow: pushes branch, detects existing PR, composes title + body from commits, squash-merges with confirmation and branch cleanup
- **`/report-bug`** — Files a GitHub issue in the **target project's** repo (auto-detected via `gh repo view`), collects structured bug details (expected/actual/steps/env), checks for duplicates before filing

All three commands prompt for missing input at every required step rather than failing silently.

## Test plan

- [ ] `/commit` on main → warns before proceeding
- [ ] `/commit` with no staged files → asks what to stage
- [ ] `/commit` with staged changes → suggests conventional message from diff
- [ ] `/merge` on feature branch → pushes, creates PR, merges
- [ ] `/merge` on main → stops with clear error
- [ ] `/report-bug` → detects correct repo, collects all fields, checks duplicates
- [ ] `/report-bug "login broken"` → skips title prompt, asks for remaining details

🤖 Generated with [Claude Code](https://claude.ai/claude-code)