### PR TITLE
fix(strictdoc): remove double blank lines causing TextX parse failure

### DIFF
--- a/.strictdoc/docs/01-stakeholder-reqs.sdoc
+++ b/.strictdoc/docs/01-stakeholder-reqs.sdoc
@@ -1,7 +1,6 @@
 [DOCUMENT]
 TITLE: Stakeholder Requirements Specification (L1)
 
-
 [REQUIREMENT]
 UID: REQ-STK-001
 TITLE: Framework stellt standardisierte Agent-Rollen bereit

--- a/.strictdoc/docs/02-system-reqs/02a-agent-framework.sdoc
+++ b/.strictdoc/docs/02-system-reqs/02a-agent-framework.sdoc
@@ -1,7 +1,6 @@
 [DOCUMENT]
 TITLE: System Requirements — Agent Framework Core (L2)
 
-
 [REQUIREMENT]
 UID: REQ-SYS-001
 TITLE: sync.py ist zentrale Generator-Engine

--- a/.strictdoc/docs/index.sdoc
+++ b/.strictdoc/docs/index.sdoc
@@ -1,7 +1,6 @@
 [DOCUMENT]
 TITLE: agent-meta Requirements Specification
 
-
 [[SECTION]]
 TITLE: Total Requirements: 46
 


### PR DESCRIPTION
## Summary

- StrictDoc's TextX grammar rejects triple newlines (`\n\n\n`) after a `[DOCUMENT]` block — the parser emits `Expected EOF` at the first `[REQUIREMENT]` that follows
- Three files had this issue and would fail the GitHub Actions export job
- Fixed by collapsing all consecutive blank lines to a single blank line

## Files fixed

- `.strictdoc/docs/01-stakeholder-reqs.sdoc`
- `.strictdoc/docs/02-system-reqs/02a-agent-framework.sdoc`
- `.strictdoc/docs/index.sdoc`

## Test plan

- [ ] GitHub Actions `strictdoc-export` job passes without parse errors
- [ ] All 13 `.sdoc` files parse without `Expected EOF` errors
- [ ] StrictDoc HTML output is generated correctly to `_build/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)