### PR TITLE
fix(strictdoc): remove invalid PREAMBLE fields from sdoc documents

### DIFF
--- a/.strictdoc/docs/01-stakeholder-reqs.sdoc
+++ b/.strictdoc/docs/01-stakeholder-reqs.sdoc
@@ -1,11 +1,6 @@
 [DOCUMENT]
 TITLE: Stakeholder Requirements Specification (L1)
 
-PREAMBLE: >>>
-This document captures user-level and product-level requirements for agent-meta.
-These are the capabilities that users and developers expect from the framework.
-Stakeholders: Framework developers, project maintainers, AI researchers.
-<<<
 
 [REQUIREMENT]
 UID: REQ-STK-001

--- a/.strictdoc/docs/02-system-reqs/02a-agent-framework.sdoc
+++ b/.strictdoc/docs/02-system-reqs/02a-agent-framework.sdoc
@@ -1,13 +1,6 @@
 [DOCUMENT]
 TITLE: System Requirements — Agent Framework Core (L2)
 
-PREAMBLE: >>>
-System-level requirements for the core agent framework:
-- sync.py as central orchestration engine
-- Layer-stacking and composition
-- Frontmatter injection
-- Agent hints and metadata
-<<<
 
 [REQUIREMENT]
 UID: REQ-SYS-001

--- a/.strictdoc/docs/04-module-reqs/04a-agents-module.sdoc
+++ b/.strictdoc/docs/04-module-reqs/04a-agents-module.sdoc
@@ -1,11 +1,5 @@
 [DOCUMENT]
 TITLE: Module Requirements — agents.py (Agent Composition Engine)
-PREAMBLE: >>>
-Design-level requirements for lib/agents.py module.
-Covers agent source loading, layer composition, extends chain resolution,
-patching, frontmatter injection, and multi-provider agent generation.
-Total: 56 requirements covering all 56 functions in agents.py.
-<<<
 
 [REQUIREMENT]
 UID: REQ-AGENTS-001

--- a/.strictdoc/docs/04-module-reqs/04b-config-module.sdoc
+++ b/.strictdoc/docs/04-module-reqs/04b-config-module.sdoc
@@ -1,11 +1,5 @@
 [DOCUMENT]
 TITLE: Module Requirements — config.py (Configuration Loading & Variables)
-PREAMBLE: >>>
-Design-level requirements for lib/config.py module.
-Covers project configuration loading, role defaults, variable building,
-substitution engine, and related operations.
-Total: 15 requirements covering all functions in config.py.
-<<<
 
 [REQUIREMENT]
 UID: REQ-CONFIG-001

--- a/.strictdoc/docs/04-module-reqs/04c-rules-hooks-commands.sdoc
+++ b/.strictdoc/docs/04-module-reqs/04c-rules-hooks-commands.sdoc
@@ -1,10 +1,5 @@
 [DOCUMENT]
 TITLE: Module Requirements — rules.py, hooks.py, commands.py
-PREAMBLE: >>>
-Design-level requirements for policy management, hook registration, and command sync.
-Consolidated requirements for three related policy/configuration modules.
-Total: 30 requirements (rules: 12, hooks: 8, commands: 10).
-<<<
 
 [REQUIREMENT]
 UID: REQ-RULES-001

--- a/.strictdoc/docs/04-module-reqs/04d-mcp-providers-skills.sdoc
+++ b/.strictdoc/docs/04-module-reqs/04d-mcp-providers-skills.sdoc
@@ -1,10 +1,5 @@
 [DOCUMENT]
 TITLE: Module Requirements — mcp.py, providers.py, skills.py
-PREAMBLE: >>>
-Design-level requirements for MCP server management, provider abstraction, and skill integration.
-Consolidated requirements for three foundational modules.
-Total: 32 requirements (mcp: 12, providers: 8, skills: 12).
-<<<
 
 [REQUIREMENT]
 UID: REQ-MCP-001

--- a/.strictdoc/docs/04-module-reqs/04e-extensions-context-isolation.sdoc
+++ b/.strictdoc/docs/04-module-reqs/04e-extensions-context-isolation.sdoc
@@ -1,10 +1,5 @@
 [DOCUMENT]
 TITLE: Module Requirements — extensions.py, context.py, isolation.py
-PREAMBLE: >>>
-Design-level requirements for project extensions, context/variable injection, and provider isolation.
-Consolidated requirements for three important framework modules.
-Total: 32 requirements (extensions: 8, context: 12, isolation: 12).
-<<<
 
 [REQUIREMENT]
 UID: REQ-EXTENSIONS-001

--- a/.strictdoc/docs/04-module-reqs/04f-viz-migrate-lifecycle.sdoc
+++ b/.strictdoc/docs/04-module-reqs/04f-viz-migrate-lifecycle.sdoc
@@ -1,10 +1,5 @@
 [DOCUMENT]
 TITLE: Module Requirements — viz.py, migrate-config.py, lifecycle_check.py
-PREAMBLE: >>>
-Design-level requirements for visualization/reporting, configuration migration, and lifecycle automation.
-Consolidated requirements for three operational/infrastructure modules.
-Total: 22 requirements (viz: 8, migrate: 6, lifecycle: 8).
-<<<
 
 [REQUIREMENT]
 UID: REQ-VIZ-001

--- a/.strictdoc/docs/index.sdoc
+++ b/.strictdoc/docs/index.sdoc
@@ -1,19 +1,6 @@
 [DOCUMENT]
 TITLE: agent-meta Requirements Specification
 
-PREAMBLE: >>>
-Central requirements specification for agent-meta framework v0.39.0.
-
-This specification is organized in three levels following ISO/IEC/IEEE 29148 standard:
-- L1 (Stakeholder): What users expect from the framework
-- L2 (System): How the system implements stakeholder requirements
-- L3 (Design): Which modules implement system requirements
-
-All requirements are traceable from stakeholder needs through system design to implementation.
-
-Generated from source: .sdoc files using Strictdoc format.
-Last updated: 2026-05-13
-<<<
 
 [[SECTION]]
 TITLE: Total Requirements: 46


### PR DESCRIPTION
## Summary
- Removes `PREAMBLE:` fields from all 9 `.sdoc` document headers
- `PREAMBLE` is not a valid field for `[DOCUMENT]` blocks in the current StrictDoc version, causing `TextXSyntaxError` on every CI run

## Root Cause
The StrictDoc HTML export workflow was failing with:
```
error: Could not parse file: ...02a-agent-framework.sdoc:4:1:
Expected '[GRAMMAR]' or '[SECTION]' or '[[' or '[' or '[DOCUMENT_FROM_FILE]' or EOF => 'PREAMBLE: '
```

## Test plan
- [ ] StrictDoc → GitHub Pages workflow passes on push to main
- [ ] All 9 affected sdoc files parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)