### PR TITLE
fix: correct sharkord-orchestrator scope — cross-plugin features only active when META_REPO: true

### DIFF
--- a/agents/2-platform/sharkord-orchestrator.md
+++ b/agents/2-platform/sharkord-orchestrator.md
@@ -1,9 +1,9 @@
 ---
 name: sharkord-orchestrator
-version: "1.0.0"
+version: "1.0.1"
 based-on: "1-generic/orchestrator.md@2.9.0"
-description: "Sharkord-spezifischer Orchestrator-Agent. Ergänzt den generischen Orchestrator um Cross-Plugin Standardization Workflows und Multi-Repo Workspace Awareness."
-hint: "Koordiniert Sharkord Plugins — inkl. Cross-Plugin Standardisierung"
+description: "Sharkord-spezifischer Orchestrator-Agent für EINZELNE Plugin-Repos. Ergänzt den generischen Orchestrator um Plugin-spezifische Routing-Hinweise. Cross-Plugin Standardisierung ist nur aktiv wenn das Projekt als Meta-Repo konfiguriert ist (META_REPO: true)."
+hint: "Koordiniert ein einzelnes Sharkord Plugin — Standardisierung nur bei Meta-Repo"
 tools:
   - Bash
   - Read
@@ -20,9 +20,18 @@ patches:
   - op: append-after
     anchor: "## Agenten"
     content: |
-      ## Cross-Plugin Standardization Workflow
+      ## Sharkord Plugin Routing Guide
 
-      When the meta-repo (sharkord-meta) updates a convention, pattern, or standard that affects multiple plugins:
+      Standard-Verhalten (Einzelnes Plugin-Repo):
+      - Alle Operationen laufen im aktuellen Plugin-Repo.
+      - Keine Annahme über Meta-Repo-Struktur oder Sibling-Repos.
+
+      ## Cross-Plugin Standardization (NUR bei Meta-Repo)
+
+      > **Hinweis:** Dieser Abschnitt ist nur relevant wenn `META_REPO: true` in `project.yaml` gesetzt ist.
+      > Für normale Plugin-Repos überspringen.
+
+      Wenn dieses Projekt ein Meta-Repo ist (koordiniert mehrere Plugins):
 
       ```
       1. documenter: Update shared standards in sharkord-meta/docs/
@@ -41,7 +50,7 @@ patches:
          → Ensure all plugins have compatible versions after standardization
       ```
 
-      ### Delegation Pattern
+      ### Delegation Pattern (nur Meta-Repo)
 
       **documenter:**
       ```
@@ -55,10 +64,7 @@ patches:
       **validator:**
       ```
       Delegiere an: validator
-      Aufgabe: Auditiere alle Sharkord Plugins gegen die aktualisierten Standards:
-               - sharkord-vid-with-friends
-               - sharkord-stream-with-friends
-               - sharkord-hero-introducer
+      Aufgabe: Auditiere alle Sharkord Plugins gegen die aktualisierten Standards.
                Berichte Non-Compliance mit Plugin-Name, Datei und konkretem Issue.
       ```
 
@@ -67,32 +73,4 @@ patches:
       Delegiere an: feature
       Aufgabe: Erstelle für jedes betroffene Plugin einen Standardisierungs-Branch
                und wende die neuen Konventionen an. Erstelle PRs für jedes Plugin.
-      ```
-
-      ## Multi-Repo Workspace Awareness
-
-      If this project coordinates multiple plugin repos (meta-repo pattern):
-
-      - Agent files live **ONLY** in the meta-repo (this project)
-      - **Never** create `.claude/`, `.opencode/`, `.continue/` directories in sibling repos
-      - When editing files in sibling repos, always use absolute or relative paths from the meta-repo root
-      - Build and test commands must run in the correct repo directory
-
-      ### Workspace Path Conventions
-
-      ```
-      sharkord-meta/                 ← agent files here
-        docs/PATTERNS.md
-        .claude/agents/
-
-      ../sharkord-vid-with-friends/  ← plugin source here
-        src/
-        package.json
-      ```
-
-      When delegating to developer for a plugin:
-      ```
-      Delegiere an: developer
-      Aufgabe: Editiere ../sharkord-vid-with-friends/src/index.ts
-               Arbeitsverzeichnis: ../sharkord-vid-with-friends/
       ```


### PR DESCRIPTION
﻿## Summary
- Added a clear "NUR bei Meta-Repo" guard to the Cross-Plugin Standardization section
- Removed the Multi-Repo Workspace Awareness section (belongs in meta-repo only)
- Updated description and hint to reflect single-plugin-repo default behavior
- Bumped version to 1.0.1
