### PR TITLE
chore: bump agent-meta-version to 0.35.0 in project.yaml

### DIFF
--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -1,7 +1,7 @@
 # agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.
 # Schema-Validierung: agent-meta.schema.json (JSON Schema bleibt JSON — IDE-Standard)
 
-agent-meta-version: 0.34.2
+agent-meta-version: 0.35.0
 
 # agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
 # Provider isolation must be disabled here — the meta-repo intentionally


### PR DESCRIPTION
## Summary
- Fix stale `agent-meta-version: 0.34.2` → `0.35.0` in `.meta-config/project.yaml`
- Initialize external submodules (`neat-little-package`, `awesome-claude-code`) to their pinned commits
- `sync.py` now runs with 0 warnings

## Test plan
- [x] `sync.py` runs clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)