### PR TITLE
feat: implement meta-repo as first-class top-level config option

### DIFF
--- a/agents/1-generic/documenter.md
+++ b/agents/1-generic/documenter.md
@@ -129,7 +129,8 @@ Dokumentationszyklus MUSS laufen, wenn mindestens eines zutrifft:
 
 ## 4. Meta-Repository Documentation Strategy (Optional)
 
-> Activated when `META_REPO: true` is set in project variables.
+> Activated when `meta-repo: true` is set in `.meta-config/project.yaml`.
+> For normal (non-meta) projects, skip this section.
 
 If this project is a **meta-repository** coordinating multiple sub-projects:
 

--- a/agents/2-platform/sharkord-orchestrator.md
+++ b/agents/2-platform/sharkord-orchestrator.md
@@ -28,7 +28,7 @@ patches:
 
       ## Cross-Plugin Standardization (NUR bei Meta-Repo)
 
-      > **Hinweis:** Dieser Abschnitt ist nur relevant wenn `META_REPO: true` in `project.yaml` gesetzt ist.
+      > **Hinweis:** Dieser Abschnitt ist nur relevant wenn `meta-repo: true` in `.meta-config/project.yaml` gesetzt ist.
       > Für normale Plugin-Repos überspringen.
 
       Wenn dieses Projekt ein Meta-Repo ist (koordiniert mehrere Plugins):

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -474,6 +474,11 @@
       "enum": ["disabled"],
       "description": "Set to 'disabled' to skip provider isolation generation (e.g. in the agent-meta meta-repo itself, which intentionally manages all provider directories)."
     },
+    "meta-repo": {
+      "type": "boolean",
+      "description": "When true, activates meta-repository features: cross-plugin standardization, multi-repo workspace awareness, and centralized documentation (PATTERNS.md, LEARNINGS.md, CONVENTIONS.md). Use when this project coordinates multiple sub-projects (e.g. sharkord-meta with multiple plugins).",
+      "default": false
+    },
     "rules-preset": {
       "type": "string",
       "description": "Controls which rules are always active (alwaysApply) and per-provider skip behavior. Presets are defined in config/rules-presets.yaml.",

--- a/howto/configs/project.yaml.example
+++ b/howto/configs/project.yaml.example
@@ -89,7 +89,11 @@ max-parallel-agents: 2
 # dod:
 #   security-audit: true
 
-# Multi-Repo Workspace (optional — für Meta-Repos mit mehreren Plugin-Repos)
+# Meta-Repo Modus — nur aktivieren wenn dieses Projekt mehrere Sub-Projekte koordiniert
+# Aktiviert Cross-Plugin Standardisierung und zentrale Dokumentation (PATTERNS.md, LEARNINGS.md, CONVENTIONS.md)
+# meta-repo: true
+
+# Multi-Repo Workspace (optional — nur bei meta-repo: true relevant)
 # variables:
 #   WORKSPACE_REPOS: |
 #     - path: ../sharkord-vid-with-friends
@@ -101,7 +105,6 @@ max-parallel-agents: 2
 #     - path: ../sharkord-hero-introducer
 #       name: hero-introducer
 #       prefix: hero
-#   META_REPO: "true"
 #   SUB_PROJECTS: |
 #     - vid-with-friends
 #     - stream-with-friends

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -248,10 +248,11 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
     sub_projects = config.get("variables", {}).get("SUB_PROJECTS", "")
     if sub_projects:
         variables["SUB_PROJECTS"] = sub_projects
-    # META_REPO: auto-inject flag for meta-repository documentation strategy
-    meta_repo = config.get("variables", {}).get("META_REPO", "")
+    # META_REPO: auto-inject from top-level config field (default: false)
+    # When true, activates cross-plugin standardization and centralized docs
+    meta_repo = config.get("meta-repo", False)
     if meta_repo:
-        variables["META_REPO"] = meta_repo
+        variables["META_REPO"] = "true"
     # DOD_*: resolve from dod-preset (base) + dod (overrides).
     # Precedence: dod (project override) > dod-preset > "full" (implicit default).
     dod_resolved = resolve_dod(config, agent_meta_root)

--- a/scripts/lib/setup.py
+++ b/scripts/lib/setup.py
@@ -187,6 +187,7 @@ def run_setup_wizard(
     config["speech-mode"] = "full"
     config["max-parallel-agents"] = 2
     config["model-overrides"] = {}
+    config["meta-repo"] = False
     config["hooks"] = {}
     config["provider-options"] = {}
     config["external-skills"] = {}
@@ -330,6 +331,15 @@ def _write_config(path: Path, config: dict) -> None:
             "#     generate-prompts: true\n"
             "#     prompt-mode: full\n"
             "#   Opencode: {}\n"
+            "\n"
+        ),
+    )
+    body = body.replace(
+        "meta-repo: false\n",
+        (
+            "# Meta-Repo Modus — nur aktivieren wenn dieses Projekt mehrere Sub-Projekte koordiniert\n"
+            "# (z.B. sharkord-meta mit mehreren Plugin-Repos). Aktiviert Cross-Plugin Standardisierung.\n"
+            "# meta-repo: true\n"
             "\n"
         ),
     )


### PR DESCRIPTION
## Summary

- Migrate META_REPO from a buried `variables:` entry to a first-class top-level config option `meta-repo` in `.meta-config/project.yaml`
- Update JSON schema (`config/project-config.schema.json`) with new `meta-repo: boolean` field
- Update `scripts/lib/config.py` to read `meta-repo` from top-level (default: false) instead of `variables.META_REPO`
- Update `scripts/lib/setup.py` to include `meta-repo: false` in new configs with proper commented documentation
- Update template references in `agents/1-generic/documenter.md` and `agents/2-platform/sharkord-orchestrator.md`
- Update `howto/configs/project.yaml.example` with new meta-repo section and remove old `META_REPO` variable