### PR TITLE
fix(orchestrator): add opencode permission mapping for subagent task tool

### DIFF
--- a/.opencode/agents/agent-meta-manager.md
+++ b/.opencode/agents/agent-meta-manager.md
@@ -3,6 +3,15 @@ name: agent-meta-manager
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 mode: subagent
 model: opencode-go/qwen3.6-plus
+permission:
+  bash: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  task: allow
+  todowrite: allow
+  webfetch: allow
 ---
 # Agent-Meta-Manager — agent-meta
 

--- a/.opencode/agents/agent-meta-scout.md
+++ b/.opencode/agents/agent-meta-scout.md
@@ -3,6 +3,10 @@ name: agent-meta-scout
 description: "Scoutet das KI-Ökosystem auf neue Skills, Agenten-Patterns, Rules und Workflows. Bewertet Kandidaten und macht konkrete Erweiterungsvorschläge für agent-meta."
 mode: subagent
 model: opencode-go/qwen3.6-plus
+permission:
+  read: allow
+  webfetch: allow
+  websearch: allow
 ---
 # Agent-Meta Scout — agent-meta
 

--- a/.opencode/agents/developer.md
+++ b/.opencode/agents/developer.md
@@ -2,6 +2,14 @@
 name: developer
 description: "Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen"
 mode: subagent
+permission:
+  bash: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  task: allow
+  todowrite: allow
 ---
 # Developer — agent-meta
 

--- a/.opencode/agents/documenter.md
+++ b/.opencode/agents/documenter.md
@@ -3,6 +3,12 @@ name: documenter
 description: "Pflegt CODEBASE_OVERVIEW.md, ARCHITECTURE.md, README.md und Session-Erkenntnisse."
 mode: subagent
 model: opencode-go/qwen3.6-plus
+permission:
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  todowrite: allow
 ---
 # Documenter — agent-meta
 

--- a/.opencode/agents/feature.md
+++ b/.opencode/agents/feature.md
@@ -2,6 +2,11 @@
 name: feature
 description: "Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR."
 mode: subagent
+permission:
+  bash: allow
+  read: allow
+  task: allow
+  todowrite: allow
 ---
 # Feature — agent-meta
 

--- a/.opencode/agents/feedback.md
+++ b/.opencode/agents/feedback.md
@@ -3,6 +3,12 @@ name: feedback
 description: "Standardisiert Bug-Reports, Feature-Requests und Verbesserungsvorschläge für das eingesetzte Projekt — kategorisiert, aufbereitet und direkt als GitHub Issue eingereicht."
 mode: subagent
 model: opencode-go/qwen3.6-plus
+permission:
+  bash: allow
+  glob: allow
+  grep: allow
+  read: allow
+  todowrite: allow
 ---
 # Feedback — agent-meta
 

--- a/.opencode/agents/git.md
+++ b/.opencode/agents/git.md
@@ -3,6 +3,13 @@ name: git
 description: "Git-Operationen: Commits, Branches, Merges, Tags, Push/Pull und Commit-Messages — plattformunabhängig (GitHub, GitLab, Gitea)."
 mode: subagent
 model: opencode-go/deepseek-v4-flash
+permission:
+  bash: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  todowrite: allow
 ---
 # Git Agent — agent-meta
 

--- a/.opencode/agents/ideation.md
+++ b/.opencode/agents/ideation.md
@@ -2,6 +2,15 @@
 name: ideation
 description: "Ideenfindung, Visions-Schärfung und Konzept-Konkretisierung — stellt Fragen, denkt Ecken, übergibt reife Ideen an Requirements."
 mode: subagent
+permission:
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  task: allow
+  todowrite: allow
+  webfetch: allow
+  websearch: allow
 ---
 # Ideation — agent-meta
 

--- a/.opencode/agents/log-analyzer.md
+++ b/.opencode/agents/log-analyzer.md
@@ -3,6 +3,15 @@ name: log-analyzer
 description: "Analysiert System- und Applikations-Logs: Frequency-Clustering, Severity-Klassifikation (RFC 5424), Root-Cause-Hypothesen und strukturierte Findings mit Delegations-Routing."
 mode: subagent
 model: opencode-go/qwen3.6-plus
+permission:
+  bash: allow
+  glob: allow
+  grep: allow
+  read: allow
+  task: allow
+  todowrite: allow
+  webfetch: allow
+  websearch: allow
 ---
 # Log-Analyzer — agent-meta
 

--- a/.opencode/agents/meta-feedback.md
+++ b/.opencode/agents/meta-feedback.md
@@ -3,6 +3,11 @@ name: meta-feedback
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
 mode: subagent
 model: opencode-go/deepseek-v4-flash
+permission:
+  bash: allow
+  read: allow
+  todowrite: allow
+  webfetch: allow
 ---
 # Meta-Feedback — agent-meta
 

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -2,6 +2,9 @@
 name: orchestrator
 description: "Koordiniert alle Agenten durch den Entwicklungsprozess: Requirements → Development → Testing → Validation → Documentation."
 mode: subagent
+permission:
+  task: allow
+  todowrite: allow
 ---
 # Orchestrator — agent-meta
 
@@ -211,7 +214,7 @@ Parallel: max. 4 Agenten für unabhängige Schritte (∥).
 Nicht parallel: tester↔developer, validator→git, requirements→tester.
 
 **Parallel-Pattern (konkret):**
-Opencode unterstützt parallele Subagent-Ausführung via mehrfacher `Agent`-Tool-Aufrufe.
+Opencode unterstützt parallele Subagent-Ausführung via mehrfacher `task`-Tool-Aufrufe.
 Starte unabhängige Agenten nacheinander im selben Kontext — sie laufen implizit parallel.
 
 

--- a/.opencode/agents/release.md
+++ b/.opencode/agents/release.md
@@ -3,6 +3,13 @@ name: release
 description: "Versioning, Changelogs, Build-Prozesse und GitHub-Releases verwalten."
 mode: subagent
 model: opencode-go/qwen3.6-plus
+permission:
+  bash: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  todowrite: allow
 ---
 # Release Manager — agent-meta
 

--- a/.opencode/agents/requirements.md
+++ b/.opencode/agents/requirements.md
@@ -2,6 +2,12 @@
 name: requirements
 description: "Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen und Traceability prüfen."
 mode: subagent
+permission:
+  edit: allow
+  glob: allow
+  grep: allow
+  read: allow
+  todowrite: allow
 ---
 # Requirements Engineer — agent-meta
 

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -35,7 +35,7 @@ _PROVIDER_PARALLEL_PATTERNS: dict[str, str] = {
     ),
     "Opencode": (
         "**Parallel-Pattern (konkret):**\n"
-        "Opencode unterstützt parallele Subagent-Ausführung via mehrfacher `Agent`-Tool-Aufrufe.\n"
+        "Opencode unterstützt parallele Subagent-Ausführung via mehrfacher `task`-Tool-Aufrufe.\n"
         "Starte unabhängige Agenten nacheinander im selben Kontext — sie laufen implizit parallel.\n"
     ),
     "Gemini": (
@@ -842,6 +842,42 @@ def inject_debug_block(content: str, agent_name: str) -> str:
     )
 
 
+def _map_claude_tools_to_opencode_permissions(tools: list) -> dict[str, str]:
+    """Map Claude Code tool names to opencode permission keys.
+
+    opencode uses a permission-based model (tools frontmatter is deprecated).
+    Each mapped key is set to 'allow'. Unknown tools are ignored.
+
+    Known mappings:
+      Bash -> bash
+      Read -> read
+      Write / Edit -> edit  (write/edit/apply_patch gated by edit permission)
+      Glob -> glob
+      Grep -> grep
+      WebFetch -> webfetch
+      WebSearch -> websearch
+      Agent -> task          (subagent invocation via task tool)
+      TodoWrite -> todowrite
+    """
+    mapping = {
+        "Agent": "task",
+        "TodoWrite": "todowrite",
+        "Bash": "bash",
+        "Read": "read",
+        "Write": "edit",
+        "Edit": "edit",
+        "Glob": "glob",
+        "Grep": "grep",
+        "WebFetch": "webfetch",
+        "WebSearch": "websearch",
+    }
+    perms: dict[str, str] = {}
+    for t in tools:
+        if isinstance(t, str) and t in mapping:
+            perms[mapping[t]] = "allow"
+    return perms
+
+
 def _transform_frontmatter_for_opencode(
     content: str,
     name: str,
@@ -851,12 +887,13 @@ def _transform_frontmatter_for_opencode(
 ) -> str:
     """Build opencode-native agent frontmatter.
 
-    opencode frontmatter schema (all others stripped):
-      name: <role>             (required — used to invoke the agent)
-      description: "..."       (required)
-      mode: subagent           (all agent-meta agents are subagents)
-      model: provider/model-id (optional — only when tier maps to a model ID)
-      generated-from: "..."    (traceability, kept for diffability)
+    opencode frontmatter schema:
+      name: <role>
+      description: "..."
+      mode: subagent
+      model: provider/model-id (optional)
+      permission:             (mapped from template frontmatter tools)
+        <key>: allow
     """
     body = _strip_frontmatter(content)
     body = _strip_claude_specific_lines(body)
@@ -864,8 +901,16 @@ def _transform_frontmatter_for_opencode(
     lines = [f'name: {name}', f'description: "{description}"', 'mode: subagent']
     if model:
         lines.append(f'model: {model}')
-    # NOTE: generated-from is intentionally omitted because opencode rejects
-    # unknown frontmatter fields (Extra inputs are not permitted).
+
+    # Map template tools to opencode permission block
+    template_fm = _parse_frontmatter_yaml(content)
+    template_tools = template_fm.get("tools")
+    if isinstance(template_tools, list) and template_tools:
+        perms = _map_claude_tools_to_opencode_permissions(template_tools)
+        if perms:
+            lines.append("permission:")
+            for key in sorted(perms):
+                lines.append(f"  {key}: {perms[key]}")
 
     return '---\n' + '\n'.join(lines) + '\n---\n' + body
 

--- a/tests/test_opencode_agents.py
+++ b/tests/test_opencode_agents.py
@@ -1,0 +1,212 @@
+"""Test suite for opencode-generated agent files.
+
+Validates that agent frontmatter contains correctly mapped permissions,
+especially the `task` permission required for subagent delegation.
+
+Run: python tests/test_opencode_agents.py
+"""
+
+from pathlib import Path
+import re
+import sys
+
+
+def _split_frontmatter(content: str) -> tuple[str, str]:
+    """Split content into (frontmatter_block, body)."""
+    if not content.startswith("---"):
+        return "", content
+    end = content.find("\n---", 3)
+    if end == -1:
+        return "", content
+    return content[: end + 4], content[end + 4:]
+
+
+def _extract_yaml_permissions(fm: str) -> dict[str, str]:
+    """Extract permission key/value pairs from opencode frontmatter.
+
+    Handles block form:
+      permission:
+        key: value
+        key: value
+    """
+    perms: dict[str, str] = {}
+    block = re.search(
+        r"^permission:\s*\n((?:  .+\n?)+)",
+        fm,
+        flags=re.MULTILINE,
+    )
+    if block:
+        for line in block.group(1).strip().splitlines():
+            stripped = line.strip()
+            if ":" in stripped:
+                key, val = stripped.split(":", 1)
+                perms[key.strip()] = val.strip().strip('"').strip("'")
+    return perms
+
+
+AGENTS_DIR = Path(".opencode/agents")
+
+# Roles that are expected to have a `task` permission because they delegate
+DELEGATING_ROLES = {
+    "orchestrator",
+    "feature",
+    "developer",
+    "ideation",
+    "log-analyzer",
+    "tester",
+    "agent-meta-manager",
+}
+
+# Map template tool names to expected opencode permission keys
+EXPECTED_PERMISSION_MAPPINGS = {
+    "Agent": "task",
+    "TodoWrite": "todowrite",
+    "Bash": "bash",
+    "Read": "read",
+    "Write": "edit",
+    "Edit": "edit",
+    "Glob": "glob",
+    "Grep": "grep",
+    "WebFetch": "webfetch",
+    "WebSearch": "websearch",
+}
+
+
+def test_all_agents_have_permissions() -> list[str]:
+    """Every generated opencode agent (except ping-test) must have a permission block."""
+    errors = []
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(content)
+        name_match = re.search(r"^name:\s*(.+)$", fm, flags=re.MULTILINE)
+        name = name_match.group(1).strip() if name_match else path.stem
+
+        if name == "ping-test":
+            continue  # intentionally minimal
+
+        perms = _extract_yaml_permissions(fm)
+        if not perms:
+            errors.append(f"{name}: missing 'permission:' frontmatter block")
+
+    return errors
+
+
+def test_delegating_roles_have_task() -> list[str]:
+    """Roles that delegate must have task permission set to allow."""
+    errors = []
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(content)
+        name_match = re.search(r"^name:\s*(.+)$", fm, flags=re.MULTILINE)
+        name = name_match.group(1).strip() if name_match else path.stem
+
+        if name not in DELEGATING_ROLES:
+            continue
+
+        perms = _extract_yaml_permissions(fm)
+        if perms.get("task") != "allow":
+            errors.append(
+                f"{name}: must have permission 'task: allow' for subagent delegation, got: {perms.get('task', 'MISSING')}"
+            )
+
+    return errors
+
+
+def test_no_claude_tool_names_in_permissions() -> list[str]:
+    """No PascalCase Claude tool names should leak into opencode permission values."""
+    errors = []
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(content)
+        perms = _extract_yaml_permissions(fm)
+
+        for key in perms:
+            if key in EXPECTED_PERMISSION_MAPPINGS:
+                errors.append(
+                    f"{path.stem}: unmapped Claude tool name '{key}' found in opencode permission block"
+                )
+
+    return errors
+
+
+def test_orchestrator_can_delegate() -> list[str]:
+    """Orchestrator specifically needs task + todowrite permissions."""
+    errors = []
+    path = AGENTS_DIR / "orchestrator.md"
+    if not path.exists():
+        errors.append("orchestrator.md not found in .opencode/agents/")
+        return errors
+
+    content = path.read_text(encoding="utf-8")
+    fm, _ = _split_frontmatter(content)
+    perms = _extract_yaml_permissions(fm)
+
+    if perms.get("task") != "allow":
+        errors.append("orchestrator: missing permission 'task: allow' — cannot delegate to subagents")
+    if perms.get("todowrite") != "allow":
+        errors.append("orchestrator: missing permission 'todowrite: allow' — cannot manage todos")
+
+    return errors
+
+
+def test_no_deprecated_tools_field() -> list[str]:
+    """Opencode agents must not use the deprecated 'tools:' frontmatter field."""
+    errors = []
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(content)
+        if re.search(r"^tools:", fm, flags=re.MULTILINE):
+            errors.append(f"{path.stem}: uses deprecated 'tools:' frontmatter field")
+    return errors
+
+
+def test_parallel_pattern_uses_task() -> list[str]:
+    """The parallel execution pattern in orchestrator must reference `task`, not `Agent`."""
+    errors = []
+    path = AGENTS_DIR / "orchestrator.md"
+    if not path.exists():
+        return errors
+
+    body = path.read_text(encoding="utf-8")
+    if "`Agent`-Tool" in body or "`Agent` Tool" in body:
+        errors.append(
+            "orchestrator: body still references Claude 'Agent' tool instead of opencode 'task'"
+        )
+
+    return errors
+
+
+def run_all() -> int:
+    """Run all tests and print a summary."""
+    all_errors: list[str] = []
+    tests = [
+        ("All agents have permissions", test_all_agents_have_permissions),
+        ("Delegating roles have task", test_delegating_roles_have_task),
+        ("No deprecated tools field", test_no_deprecated_tools_field),
+        ("No Claude tool names remain", test_no_claude_tool_names_in_permissions),
+        ("Orchestrator can delegate", test_orchestrator_can_delegate),
+        ("Parallel pattern uses task", test_parallel_pattern_uses_task),
+    ]
+
+    print("=" * 60)
+    print("Opencode Agent Frontmatter Tests")
+    print("=" * 60)
+
+    for label, fn in tests:
+        errors = fn()
+        status = "PASS" if not errors else "FAIL"
+        print(f"  [{status}] {label}")
+        for err in errors:
+            print(f"         ! {err}")
+        all_errors.extend(errors)
+
+    print("=" * 60)
+    if not all_errors:
+        print("All tests passed.")
+        return 0
+    print(f"FAILED: {len(all_errors)} error(s) found.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(run_all())


### PR DESCRIPTION
Closes #189

**Problem:** Opencode-generated agents (especially orchestrator and feature) lacked the 	ask permission, making subagent delegation impossible.

**Fix:** Updated scripts/lib/agents.py to map template 	ools: fields into opencode-native permission: blocks (	ask: allow, 	odowrite: allow, etc.).

**Verification:**
- python tests/test_opencode_agents.py → all 6 tests pass
- Live ping test via orchestrator → all 5 subagents responded successfully

**Provider impact:**
- Claude: unchanged (already worked)
- Opencode: fixed
- Gemini: unchanged (separate issue #189 follow-up)
- Continue: unchanged (by design)

**Files changed:**
- scripts/lib/agents.py
- .opencode/agents/*.md (regenerated)
- 	ests/test_opencode_agents.py (new)