### PR TITLE
fix: make infrastructure-check multi-provider aware

### DIFF
--- a/.claude/agents/.agent-meta-managed
+++ b/.claude/agents/.agent-meta-managed
@@ -6,6 +6,7 @@ feature.md
 feedback.md
 git.md
 ideation.md
+infrastructure-check.md
 log-analyzer.md
 meta-feedback.md
 orchestrator.md

--- a/.claude/agents/infrastructure-check.md
+++ b/.claude/agents/infrastructure-check.md
@@ -1,7 +1,10 @@
 ---
-name: template-infrastructure-check
+name: infrastructure-check
+model: claude-haiku-4-5-20251001
+permissionMode: plan
 version: "2.0.0"
 description: "Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider."
+generated-from: "1-generic/infrastructure-check.md@2.0.0"
 hint: "Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben"
 tools:
   - Bash
@@ -11,11 +14,11 @@ tools:
   - TodoWrite
 ---
 
-# Infrastructure-Check — {{PROJECT_NAME}}
+# Infrastructure-Check — agent-meta
 
-> **Extension:** Falls `{{EXTENSION_DIR}}/{{PREFIX}}-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
+> **Extension:** Falls `.claude/3-project/am-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
 
-Du bist der **Infrastructure-Check-Agent** für {{PROJECT_NAME}}.
+Du bist der **Infrastructure-Check-Agent** für agent-meta.
 Du prüfst on-demand alle generierten Artefakte auf fehlende externe Voraussetzungen — ohne zu installieren.
 **Nur Reporting, kein Auto-Install.**
 
@@ -228,4 +231,36 @@ Gefunden: <X> BLOCKING, <Y> WARNING, <Z> INFO
 
 ## Sprache
 
-Report → {{INTERNAL_DOCS_LANGUAGE}}
+Report → Deutsch
+
+## Visualization Reporting (Pflicht-Anweisung)
+
+Der Visualisierungsmodus ist aktiv. Protokolliere deinen Status via **Bash-Tool** in `.meta-viz/events.jsonl`.
+
+### Pflicht-Events — exakt diese Bash-Befehle ausführen
+
+**1. Beim Start deiner Aufgabe (erstes was du tust):**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Claude'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Claude'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**2. Wenn du an einen anderen Agenten delegierst** (`ZIEL_AGENT` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3. Wenn du fertig bist — Erfolg:**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3b. Wenn du fertig bist — Fehler** (`FEHLERMELDUNG` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+### Regeln
+- Diese Bash-Befehle **immer ausführen** — sie schreiben eine Zeile JSON ans Log.
+- Kein anderes Tool verwenden — nur `Bash`.
+- Timestamp wird automatisch gesetzt.
+- Nie den Bash-Befehl weglassen oder überspringen.

--- a/.continue/agents/.agent-meta-managed
+++ b/.continue/agents/.agent-meta-managed
@@ -6,6 +6,7 @@ feature.md
 feedback.md
 git.md
 ideation.md
+infrastructure-check.md
 log-analyzer.md
 meta-feedback.md
 orchestrator.md

--- a/.continue/agents/infrastructure-check.md
+++ b/.continue/agents/infrastructure-check.md
@@ -1,21 +1,13 @@
 ---
-name: template-infrastructure-check
-version: "2.0.0"
+name: infrastructure-check
 description: "Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider."
-hint: "Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben"
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - TodoWrite
+alwaysApply: false
 ---
+# Infrastructure-Check — agent-meta
 
-# Infrastructure-Check — {{PROJECT_NAME}}
+> **Extension:** Falls `.continue/3-project/am-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
 
-> **Extension:** Falls `{{EXTENSION_DIR}}/{{PREFIX}}-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
-
-Du bist der **Infrastructure-Check-Agent** für {{PROJECT_NAME}}.
+Du bist der **Infrastructure-Check-Agent** für agent-meta.
 Du prüfst on-demand alle generierten Artefakte auf fehlende externe Voraussetzungen — ohne zu installieren.
 **Nur Reporting, kein Auto-Install.**
 
@@ -228,4 +220,36 @@ Gefunden: <X> BLOCKING, <Y> WARNING, <Z> INFO
 
 ## Sprache
 
-Report → {{INTERNAL_DOCS_LANGUAGE}}
+Report → Deutsch
+
+## Visualization Reporting (Pflicht-Anweisung)
+
+Der Visualisierungsmodus ist aktiv. Protokolliere deinen Status via **Bash-Tool** in `.meta-viz/events.jsonl`.
+
+### Pflicht-Events — exakt diese Bash-Befehle ausführen
+
+**1. Beim Start deiner Aufgabe (erstes was du tust):**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Continue'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Continue'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**2. Wenn du an einen anderen Agenten delegierst** (`ZIEL_AGENT` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3. Wenn du fertig bist — Erfolg:**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3b. Wenn du fertig bist — Fehler** (`FEHLERMELDUNG` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+### Regeln
+- Diese Bash-Befehle **immer ausführen** — sie schreiben eine Zeile JSON ans Log.
+- Kein anderes Tool verwenden — nur `Bash`.
+- Timestamp wird automatisch gesetzt.
+- Nie den Bash-Befehl weglassen oder überspringen.

--- a/.continue/config.yaml
+++ b/.continue/config.yaml
@@ -1,5 +1,5 @@
 # agent-meta:managed-begin
-# Managed by agent-meta v0.39.0 — 2026-05-12
+# Managed by agent-meta v0.39.0 — 2026-05-14
 # Agents : .continue/agents/  (auto-discovered by Continue)
 # Rules  : .continue/rules/   (auto-discovered by Continue)
 # agent-meta:managed-end

--- a/.continue/prompts/.agent-meta-managed
+++ b/.continue/prompts/.agent-meta-managed
@@ -6,6 +6,7 @@ feature.md
 feedback.md
 git.md
 ideation.md
+infrastructure-check.md
 log-analyzer.md
 meta-feedback.md
 orchestrator.md

--- a/.continue/prompts/infrastructure-check.md
+++ b/.continue/prompts/infrastructure-check.md
@@ -1,21 +1,13 @@
 ---
-name: template-infrastructure-check
-version: "2.0.0"
+name: infrastructure-check
 description: "Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider."
-hint: "Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben"
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - TodoWrite
+invokable: true
 ---
+# Infrastructure-Check — agent-meta
 
-# Infrastructure-Check — {{PROJECT_NAME}}
+> **Extension:** Falls `.continue/3-project/am-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
 
-> **Extension:** Falls `{{EXTENSION_DIR}}/{{PREFIX}}-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
-
-Du bist der **Infrastructure-Check-Agent** für {{PROJECT_NAME}}.
+Du bist der **Infrastructure-Check-Agent** für agent-meta.
 Du prüfst on-demand alle generierten Artefakte auf fehlende externe Voraussetzungen — ohne zu installieren.
 **Nur Reporting, kein Auto-Install.**
 
@@ -228,4 +220,4 @@ Gefunden: <X> BLOCKING, <Y> WARNING, <Z> INFO
 
 ## Sprache
 
-Report → {{INTERNAL_DOCS_LANGUAGE}}
+Report → Deutsch

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.39.0 — `2026-05-12`
+Generiert von agent-meta v0.39.0 — `2026-05-14`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.
@@ -21,6 +21,7 @@ DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Cod
 | `feedback` | Projekt-Feedback: Bugs, Features, Verbesserungen als GitHub Issues standardisiert einreichen — immer vor git |
 | `git` | Commits, Branches, Tags, Push/Pull und alle Git-Operationen |
 | `ideation` | Neue Ideen explorieren, Vision schärfen, Übergabe an requirements |
+| `infrastructure-check` | Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben |
 | `log-analyzer` | Log-Analyse: Fehler clustern, Severity klassifizieren (RFC 5424), Findings als Issues oder Tasks delegieren |
 | `meta-feedback` | Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen |
 | `orchestrator` | Einstiegspunkt für alle Entwicklungsaufgaben — koordiniert alle anderen Agenten |

--- a/.gemini/agents/.agent-meta-managed
+++ b/.gemini/agents/.agent-meta-managed
@@ -6,6 +6,7 @@ feature.md
 feedback.md
 git.md
 ideation.md
+infrastructure-check.md
 log-analyzer.md
 meta-feedback.md
 orchestrator.md

--- a/.gemini/agents/infrastructure-check.md
+++ b/.gemini/agents/infrastructure-check.md
@@ -1,7 +1,9 @@
 ---
-name: template-infrastructure-check
+name: infrastructure-check
+model: gemini-2.5-flash
 version: "2.0.0"
 description: "Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider."
+generated-from: "1-generic/infrastructure-check.md@2.0.0"
 hint: "Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben"
 tools:
   - Bash
@@ -10,12 +12,11 @@ tools:
   - Grep
   - TodoWrite
 ---
+# Infrastructure-Check — agent-meta
 
-# Infrastructure-Check — {{PROJECT_NAME}}
+> **Extension:** Falls `.gemini/3-project/am-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
 
-> **Extension:** Falls `{{EXTENSION_DIR}}/{{PREFIX}}-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
-
-Du bist der **Infrastructure-Check-Agent** für {{PROJECT_NAME}}.
+Du bist der **Infrastructure-Check-Agent** für agent-meta.
 Du prüfst on-demand alle generierten Artefakte auf fehlende externe Voraussetzungen — ohne zu installieren.
 **Nur Reporting, kein Auto-Install.**
 
@@ -228,4 +229,36 @@ Gefunden: <X> BLOCKING, <Y> WARNING, <Z> INFO
 
 ## Sprache
 
-Report → {{INTERNAL_DOCS_LANGUAGE}}
+Report → Deutsch
+
+## Visualization Reporting (Pflicht-Anweisung)
+
+Der Visualisierungsmodus ist aktiv. Protokolliere deinen Status via **Bash-Tool** in `.meta-viz/events.jsonl`.
+
+### Pflicht-Events — exakt diese Bash-Befehle ausführen
+
+**1. Beim Start deiner Aufgabe (erstes was du tust):**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Gemini'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Gemini'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**2. Wenn du an einen anderen Agenten delegierst** (`ZIEL_AGENT` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3. Wenn du fertig bist — Erfolg:**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3b. Wenn du fertig bist — Fehler** (`FEHLERMELDUNG` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+### Regeln
+- Diese Bash-Befehle **immer ausführen** — sie schreiben eine Zeile JSON ans Log.
+- Kein anderes Tool verwenden — nur `Bash`.
+- Timestamp wird automatisch gesetzt.
+- Nie den Bash-Befehl weglassen oder überspringen.

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -34,6 +34,7 @@ roles:
   - agent-meta-scout
   - log-analyzer
   - feedback
+  - infrastructure-check
 
 project:
   name: agent-meta

--- a/.opencode/agents/.agent-meta-managed
+++ b/.opencode/agents/.agent-meta-managed
@@ -6,6 +6,7 @@ feature.md
 feedback.md
 git.md
 ideation.md
+infrastructure-check.md
 log-analyzer.md
 meta-feedback.md
 orchestrator.md

--- a/.opencode/agents/infrastructure-check.md
+++ b/.opencode/agents/infrastructure-check.md
@@ -1,21 +1,15 @@
 ---
-name: template-infrastructure-check
-version: "2.0.0"
+name: infrastructure-check
 description: "Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider."
-hint: "Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben"
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - TodoWrite
+mode: subagent
+model: opencode-go/deepseek-v4-flash
+generated-from: "1-generic/infrastructure-check.md@2.0.0"
 ---
+# Infrastructure-Check — agent-meta
 
-# Infrastructure-Check — {{PROJECT_NAME}}
+> **Extension:** Falls `.opencode/3-project/am-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
 
-> **Extension:** Falls `{{EXTENSION_DIR}}/{{PREFIX}}-infrastructure-check-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
-
-Du bist der **Infrastructure-Check-Agent** für {{PROJECT_NAME}}.
+Du bist der **Infrastructure-Check-Agent** für agent-meta.
 Du prüfst on-demand alle generierten Artefakte auf fehlende externe Voraussetzungen — ohne zu installieren.
 **Nur Reporting, kein Auto-Install.**
 
@@ -228,4 +222,36 @@ Gefunden: <X> BLOCKING, <Y> WARNING, <Z> INFO
 
 ## Sprache
 
-Report → {{INTERNAL_DOCS_LANGUAGE}}
+Report → Deutsch
+
+## Visualization Reporting (Pflicht-Anweisung)
+
+Der Visualisierungsmodus ist aktiv. Protokolliere deinen Status via **Bash-Tool** in `.meta-viz/events.jsonl`.
+
+### Pflicht-Events — exakt diese Bash-Befehle ausführen
+
+**1. Beim Start deiner Aufgabe (erstes was du tust):**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Opencode'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_start','agent':'infrastructure-check','provider':'Opencode'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**2. Wenn du an einen anderen Agenten delegierst** (`ZIEL_AGENT` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'delegate','from':'infrastructure-check','to':'ZIEL_AGENT'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3. Wenn du fertig bist — Erfolg:**
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'success'};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+**3b. Wenn du fertig bist — Fehler** (`FEHLERMELDUNG` ersetzen):
+```bash
+python3 -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null || python -c "import json,os,sys;from datetime import datetime,timezone;d={'event':'agent_end','agent':'infrastructure-check','status':'error','payload':{'error':'FEHLERMELDUNG'}};d.setdefault('ts',datetime.now(timezone.utc).isoformat());p='.meta-viz/events.jsonl';os.makedirs(os.path.dirname(p),exist_ok=True);open(p,'a',encoding='utf-8').write(json.dumps(d,ensure_ascii=False)+'\n')" 2>/dev/null
+```
+
+### Regeln
+- Diese Bash-Befehle **immer ausführen** — sie schreiben eine Zeile JSON ans Log.
+- Kein anderes Tool verwenden — nur `Bash`.
+- Timestamp wird automatisch gesetzt.
+- Nie den Bash-Befehl weglassen oder überspringen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.39.0 — `2026-05-12`
+Generiert von agent-meta v0.39.0 — `2026-05-14`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.
@@ -21,6 +21,7 @@ DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Cod
 | `feedback` | Projekt-Feedback: Bugs, Features, Verbesserungen als GitHub Issues standardisiert einreichen — immer vor git |
 | `git` | Commits, Branches, Tags, Push/Pull und alle Git-Operationen |
 | `ideation` | Neue Ideen explorieren, Vision schärfen, Übergabe an requirements |
+| `infrastructure-check` | Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben |
 | `log-analyzer` | Log-Analyse: Fehler clustern, Severity klassifizieren (RFC 5424), Findings als Issues oder Tasks delegieren |
 | `meta-feedback` | Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen |
 | `orchestrator` | Einstiegspunkt für alle Entwicklungsaufgaben — koordiniert alle anderen Agenten |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ Sinnvoll für das agent-meta Meta-Repository selbst, das alle Provider-Verzeichn
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.39.0 — `2026-05-12`
+Generiert von agent-meta v0.39.0 — `2026-05-14`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.
@@ -189,7 +189,7 @@ DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Cod
 | `feedback` | Projekt-Feedback: Bugs, Features, Verbesserungen als GitHub Issues standardisiert einreichen — immer vor git |
 | `git` | Commits, Branches, Tags, Push/Pull und alle Git-Operationen |
 | `ideation` | Neue Ideen explorieren, Vision schärfen, Übergabe an requirements |
-| `infrastructure-check` | On-demand Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates erkennen |
+| `infrastructure-check` | Prerequisite-Check: fehlende CLIs/Runtimes in Hooks, MCP-Configs und Agent-Templates aller aktiven Provider erkennen und Installationsanleitung geben |
 | `log-analyzer` | Log-Analyse: Fehler clustern, Severity klassifizieren (RFC 5424), Findings als Issues oder Tasks delegieren |
 | `meta-feedback` | Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen |
 | `orchestrator` | Einstiegspunkt für alle Entwicklungsaufgaben — koordiniert alle anderen Agenten |

--- a/docs/agent-graph.html
+++ b/docs/agent-graph.html
@@ -171,9 +171,7 @@ graph TD
     classDef required fill:#e03131,stroke:#fff,stroke-width:2px,color:#fff
     classDef recommended fill:#1971c2,stroke:#fff,stroke-width:2px,color:#fff
     classDef optional fill:#868e96,stroke:#fff,stroke-width:2px,color:#fff
-    class developer,feedback,git,log-analyzer,orchestrator required
-    class documenter,feature,requirements,reviewer,tester,validator recommended
-    class agent-meta-manager,agent-meta-scout,docker,ideation,meta-feedback,openscad-developer,performance,release,security-auditor optional
+    class agent-meta-manager,agent-meta-scout,developer,docker,documenter,feature,feedback,git,ideation,infrastructure-check,log-analyzer,meta-feedback,openscad-developer,orchestrator,performance,release,requirements,reviewer,security-auditor,tester,validator optional
                 </div>
                 <div class="legend">
                     <div class="legend-item">
@@ -221,11 +219,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-required" id="developer">
+        <div class="agent-card tier-optional" id="developer">
             <div class="agent-header">
-                <span class="tier-icon">🔴</span>
+                <span class="tier-icon">⚪</span>
                 <h3>developer</h3>
-                <span class="tier-badge">required</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur, Rollen-Anlegen-Prozess und Sync-Interface.</p>
             <div class="meta">
@@ -249,11 +247,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-recommended" id="documenter">
+        <div class="agent-card tier-optional" id="documenter">
             <div class="agent-header">
-                <span class="tier-icon">🔵</span>
+                <span class="tier-icon">⚪</span>
                 <h3>documenter</h3>
-                <span class="tier-badge">recommended</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Pflegt CODEBASE_OVERVIEW.md, ARCHITECTURE.md, README.md und Session-Erkenntnisse.</p>
             <div class="meta">
@@ -263,11 +261,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-recommended" id="feature">
+        <div class="agent-card tier-optional" id="feature">
             <div class="agent-header">
-                <span class="tier-icon">🔵</span>
+                <span class="tier-icon">⚪</span>
                 <h3>feature</h3>
-                <span class="tier-badge">recommended</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR.</p>
             <div class="meta">
@@ -277,11 +275,11 @@ graph TD
             <div class="children"><strong>Delegiert an:</strong> <a href="#requirements" onclick="scrollToAgent('requirements')">requirements</a>, <a href="#validator" onclick="scrollToAgent('validator')">validator</a>, <a href="#developer" onclick="scrollToAgent('developer')">developer</a>, <a href="#tester" onclick="scrollToAgent('tester')">tester</a>, <a href="#git" onclick="scrollToAgent('git')">git</a></div>
         </div>
         
-        <div class="agent-card tier-required" id="feedback">
+        <div class="agent-card tier-optional" id="feedback">
             <div class="agent-header">
-                <span class="tier-icon">🔴</span>
+                <span class="tier-icon">⚪</span>
                 <h3>feedback</h3>
-                <span class="tier-badge">required</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Standardisiert Bug-Reports, Feature-Requests und Verbesserungsvorschläge für das eingesetzte Projekt — kategorisiert, aufbereitet und direkt als GitHub Issue eingereicht.</p>
             <div class="meta">
@@ -291,11 +289,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-required" id="git">
+        <div class="agent-card tier-optional" id="git">
             <div class="agent-header">
-                <span class="tier-icon">🔴</span>
+                <span class="tier-icon">⚪</span>
                 <h3>git</h3>
-                <span class="tier-badge">required</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Git-Operationen: Commits, Branches, Merges, Tags, Push/Pull und Commit-Messages — plattformunabhängig (GitHub, GitLab, Gitea).</p>
             <div class="meta">
@@ -319,11 +317,25 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-required" id="log-analyzer">
+        <div class="agent-card tier-optional" id="infrastructure-check">
             <div class="agent-header">
-                <span class="tier-icon">🔴</span>
+                <span class="tier-icon">⚪</span>
+                <h3>infrastructure-check</h3>
+                <span class="tier-badge">optional</span>
+            </div>
+            <p class="description">Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider.</p>
+            <div class="meta">
+                <span><strong>Model:</strong> <span>Claude: claude-haiku-4-5-20251001</span><br><span>Continue: codellama:7b</span><br><span>Gemini: gemini-2.5-flash</span><br><span>Opencode: opencode-go/deepseek-v4-flash</span></span>
+                <span><strong>Memory:</strong> -</span>
+            </div>
+            
+        </div>
+        
+        <div class="agent-card tier-optional" id="log-analyzer">
+            <div class="agent-header">
+                <span class="tier-icon">⚪</span>
                 <h3>log-analyzer</h3>
-                <span class="tier-badge">required</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Analysiert System- und Applikations-Logs: Frequency-Clustering, Severity-Klassifikation (RFC 5424), Root-Cause-Hypothesen und strukturierte Findings mit Delegations-Routing.</p>
             <div class="meta">
@@ -361,11 +373,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-required" id="orchestrator">
+        <div class="agent-card tier-optional" id="orchestrator">
             <div class="agent-header">
-                <span class="tier-icon">🔴</span>
+                <span class="tier-icon">⚪</span>
                 <h3>orchestrator</h3>
-                <span class="tier-badge">required</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Koordiniert alle Agenten durch den Entwicklungsprozess: Requirements → Development → Testing → Validation → Documentation.</p>
             <div class="meta">
@@ -403,11 +415,11 @@ graph TD
             <div class="children"><strong>Delegiert an:</strong> <a href="#git" onclick="scrollToAgent('git')">git</a>, <a href="#documenter" onclick="scrollToAgent('documenter')">documenter</a></div>
         </div>
         
-        <div class="agent-card tier-recommended" id="requirements">
+        <div class="agent-card tier-optional" id="requirements">
             <div class="agent-header">
-                <span class="tier-icon">🔵</span>
+                <span class="tier-icon">⚪</span>
                 <h3>requirements</h3>
-                <span class="tier-badge">recommended</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen und Traceability prüfen.</p>
             <div class="meta">
@@ -417,11 +429,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-recommended" id="reviewer">
+        <div class="agent-card tier-optional" id="reviewer">
             <div class="agent-header">
-                <span class="tier-icon">🔵</span>
+                <span class="tier-icon">⚪</span>
                 <h3>reviewer</h3>
-                <span class="tier-badge">recommended</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Code-Review vor dem Merge: Qualität, Stil, Logik, Best Practices und Security-Smells prüfen.</p>
             <div class="meta">
@@ -445,11 +457,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-recommended" id="tester">
+        <div class="agent-card tier-optional" id="tester">
             <div class="agent-header">
-                <span class="tier-icon">🔵</span>
+                <span class="tier-icon">⚪</span>
                 <h3>tester</h3>
-                <span class="tier-badge">recommended</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Unit-/Integration-/E2E-Tests nach TDD-Workflow schreiben, ausführen und Testabdeckung pro REQ-ID sicherstellen.</p>
             <div class="meta">
@@ -459,11 +471,11 @@ graph TD
             
         </div>
         
-        <div class="agent-card tier-recommended" id="validator">
+        <div class="agent-card tier-optional" id="validator">
             <div class="agent-header">
-                <span class="tier-icon">🔵</span>
+                <span class="tier-icon">⚪</span>
                 <h3>validator</h3>
-                <span class="tier-badge">recommended</span>
+                <span class="tier-badge">optional</span>
             </div>
             <p class="description">Code gegen Anforderungen prüfen, Traceability validieren, Definition of Done und Codequalität sicherstellen.</p>
             <div class="meta">

--- a/docs/agent-mindmap.md
+++ b/docs/agent-mindmap.md
@@ -5,37 +5,37 @@
 ```mermaid
 mindmap
   root((orchestrator))
-    🔴 developer
+    ⚪ developer
       tester
       git
-    🔵 feature
+    ⚪ feature
       requirements
       validator
       developer
       tester
       git
-    🔴 git
-    🔵 documenter
+    ⚪ git
+    ⚪ documenter
     ⚪ ideation
     ⚪ release
       git
       documenter
     ⚪ security-auditor
     ⚪ docker
-    🔴 log-analyzer
+    ⚪ log-analyzer
       feedback
       developer
       security-auditor
-    🔴 feedback
+    ⚪ feedback
     ⚪ agent-meta-manager
       agent-meta-scout
       developer
       git
     ⚪ agent-meta-scout
     ⚪ meta-feedback
-    🔵 requirements
-    🔵 validator
-    🔵 tester
+    ⚪ requirements
+    ⚪ validator
+    ⚪ tester
 ```
 
 ## Legende
@@ -60,7 +60,7 @@ mindmap
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
 ### developer
-- **Tier:** required
+- **Tier:** optional
 - **Beschreibung:** Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur, Rollen-Anlegen-Prozess und Sync-Interface.
 - **Model:** Claude: claude-opus-4-7, Continue: claude-opus-4-7, Gemini: gemini-2.5-pro, Opencode: opencode-go/kimi-k2.6
 - **Delegiert an:** tester, git
@@ -71,23 +71,23 @@ mindmap
 - **Model:** Claude: claude-haiku-4-5-20251001, Continue: codellama:7b, Gemini: gemini-2.5-flash, Opencode: opencode-go/deepseek-v4-flash
 
 ### documenter
-- **Tier:** recommended
+- **Tier:** optional
 - **Beschreibung:** Pflegt CODEBASE_OVERVIEW.md, ARCHITECTURE.md, README.md und Session-Erkenntnisse.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
 ### feature
-- **Tier:** recommended
+- **Tier:** optional
 - **Beschreibung:** Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 - **Delegiert an:** requirements, validator, developer, tester, git
 
 ### feedback
-- **Tier:** required
+- **Tier:** optional
 - **Beschreibung:** Standardisiert Bug-Reports, Feature-Requests und Verbesserungsvorschläge für das eingesetzte Projekt — kategorisiert, aufbereitet und direkt als GitHub Issue eingereicht.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
 ### git
-- **Tier:** required
+- **Tier:** optional
 - **Beschreibung:** Git-Operationen: Commits, Branches, Merges, Tags, Push/Pull und Commit-Messages — plattformunabhängig (GitHub, GitLab, Gitea).
 - **Model:** Claude: claude-haiku-4-5-20251001, Continue: codellama:7b, Gemini: gemini-2.5-flash, Opencode: opencode-go/deepseek-v4-flash
 
@@ -96,8 +96,13 @@ mindmap
 - **Beschreibung:** Ideenfindung, Visions-Schärfung und Konzept-Konkretisierung — stellt Fragen, denkt Ecken, übergibt reife Ideen an Requirements.
 - **Model:** inherited
 
+### infrastructure-check
+- **Tier:** optional
+- **Beschreibung:** Prüft alle generierten Artefakte auf fehlende externe Voraussetzungen (CLIs, Runtimes, Binaries) — provider-übergreifend für alle aktiven AI-Provider.
+- **Model:** Claude: claude-haiku-4-5-20251001, Continue: codellama:7b, Gemini: gemini-2.5-flash, Opencode: opencode-go/deepseek-v4-flash
+
 ### log-analyzer
-- **Tier:** required
+- **Tier:** optional
 - **Beschreibung:** Analysiert System- und Applikations-Logs: Frequency-Clustering, Severity-Klassifikation (RFC 5424), Root-Cause-Hypothesen und strukturierte Findings mit Delegations-Routing.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 - **Delegiert an:** feedback, developer, security-auditor
@@ -113,7 +118,7 @@ mindmap
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
 ### orchestrator
-- **Tier:** required
+- **Tier:** optional
 - **Beschreibung:** Koordiniert alle Agenten durch den Entwicklungsprozess: Requirements → Development → Testing → Validation → Documentation.
 - **Model:** Claude: claude-haiku-4-5-20251001, Continue: codellama:7b, Gemini: gemini-2.5-flash, Opencode: opencode-go/deepseek-v4-flash
 - **Delegiert an:** developer, feature, git, documenter, ideation, release, security-auditor, docker, log-analyzer, feedback, agent-meta-manager, agent-meta-scout, meta-feedback, requirements, validator, tester
@@ -130,12 +135,12 @@ mindmap
 - **Delegiert an:** git, documenter
 
 ### requirements
-- **Tier:** recommended
+- **Tier:** optional
 - **Beschreibung:** Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen und Traceability prüfen.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
 ### reviewer
-- **Tier:** recommended
+- **Tier:** optional
 - **Beschreibung:** Code-Review vor dem Merge: Qualität, Stil, Logik, Best Practices und Security-Smells prüfen.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
@@ -145,11 +150,11 @@ mindmap
 - **Model:** Claude: claude-opus-4-7, Continue: claude-opus-4-7, Gemini: gemini-2.5-pro, Opencode: opencode-go/kimi-k2.6
 
 ### tester
-- **Tier:** recommended
+- **Tier:** optional
 - **Beschreibung:** Unit-/Integration-/E2E-Tests nach TDD-Workflow schreiben, ausführen und Testabdeckung pro REQ-ID sicherstellen.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus
 
 ### validator
-- **Tier:** recommended
+- **Tier:** optional
 - **Beschreibung:** Code gegen Anforderungen prüfen, Traceability validieren, Definition of Done und Codequalität sicherstellen.
 - **Model:** Claude: claude-sonnet-4-6, Continue: claude-sonnet-4-6, Gemini: gemini-2.5-pro, Opencode: opencode-go/qwen3.6-plus


### PR DESCRIPTION
## Summary

- Template v1.0.0 only scanned Claude-specific paths (`.claude/hooks/`, `.claude/agents/`, `.claude/settings.json`), silently ignoring Gemini, Opencode, and Continue
- `infrastructure-check` was missing from `project.yaml` roles entirely — the agent was never generated
- Fixed both issues: template now covers all 4 active providers, agent is now registered and generated for all providers

## Changes

- **`agents/1-generic/infrastructure-check.md`** — v1.0.0 → v2.0.0: Schritte 2–4 prüfen jetzt alle Provider; neues Provider-Pfad-Mapping als Referenztabelle; Don'ts ergänzt
- **`.meta-config/project.yaml`** — `infrastructure-check` in `roles` eingetragen
- **Generated for all providers:** `.claude/agents/`, `.gemini/agents/`, `.opencode/agents/`, `.continue/agents/`

## Test plan

- [ ] `python scripts/sync.py --dry-run` läuft fehlerfrei
- [ ] `.claude/agents/infrastructure-check.md` existiert und enthält alle 4 Provider-Abschnitte
- [ ] Agent scannt bei Aufruf Hooks/Settings für Claude + Gemini + Opencode + Continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)