### PR TITLE
chore: upgrade agent-meta to v0.36.0 and re-sync all agents

### DIFF
--- a/.continue/config.yaml
+++ b/.continue/config.yaml
@@ -1,5 +1,5 @@
 # agent-meta:managed-begin
-# Managed by agent-meta v0.35.0 — 2026-05-10
+# Managed by agent-meta v0.36.0 — 2026-05-10
 # Agents : .continue/agents/  (auto-discovered by Continue)
 # Rules  : .continue/rules/   (auto-discovered by Continue)
 # agent-meta:managed-end

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.35.0 — `2026-05-10`
+Generiert von agent-meta v0.36.0 — `2026-05-10`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -1,7 +1,7 @@
 # agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.
 # Schema-Validierung: agent-meta.schema.json (JSON Schema bleibt JSON — IDE-Standard)
 
-agent-meta-version: 0.35.0
+agent-meta-version: 0.36.0
 
 # agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
 # Provider isolation must be disabled here — the meta-repo intentionally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.35.0 — `2026-05-10`
+Generiert von agent-meta v0.36.0 — `2026-05-10`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.


### PR DESCRIPTION
## Summary

- Bumped `agent-meta-version` in `.meta-config/project.yaml` from `0.35.0` to `0.36.0`
- Re-synced all provider artifacts (Claude, Continue, Gemini, Opencode) — 86 actions executed
- Updated managed version blocks in `AGENTS.md`, `.gemini/GEMINI.md`, `.continue/config.yaml`

## Sync Details

86 actions | 102 skipped | 9 warnings (all known false positives: `{{VAR}}` in documentation tables within `agent-meta-manager.md` and `consistency-check.md` — intentional, not real placeholders)

All agent files for all 4 providers are up to date with v0.36.0.

## Test plan

- [ ] Verify `AGENTS.md` shows `v0.36.0` in the managed block
- [ ] Verify `.meta-config/project.yaml` shows `agent-meta-version: 0.36.0`
- [ ] Verify sync.log shows no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)