### PR TITLE
fix: add Opencode provider support, missing roles, and config defaults

### DIFF
--- a/.strictdoc/docs/index.sdoc
+++ b/.strictdoc/docs/index.sdoc
@@ -4,6 +4,7 @@ TITLE: agent-meta Requirements Specification
 [[SECTION]]
 TITLE: Total Requirements: 46
 
+[TEXT]
 - 17 Stakeholder Requirements (REQ-STK-001..017)
 - 21 System Requirements (REQ-SYS-001..021)
 - 8 Design Requirements (REQ-DES-001..008)

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -25,18 +25,20 @@
         "Claude",
         "Gemini",
         "Continue",
+        "Opencode",
         "GitHub"
       ]
     },
     "ai-providers": {
       "type": "array",
-      "description": "List of AI providers. Supports Claude, Gemini, Continue. Replaces the deprecated ai-provider string field. Backward-compatible: ai-provider (string) still works.",
+      "description": "List of AI providers. Supports Claude, Gemini, Continue, Opencode. Replaces the deprecated ai-provider string field. Backward-compatible: ai-provider (string) still works.",
       "items": {
         "type": "string",
         "enum": [
           "Claude",
           "Gemini",
-          "Continue"
+          "Continue",
+          "Opencode"
         ]
       },
       "uniqueItems": true
@@ -70,7 +72,10 @@
           "feature",
           "agent-meta-scout",
           "security-auditor",
-          "openscad-developer"
+          "openscad-developer",
+          "log-analyzer",
+          "feedback",
+          "infrastructure-check"
         ]
       },
       "uniqueItems": true
@@ -258,6 +263,17 @@
           "type": "object",
           "description": "Continue model overrides (ignored — Continue manages models in config.yaml).",
           "additionalProperties": {"type": "string"}
+        },
+        "Opencode": {
+          "type": "object",
+          "description": "Opencode-specific model overrides: role → tier or full model ID.",
+          "additionalProperties": {
+            "type": "string",
+            "anyOf": [
+              {"enum": ["nano", "fast", "balanced", "powerful", "max"]},
+              {"pattern": "^opencode"}
+            ]
+          }
         }
       },
       "additionalProperties": {
@@ -400,6 +416,12 @@
               "default": "full"
             }
           }
+        },
+        "Opencode": {
+          "type": "object",
+          "description": "Options for the Opencode provider.",
+          "additionalProperties": false,
+          "properties": {}
         }
       },
       "additionalProperties": false
@@ -451,6 +473,74 @@
       "type": "string",
       "enum": ["disabled"],
       "description": "Set to 'disabled' to skip provider isolation generation (e.g. in the agent-meta meta-repo itself, which intentionally manages all provider directories)."
+    },
+    "rules-preset": {
+      "type": "string",
+      "description": "Controls which rules are always active (alwaysApply) and per-provider skip behavior. Presets are defined in config/rules-presets.yaml.",
+      "enum": ["default", "minimal", "silent"],
+      "default": "default"
+    },
+    "viz": {
+      "type": "object",
+      "description": "Agent visualization and session tracking configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable agent visualization (mindmap, event log, session tracking).",
+          "default": false
+        },
+        "mode": {
+          "type": "string",
+          "description": "Visualization mode: 'off' = disabled, 'static' = only mindmap, 'dynamic' = session tracking, 'full' = both.",
+          "enum": ["off", "static", "dynamic", "full"],
+          "default": "off"
+        },
+        "event_log": {
+          "type": "string",
+          "description": "Path to the newline-delimited JSON event log file.",
+          "default": ".meta-viz/events.jsonl"
+        },
+        "report": {
+          "type": "object",
+          "description": "Session report retention settings.",
+          "properties": {
+            "retention_days": {
+              "type": "integer",
+              "description": "How long to keep generated session reports.",
+              "default": 7,
+              "minimum": 1
+            },
+            "session_timeout_min": {
+              "type": "integer",
+              "description": "Minutes of inactivity before a session is considered ended.",
+              "default": 5,
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "server": {
+          "type": "object",
+          "description": "Optional local visualization server settings.",
+          "properties": {
+            "port": {
+              "type": "integer",
+              "description": "Port for the local viz server.",
+              "default": 8765,
+              "minimum": 1024,
+              "maximum": 65535
+            },
+            "timeout_sec": {
+              "type": "integer",
+              "description": "Server request timeout in seconds.",
+              "default": 300,
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "allow-committed-secrets": {
       "type": "boolean",

--- a/howto/configs/project.yaml.example
+++ b/howto/configs/project.yaml.example
@@ -43,10 +43,10 @@ project:
   short: mein-plugin               # Kurzname ohne Plattform-Prefix
 
 # Kommunikationsstil: "full" (Default), "short", "childish", "caveman", "asozial", "submissive"
-# speech-mode: full
+speech-mode: full
 
 # Maximale parallele Agenten (1 = sequentiell, 2 = Default)
-# max-parallel-agents: 2
+max-parallel-agents: 2
 
 # Hooks — opt-in pro Hook
 # hooks:

--- a/howto/configs/project.yaml.homeassistant.example
+++ b/howto/configs/project.yaml.homeassistant.example
@@ -32,10 +32,10 @@ roles:
   - agent-meta-manager
 
 # Kommunikationsstil
-# speech-mode: full
+speech-mode: full
 
 # Maximale parallele Agenten
-# max-parallel-agents: 2
+max-parallel-agents: 2
 
 # Hooks — opt-in
 # hooks:

--- a/scripts/lib/setup.py
+++ b/scripts/lib/setup.py
@@ -183,6 +183,13 @@ def run_setup_wizard(
         config["platforms"] = platforms
 
     config["dod-preset"] = dod_preset
+    config["dod"] = {}
+    config["speech-mode"] = "full"
+    config["max-parallel-agents"] = 2
+    config["model-overrides"] = {}
+    config["hooks"] = {}
+    config["provider-options"] = {}
+    config["external-skills"] = {}
     config["project"] = {
         "name": name,
         "prefix": prefix,
@@ -264,4 +271,76 @@ def _write_config(path: Path, config: dict) -> None:
         "# Danach: py .agent-meta/scripts/sync.py\n\n"
     )
     body = yaml.dump(config, allow_unicode=True, sort_keys=False, default_flow_style=False)
+    # Replace empty placeholders with commented YAML blocks
+    body = body.replace(
+        "dod: {}\n",
+        (
+            "# Definition of Done — einzelne Kriterien überschreiben (erbt von dod-preset)\n"
+            "# dod:\n"
+            "#   req-traceability: false\n"
+            "#   tests-required: false\n"
+            "#   codebase-overview: false\n"
+            "#   security-audit: false\n"
+            "\n"
+        ),
+    )
+    body = body.replace(
+        "model-overrides: {}\n",
+        (
+            "# Modell-Tiers pro Rolle überschreiben (optional)\n"
+            "# Tiers: nano | fast | balanced | powerful | max\n"
+            "# Form A — provider-spezifisch (empfohlen bei Multi-Provider):\n"
+            "# model-overrides:\n"
+            "#   Claude:\n"
+            "#     orchestrator: powerful\n"
+            "#     developer: powerful\n"
+            "#     git: nano\n"
+            "#   Gemini:\n"
+            "#     orchestrator: balanced\n"
+            "#     developer: balanced\n"
+            "#     git: fast\n"
+            "#\n"
+            "# Form B — flat (Legacy, wird als Claude-Override interpretiert):\n"
+            "# model-overrides:\n"
+            "#   git: fast\n"
+            "#   developer: powerful\n"
+            "\n"
+        ),
+    )
+    body = body.replace(
+        "hooks: {}\n",
+        (
+            "# Hooks — opt-in pro Hook (Script muss existieren + enabled: true)\n"
+            "# hooks:\n"
+            "#   dod-push-check:\n"
+            "#     enabled: true\n"
+            "#   lifecycle-check:\n"
+            "#     enabled: true\n"
+            "\n"
+        ),
+    )
+    body = body.replace(
+        "provider-options: {}\n",
+        (
+            "# Provider-spezifische Optionen — z.B. Continue: generate-prompts, prompt-mode\n"
+            "# provider-options:\n"
+            "#   Claude: {}\n"
+            "#   Gemini: {}\n"
+            "#   Continue:\n"
+            "#     generate-prompts: true\n"
+            "#     prompt-mode: full\n"
+            "#   Opencode: {}\n"
+            "\n"
+        ),
+    )
+    body = body.replace(
+        "external-skills: {}\n",
+        (
+            "# Externe Skills — opt-in (muss auch approved: true in skills-registry.yaml sein)\n"
+            "# external-skills:\n"
+            "#   home-organization:\n"
+            "#     enabled: true\n"
+            "\n"
+        ),
+    )
     path.write_text(header + body, encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR adds comprehensive Opencode provider support to the JSON schema, fills in missing roles and config fields, and improves the default project generation.

## Changes

### JSON Schema (`config/project-config.schema.json`)
- **Opencode provider**: Added `Opencode` to the `ai-provider` enum, `ai-providers` array, `model-overrides` (with relaxed pattern `^opencode`), and `provider-options` blocks
- **Missing roles**: Added `log-analyzer`, `feedback`, and `infrastructure-check` to the roles enum
- **Top-level fields**: Added `rules-preset` (enum: default/minimal/silent) and `viz` (enabled, mode, event_log, report, server)

### Setup Script (`scripts/lib/setup.py`)
- Always generates `speech-mode`, `max-parallel-agents`, `model-overrides`, `dod`, `hooks`, `provider-options`, and `external-skills` with empty defaults
- Empty dicts are replaced with commented YAML placeholders showing example values

### Example Configs
- Activated `speech-mode: full` and `max-parallel-agents: 2` (was commented out) in both `project.yaml.example` and `project.yaml.homeassistant.example`

### StrictDoc
- Fixed missing `[TEXT]` marker in `index.sdoc`

## Related
- Commit: `41bb191`