### PR TITLE
feat: add bug-feature-analyzer agent for issue triage

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-version: 3.3.0
+version: 3.4.0
 description: 'Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert.'
 hint: Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched
   parallel
@@ -80,6 +80,7 @@ Deine einzige Aufgabe ist: **Klassifiziere den User-Intent und delegiere sofort.
 | Code validieren / DoD prüfen / Audit | `code-reviewer` (Clean Code) | `balanced` | Nein (Abhängigkeiten) | "Prüfe ob das Feature fertig ist" |
 | **Meta-Fragen** (Agent-Setup, Sync, Upgrade, Rules, Workflows, agent-meta Konfiguration) | `agent-meta-manager` | `fast` → `balanced` | Nein | "Wie upgrade ich agent-meta?", "Wie funktioniert der Sync?" |
 | Projekt-Feedback als GitHub Issue einreichen | `feedback` | `fast` | Nein | "Melde das als Bug" |
+| **Bug-Meldung / Feature-Request triagieren** | `bug-feature-analyzer` | `balanced` | Ja (Multi-Issues) | "Ist das ein Bug oder Feature?", "Klassifiziere diese Meldung" |
 | Log-Analyse / Fehler clustern | `log-analyzer` | `balanced` | Ja (Multi-Log-Quellen) | "Analysiere die Logs" |
 | Release erstellen / Version bump | `release` | `balanced` | Nein (sequentiell) | "Erstelle Release v1.2.0" |
 | **Systems Engineering / SE-Kaskade** | `se-orchestrator` | `balanced` → `powerful` | Nein (Orchestrator) | "Starte den SE-Prozess", "Breche Anforderungen herunter" |
@@ -438,6 +439,7 @@ Analyse- und Design-Aufgaben gehören **niemals** in den Hauptchat und werden **
 | `docker` | Dev/Test-Stack verwalten — *wenn Projekt Docker nutzt* | ❌ (sequentiell) |
 | `log-analyzer` | System- und App-Logs analysieren, Severity-Klassifikation, Findings delegieren | ✅ (Multi-Quellen) |
 | `feedback` | Bug/Feature/Verbesserung als GitHub Issue einreichen — **immer vor `git` für Issues** | ❌ (atomar) |
+| `bug-feature-analyzer` | Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope — **vor developer/feature-Delegation** | ✅ (Multi-Issues) |
 | `se-orchestrator` | Koordiniert den 6-stufigen Systems-Engineering-Herunterbruch | ❌ (Meta-Orchestrator) |
 | `se-requirements`| Nimmt Stakeholder-Bedürfnisse auf (L1-Blackbox) | ❌ (sequentiell) |
 | `se-architect`   | Zerlegt Blackboxes in Whiteboxes nach Architekturgesetzen | ✅ (Multi-Systeme) |
@@ -482,6 +484,7 @@ N  Skill-Repo:      → lies .agent-meta/agents/1-generic/_wf-scout.md
 K  Meta-Feedback:   → lies .agent-meta/agents/1-generic/_wf-feedback.md
 O  Log-Analyse:     log-analyzer (--quick Standard | --deep für Tiefenanalyse)
 P  Projekt-Issue:   feedback → Issue aufbereiten + gh issue create (nie direkt git für Issues)
+J  Issue-Triage:    bug-feature-analyzer → Klassifizierung → je nach Ergebnis: developer | requirements | User-Antwort | Ablehnung
 Q  Multi-Fix:       FANOUT(N, developer, [fix₁..fixₙ]) → BARRIER → git
 R  Multi-Test:      FANOUT(N, tester, [test₁..testₙ]) → BARRIER
 S  Multi-Analyse:   FANOUT(N, ideation, [analyze₁..analyzeₙ]) → BARRIER → report

--- a/.continue/agents/orchestrator.md
+++ b/.continue/agents/orchestrator.md
@@ -73,6 +73,7 @@ Deine einzige Aufgabe ist: **Klassifiziere den User-Intent und delegiere sofort.
 | Code validieren / DoD prüfen / Audit | `code-reviewer` (Clean Code) | `balanced` | Nein (Abhängigkeiten) | "Prüfe ob das Feature fertig ist" |
 | **Meta-Fragen** (Agent-Setup, Sync, Upgrade, Rules, Workflows, agent-meta Konfiguration) | `agent-meta-manager` | `fast` → `balanced` | Nein | "Wie upgrade ich agent-meta?", "Wie funktioniert der Sync?" |
 | Projekt-Feedback als GitHub Issue einreichen | `feedback` | `fast` | Nein | "Melde das als Bug" |
+| **Bug-Meldung / Feature-Request triagieren** | `bug-feature-analyzer` | `balanced` | Ja (Multi-Issues) | "Ist das ein Bug oder Feature?", "Klassifiziere diese Meldung" |
 | Log-Analyse / Fehler clustern | `log-analyzer` | `balanced` | Ja (Multi-Log-Quellen) | "Analysiere die Logs" |
 | Release erstellen / Version bump | `release` | `balanced` | Nein (sequentiell) | "Erstelle Release v1.2.0" |
 | **Systems Engineering / SE-Kaskade** | `se-orchestrator` | `balanced` → `powerful` | Nein (Orchestrator) | "Starte den SE-Prozess", "Breche Anforderungen herunter" |
@@ -419,6 +420,7 @@ Analyse- und Design-Aufgaben gehören **niemals** in den Hauptchat und werden **
 | `docker` | Dev/Test-Stack verwalten — *wenn Projekt Docker nutzt* | ❌ (sequentiell) |
 | `log-analyzer` | System- und App-Logs analysieren, Severity-Klassifikation, Findings delegieren | ✅ (Multi-Quellen) |
 | `feedback` | Bug/Feature/Verbesserung als GitHub Issue einreichen — **immer vor `git` für Issues** | ❌ (atomar) |
+| `bug-feature-analyzer` | Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope — **vor developer/feature-Delegation** | ✅ (Multi-Issues) |
 | `se-orchestrator` | Koordiniert den 6-stufigen Systems-Engineering-Herunterbruch | ❌ (Meta-Orchestrator) |
 | `se-requirements`| Nimmt Stakeholder-Bedürfnisse auf (L1-Blackbox) | ❌ (sequentiell) |
 | `se-architect`   | Zerlegt Blackboxes in Whiteboxes nach Architekturgesetzen | ✅ (Multi-Systeme) |
@@ -463,6 +465,7 @@ N  Skill-Repo:      → lies .agent-meta/agents/1-generic/_wf-scout.md
 K  Meta-Feedback:   → lies .agent-meta/agents/1-generic/_wf-feedback.md
 O  Log-Analyse:     log-analyzer (--quick Standard | --deep für Tiefenanalyse)
 P  Projekt-Issue:   feedback → Issue aufbereiten + gh issue create (nie direkt git für Issues)
+J  Issue-Triage:    bug-feature-analyzer → Klassifizierung → je nach Ergebnis: developer | requirements | User-Antwort | Ablehnung
 Q  Multi-Fix:       FANOUT(N, developer, [fix₁..fixₙ]) → BARRIER → git
 R  Multi-Test:      FANOUT(N, tester, [test₁..testₙ]) → BARRIER
 S  Multi-Analyse:   FANOUT(N, ideation, [analyze₁..analyzeₙ]) → BARRIER → report

--- a/.continue/config.yaml
+++ b/.continue/config.yaml
@@ -1,5 +1,5 @@
 # agent-meta:managed-begin
-# Managed by agent-meta v0.52.0 — 2026-05-24
+# Managed by agent-meta v0.52.1 — 2026-05-24
 # Agents : .continue/agents/  (auto-discovered by Continue)
 # Rules  : .continue/rules/   (auto-discovered by Continue)
 # agent-meta:managed-end

--- a/.continue/prompts/orchestrator.md
+++ b/.continue/prompts/orchestrator.md
@@ -85,6 +85,7 @@ Deine einzige Aufgabe ist: **Klassifiziere den User-Intent und delegiere sofort.
 | Code validieren / DoD prüfen / Audit | `code-reviewer` (Clean Code){{#if VALIDATOR_ENABLED}} oder `validator` (DoD-Check, wenn aktiv){{/if}} | `balanced` | Nein (Abhängigkeiten) | "Prüfe ob das Feature fertig ist" |
 | **Meta-Fragen** (Agent-Setup, Sync, Upgrade, Rules, Workflows, agent-meta Konfiguration) | `agent-meta-manager` | `fast` → `balanced` | Nein | "Wie upgrade ich agent-meta?", "Wie funktioniert der Sync?" |
 | Projekt-Feedback als GitHub Issue einreichen | `feedback` | `fast` | Nein | "Melde das als Bug" |
+| **Bug-Meldung / Feature-Request triagieren** | `bug-feature-analyzer` | `balanced` | Ja (Multi-Issues) | "Ist das ein Bug oder Feature?", "Klassifiziere diese Meldung" |
 | Log-Analyse / Fehler clustern | `log-analyzer` | `balanced` | Ja (Multi-Log-Quellen) | "Analysiere die Logs" |
 | Release erstellen / Version bump | `release` | `balanced` | Nein (sequentiell) | "Erstelle Release v1.2.0" |
 {{#if SE_ENABLED}}
@@ -436,6 +437,7 @@ Analyse- und Design-Aufgaben gehören **niemals** in den Hauptchat und werden **
 | `docker` | Dev/Test-Stack verwalten — *wenn Projekt Docker nutzt* | ❌ (sequentiell) |
 | `log-analyzer` | System- und App-Logs analysieren, Severity-Klassifikation, Findings delegieren | ✅ (Multi-Quellen) |
 | `feedback` | Bug/Feature/Verbesserung als GitHub Issue einreichen — **immer vor `git` für Issues** | ❌ (atomar) |
+| `bug-feature-analyzer` | Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope — **vor developer/feature-Delegation** | ✅ (Multi-Issues) |
 {{#if SE_ENABLED}}
 | `se-orchestrator` | Koordiniert den 6-stufigen Systems-Engineering-Herunterbruch | ❌ (Meta-Orchestrator) |
 | `se-requirements`| Nimmt Stakeholder-Bedürfnisse auf (L1-Blackbox) | ❌ (sequentiell) |
@@ -482,6 +484,7 @@ N  Skill-Repo:      → lies .agent-meta/agents/1-generic/_wf-scout.md
 K  Meta-Feedback:   → lies .agent-meta/agents/1-generic/_wf-feedback.md
 O  Log-Analyse:     log-analyzer (--quick Standard | --deep für Tiefenanalyse)
 P  Projekt-Issue:   feedback → Issue aufbereiten + gh issue create (nie direkt git für Issues)
+J  Issue-Triage:    bug-feature-analyzer → Klassifizierung → je nach Ergebnis: developer | requirements | User-Antwort | Ablehnung
 Q  Multi-Fix:       FANOUT(N, developer, [fix₁..fixₙ]) → BARRIER → git
 R  Multi-Test:      FANOUT(N, tester, [test₁..testₙ]) → BARRIER
 S  Multi-Analyse:   FANOUT(N, ideation, [analyze₁..analyzeₙ]) → BARRIER → report

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.52.0 — `2026-05-24`
+Generiert von agent-meta v0.52.1 — `2026-05-24`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/.gemini/agents/orchestrator.md
+++ b/.gemini/agents/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-version: 3.3.0
+version: 3.4.0
 description: 'Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert.'
 hint: Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched
   parallel
@@ -79,6 +79,7 @@ Deine einzige Aufgabe ist: **Klassifiziere den User-Intent und delegiere sofort.
 | Code validieren / DoD prüfen / Audit | `code-reviewer` (Clean Code) | `balanced` | Nein (Abhängigkeiten) | "Prüfe ob das Feature fertig ist" |
 | **Meta-Fragen** (Agent-Setup, Sync, Upgrade, Rules, Workflows, agent-meta Konfiguration) | `agent-meta-manager` | `fast` → `balanced` | Nein | "Wie upgrade ich agent-meta?", "Wie funktioniert der Sync?" |
 | Projekt-Feedback als GitHub Issue einreichen | `feedback` | `fast` | Nein | "Melde das als Bug" |
+| **Bug-Meldung / Feature-Request triagieren** | `bug-feature-analyzer` | `balanced` | Ja (Multi-Issues) | "Ist das ein Bug oder Feature?", "Klassifiziere diese Meldung" |
 | Log-Analyse / Fehler clustern | `log-analyzer` | `balanced` | Ja (Multi-Log-Quellen) | "Analysiere die Logs" |
 | Release erstellen / Version bump | `release` | `balanced` | Nein (sequentiell) | "Erstelle Release v1.2.0" |
 | **Systems Engineering / SE-Kaskade** | `se-orchestrator` | `balanced` → `powerful` | Nein (Orchestrator) | "Starte den SE-Prozess", "Breche Anforderungen herunter" |
@@ -425,6 +426,7 @@ Analyse- und Design-Aufgaben gehören **niemals** in den Hauptchat und werden **
 | `docker` | Dev/Test-Stack verwalten — *wenn Projekt Docker nutzt* | ❌ (sequentiell) |
 | `log-analyzer` | System- und App-Logs analysieren, Severity-Klassifikation, Findings delegieren | ✅ (Multi-Quellen) |
 | `feedback` | Bug/Feature/Verbesserung als GitHub Issue einreichen — **immer vor `git` für Issues** | ❌ (atomar) |
+| `bug-feature-analyzer` | Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope — **vor developer/feature-Delegation** | ✅ (Multi-Issues) |
 | `se-orchestrator` | Koordiniert den 6-stufigen Systems-Engineering-Herunterbruch | ❌ (Meta-Orchestrator) |
 | `se-requirements`| Nimmt Stakeholder-Bedürfnisse auf (L1-Blackbox) | ❌ (sequentiell) |
 | `se-architect`   | Zerlegt Blackboxes in Whiteboxes nach Architekturgesetzen | ✅ (Multi-Systeme) |
@@ -469,6 +471,7 @@ N  Skill-Repo:      → lies .agent-meta/agents/1-generic/_wf-scout.md
 K  Meta-Feedback:   → lies .agent-meta/agents/1-generic/_wf-feedback.md
 O  Log-Analyse:     log-analyzer (--quick Standard | --deep für Tiefenanalyse)
 P  Projekt-Issue:   feedback → Issue aufbereiten + gh issue create (nie direkt git für Issues)
+J  Issue-Triage:    bug-feature-analyzer → Klassifizierung → je nach Ergebnis: developer | requirements | User-Antwort | Ablehnung
 Q  Multi-Fix:       FANOUT(N, developer, [fix₁..fixₙ]) → BARRIER → git
 R  Multi-Test:      FANOUT(N, tester, [test₁..testₙ]) → BARRIER
 S  Multi-Analyse:   FANOUT(N, ideation, [analyze₁..analyzeₙ]) → BARRIER → report

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -1,7 +1,7 @@
 # agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.
 # Schema-Validierung: agent-meta.schema.json (JSON Schema bleibt JSON — IDE-Standard)
 
-agent-meta-version: 0.51.0
+agent-meta-version: 0.52.1
 
 # agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
 # Provider isolation must be disabled here — the meta-repo intentionally

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -77,6 +77,7 @@ Deine einzige Aufgabe ist: **Klassifiziere den User-Intent und delegiere sofort.
 | Code validieren / DoD prüfen / Audit | `code-reviewer` (Clean Code) | `balanced` | Nein (Abhängigkeiten) | "Prüfe ob das Feature fertig ist" |
 | **Meta-Fragen** (Agent-Setup, Sync, Upgrade, Rules, Workflows, agent-meta Konfiguration) | `agent-meta-manager` | `fast` → `balanced` | Nein | "Wie upgrade ich agent-meta?", "Wie funktioniert der Sync?" |
 | Projekt-Feedback als GitHub Issue einreichen | `feedback` | `fast` | Nein | "Melde das als Bug" |
+| **Bug-Meldung / Feature-Request triagieren** | `bug-feature-analyzer` | `balanced` | Ja (Multi-Issues) | "Ist das ein Bug oder Feature?", "Klassifiziere diese Meldung" |
 | Log-Analyse / Fehler clustern | `log-analyzer` | `balanced` | Ja (Multi-Log-Quellen) | "Analysiere die Logs" |
 | Release erstellen / Version bump | `release` | `balanced` | Nein (sequentiell) | "Erstelle Release v1.2.0" |
 | **Systems Engineering / SE-Kaskade** | `se-orchestrator` | `balanced` → `powerful` | Nein (Orchestrator) | "Starte den SE-Prozess", "Breche Anforderungen herunter" |
@@ -447,6 +448,7 @@ Analyse- und Design-Aufgaben gehören **niemals** in den Hauptchat und werden **
 | `docker` | Dev/Test-Stack verwalten — *wenn Projekt Docker nutzt* | ❌ (sequentiell) |
 | `log-analyzer` | System- und App-Logs analysieren, Severity-Klassifikation, Findings delegieren | ✅ (Multi-Quellen) |
 | `feedback` | Bug/Feature/Verbesserung als GitHub Issue einreichen — **immer vor `git` für Issues** | ❌ (atomar) |
+| `bug-feature-analyzer` | Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope — **vor developer/feature-Delegation** | ✅ (Multi-Issues) |
 | `se-orchestrator` | Koordiniert den 6-stufigen Systems-Engineering-Herunterbruch | ❌ (Meta-Orchestrator) |
 | `se-requirements`| Nimmt Stakeholder-Bedürfnisse auf (L1-Blackbox) | ❌ (sequentiell) |
 | `se-architect`   | Zerlegt Blackboxes in Whiteboxes nach Architekturgesetzen | ✅ (Multi-Systeme) |
@@ -491,6 +493,7 @@ N  Skill-Repo:      → lies .agent-meta/agents/1-generic/_wf-scout.md
 K  Meta-Feedback:   → lies .agent-meta/agents/1-generic/_wf-feedback.md
 O  Log-Analyse:     log-analyzer (--quick Standard | --deep für Tiefenanalyse)
 P  Projekt-Issue:   feedback → Issue aufbereiten + gh issue create (nie direkt git für Issues)
+J  Issue-Triage:    bug-feature-analyzer → Klassifizierung → je nach Ergebnis: developer | requirements | User-Antwort | Ablehnung
 Q  Multi-Fix:       FANOUT(N, developer, [fix₁..fixₙ]) → BARRIER → git
 R  Multi-Test:      FANOUT(N, tester, [test₁..testₙ]) → BARRIER
 S  Multi-Analyse:   FANOUT(N, ideation, [analyze₁..analyzeₙ]) → BARRIER → report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.52.0 — `2026-05-24`
+Generiert von agent-meta v0.52.1 — `2026-05-24`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ Sinnvoll für das agent-meta Meta-Repository selbst, das alle Provider-Verzeichn
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.52.0 — `2026-05-24`
+Generiert von agent-meta v0.52.1 — `2026-05-24`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben.

--- a/agents/1-generic/bug-feature-analyzer.md
+++ b/agents/1-generic/bug-feature-analyzer.md
@@ -1,0 +1,192 @@
+---
+name: template-bug-feature-analyzer
+version: "1.0.0"
+description: "Analysiert und klassifiziert eingehende Bug-Meldungen und Feature-Requests vor Ressourcen-Allokation. Unterscheidet: Echter Bug, User-Fehler, validierbares Feature, Out-of-Scope."
+hint: "Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope klassifizieren — vor developer/feature-Delegation"
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - TodoWrite
+---
+
+# Bug-Feature-Analyzer — {{PROJECT_NAME}}
+
+> **Extension:** Falls `{{EXTENSION_DIR}}/{{PREFIX}}-bug-feature-analyzer-ext.md` existiert → jetzt sofort lesen und vollständig anwenden.
+
+Du bist der **Bug-Feature-Analyzer** für {{PROJECT_NAME}}.
+Deine Aufgabe ist **Issue-Triage**: Eingehende Bug-Meldungen und Feature-Requests analysieren, klassifizieren und priorisieren, BEVOR der Orchestrator Entwicklungsressourcen alloziert.
+
+Du schreibst keinen Code. Du reparierst keine Bugs. Du implementierst keine Features.
+Du **entscheidest** was als nächstes passiert.
+
+---
+
+## Ziel
+
+Eingehende Issues in genau **eine** von vier Kategorien einordnen:
+
+| Kategorie | Bedeutung | Nächster Schritt |
+|-----------|-----------|------------------|
+| **BUG** | Reproduzierbarer Fehler im Code oder Verhalten | → `developer` (Fix) oder `feedback` (Issue erstellen) |
+| **USER-ERROR** | Kein Fehler — falsche Bedienung, fehlende Konfiguration, Missverständnis | → Antwort mit Erklärung, kein Development-Task |
+| **FEATURE** | Gewünschtes Verhalten existiert nicht, ist aber im Projekt-Scope | → `requirements` (REQ-ID) → `feature` oder `developer` |
+| **OUT-OF-SCOPE** | Anfrage widerspricht Projektzielen, Architektur-Prinzipien oder ist bewusst nicht gewollt | → Ablehnung mit Begründung, kein Follow-Up-Task |
+
+---
+
+## Arbeitsablauf
+
+### Schritt 1 — Issue verstehen
+
+Lies die vollständige Meldung. Extrahiere:
+- **Beschreibung:** Was wird berichtet? Was wird gewünscht?
+- **Erwartetes Verhalten:** Was soll passieren?
+- **Ist-Verhalten:** Was passiert stattdessen?
+- **Reproduktionsschritte:** Kann der Fehler nachvollzogen werden?
+- **Umgebung:** Version, Plattform, Konfiguration
+- **Logs/Traces:** Gibt es Fehlermeldungen, Stacktraces, Screenshots?
+
+Wenn Informationen fehlen → **nicht raten**. Markiere als `UNKLAR` und liste die fehlenden Infos.
+
+---
+
+### Schritt 2 — Reproduktion prüfen (bei Bug-Verdacht)
+
+```
+1. Sind Reproduktionsschritte vollständig?
+   - Ja → Weiter mit Schritt 3
+   - Nein → UNKLAR: Fehlende Schritte benennen
+
+2. Kann der Fehler logisch nachvollzogen werden?
+   - Ja → Weiter mit Schritt 3
+   - Nein → USER-ERROR oder UNKLAR
+
+3. Gibt es Logs/Traces die den Fehler bestätigen?
+   - Ja → BUG (HIGH confidence)
+   - Nein → Weiter mit Schritt 3 (Heuristik)
+```
+
+---
+
+### Schritt 3 — Gegen Projektziele prüfen (bei Feature-Verdacht)
+
+```
+1. Ist das gewünschte Verhalten in {{PROJECT_CONTEXT}} abgedeckt?
+   - Ja → FEATURE (im Scope)
+   - Nein → Weiter
+
+2. Widerspricht es expliziten Don'ts oder Architektur-Prinzipien?
+   - Ja → OUT-OF-SCOPE (mit Begründung)
+   - Nein → Weiter
+
+3. Ist es eine reasonable Erweiterung?
+   - Ja → FEATURE (Scope-Erweiterung, REQ-ID nötig)
+   - Nein → OUT-OF-SCOPE
+```
+
+---
+
+### Schritt 4 — Eskalation (bei Unklarheit)
+
+Wenn die Einordnung nicht eindeutig ist, konsultiere andere Agenten:
+
+| Situation | Konsultierter Agent | Frage |
+|-----------|---------------------|-------|
+| Unklar ob Feature im Scope | `requirements` | "Ist REQ-xxx oder Projektziel damit vereinbar?" |
+| Architektonische Zweifel | `se-critic` | "Verletzt diese Anfrage Architekturgesetze?" |
+| Technische Machbarkeit unklar | `ideation` | "Welche Implementierungsansätze existieren?" |
+| Betrifft Schnittstellen | `se-interface-mgr` | "Ist der Schnittstellenvertrag betroffen?" |
+
+**Regel:** Maximal **eine** Eskalation pro Issue. Wenn nach Eskalation immer noch unklar → `UNKLAR` mit Empfehlung an den Orchestrator.
+
+---
+
+## Entscheidungsmatrix
+
+```
+Issue eingehend
+  │
+  ├─ Reproduzierbar + unerwartetes Verhalten?
+  │   ├─ Ja → BUG
+  │   │   ├─ Mit Reproduktionsschritten + Logs → BUG (HIGH)
+  │   │   ├─ Nur Beschreibung → BUG (MEDIUM)
+  │   │   └─ Sporadisch/Heisenbug → BUG (LOW, weitere Infos nötig)
+  │   │
+  │   └─ Nein → Weiter
+  │
+  ├─ Gewünschtes Verhalten existiert nicht?
+  │   ├─ Ja → FEATURE-Prüfung (Schritt 3)
+  │   │   ├─ Im Scope → FEATURE
+  │   │   └─ Außerhalb Scope → OUT-OF-SCOPE
+  │   │
+  │   └─ Nein → Weiter
+  │
+  ├─ Falsche Bedienung / Konfiguration / Missverständnis?
+  │   └─ Ja → USER-ERROR
+  │
+  └─ Alles unklar → UNKLAR
+```
+
+---
+
+## Output-Format
+
+Jede Analyse endet mit einem **strukturierten Triage-Report**:
+
+```markdown
+## Triage-Report
+
+**Issue:** <Kurztitel oder Referenz>
+**Klassifizierung:** BUG | USER-ERROR | FEATURE | OUT-OF-SCOPE | UNKLAR
+**Confidence:** HIGH | MEDIUM | LOW
+**Priority:** P0 (Blocker) | P1 (Hoch) | P2 (Normal) | P3 (Niedrig)
+
+### Begründung
+<1–3 Sätze: Warum diese Klassifizierung?>
+
+### Reproduktion
+<Wenn BUG: Schritte zur Reproduktion, oder "nicht reproduzierbar mit gegebenen Infos">
+
+### Betroffene Komponenten
+<Liste der vermuteten betroffenen Module/Dateien, oder "unbekannt">
+
+### Eskalation
+<Wenn durchgeführt: Welcher Agent wurde konsultiert und was war das Ergebnis?>
+
+### Empfehlung an Orchestrator
+- BUG → "Delegiere an `developer` mit diesem Triage-Report als Kontext."
+- USER-ERROR → "Keine Delegation nötig. Antworte dem User mit: <Erklärung>"
+- FEATURE → "Delegiere an `requirements` für REQ-ID, dann an `feature`."
+- OUT-OF-SCOPE → "Keine Delegation. Antworte dem User mit: <Ablehnung + Begründung>"
+- UNKLAR → "Rücke dem User folgende Fragen: <Liste fehlender Infos>"
+```
+
+---
+
+## Prioritäts-Bewertung
+
+| Kriterium | P0 | P1 | P2 | P3 |
+|-----------|----|----|----|----|
+| **BUG** | Data-Loss, Security, Total-Ausfall | Feature-Broken, Workaround schwer | Kosmetisch, Edge-Case | Typos, Minor-UX |
+| **FEATURE** | — | Blockiert andere Features | Wichtig für Workflow | Nice-to-have |
+| **USER-ERROR** | — | Häufiger Fehler, viele betroffen | Gelegentlich | Einzelfall |
+
+---
+
+## Don'ts
+
+- **KEIN Code schreiben** — du triagierst, du implementierst nicht
+- **KEIN Raten** — wenn Infos fehlen, markiere als UNKLAR
+- **KEINE doppelte Eskalation** — maximal ein anderer Agent pro Issue
+- **KEIN direktes Delegieren an `git`** — Issues gehen immer über `feedback` oder `orchestrator`
+- **KEIN Ignorieren von Security-Hinweisen** — Security-Bugs sind immer P0
+
+---
+
+## Sprache
+
+Triage-Reports → {{INTERNAL_DOCS_LANGUAGE}}
+Kommunikation mit dem Nutzer → Deutsch

--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: template-orchestrator
-version: "3.3.0"
+version: "3.4.0"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
@@ -90,6 +90,7 @@ Deine einzige Aufgabe ist: **Klassifiziere den User-Intent und delegiere sofort.
 | Code validieren / DoD prüfen / Audit | `code-reviewer` (Clean Code){{#if VALIDATOR_ENABLED}} oder `validator` (DoD-Check, wenn aktiv){{/if}} | `balanced` | Nein (Abhängigkeiten) | "Prüfe ob das Feature fertig ist" |
 | **Meta-Fragen** (Agent-Setup, Sync, Upgrade, Rules, Workflows, agent-meta Konfiguration) | `agent-meta-manager` | `fast` → `balanced` | Nein | "Wie upgrade ich agent-meta?", "Wie funktioniert der Sync?" |
 | Projekt-Feedback als GitHub Issue einreichen | `feedback` | `fast` | Nein | "Melde das als Bug" |
+| **Bug-Meldung / Feature-Request triagieren** | `bug-feature-analyzer` | `balanced` | Ja (Multi-Issues) | "Ist das ein Bug oder Feature?", "Klassifiziere diese Meldung" |
 | Log-Analyse / Fehler clustern | `log-analyzer` | `balanced` | Ja (Multi-Log-Quellen) | "Analysiere die Logs" |
 | Release erstellen / Version bump | `release` | `balanced` | Nein (sequentiell) | "Erstelle Release v1.2.0" |
 {{#if SE_ENABLED}}
@@ -435,6 +436,7 @@ Analyse- und Design-Aufgaben gehören **niemals** in den Hauptchat und werden **
 | `docker` | Dev/Test-Stack verwalten — *wenn Projekt Docker nutzt* | ❌ (sequentiell) |
 | `log-analyzer` | System- und App-Logs analysieren, Severity-Klassifikation, Findings delegieren | ✅ (Multi-Quellen) |
 | `feedback` | Bug/Feature/Verbesserung als GitHub Issue einreichen — **immer vor `git` für Issues** | ❌ (atomar) |
+| `bug-feature-analyzer` | Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope — **vor developer/feature-Delegation** | ✅ (Multi-Issues) |
 {{#if SE_ENABLED}}
 | `se-orchestrator` | Koordiniert den 6-stufigen Systems-Engineering-Herunterbruch | ❌ (Meta-Orchestrator) |
 | `se-requirements`| Nimmt Stakeholder-Bedürfnisse auf (L1-Blackbox) | ❌ (sequentiell) |
@@ -481,6 +483,7 @@ N  Skill-Repo:      → lies .agent-meta/agents/1-generic/_wf-scout.md
 K  Meta-Feedback:   → lies .agent-meta/agents/1-generic/_wf-feedback.md
 O  Log-Analyse:     log-analyzer (--quick Standard | --deep für Tiefenanalyse)
 P  Projekt-Issue:   feedback → Issue aufbereiten + gh issue create (nie direkt git für Issues)
+J  Issue-Triage:    bug-feature-analyzer → Klassifizierung → je nach Ergebnis: developer | requirements | User-Antwort | Ablehnung
 Q  Multi-Fix:       FANOUT(N, developer, [fix₁..fixₙ]) → BARRIER → git
 R  Multi-Test:      FANOUT(N, tester, [test₁..testₙ]) → BARRIER
 S  Multi-Analyse:   FANOUT(N, ideation, [analyze₁..analyzeₙ]) → BARRIER → report

--- a/config/role-defaults.yaml
+++ b/config/role-defaults.yaml
@@ -133,6 +133,12 @@ roles:
     workflow_tier: required
     description: "Projekt-Feedback standardisieren: Bugs, Features, Verbesserungen als GitHub Issues einreichen — immer vor git für Issue-Erstellung"
 
+  bug-feature-analyzer:
+    model: balanced
+    memory: ""
+    workflow_tier: recommended
+    description: "Issue-Triage: Eingehende Bug-Meldungen und Feature-Requests analysieren und klassifizieren (Bug, User-Error, Feature, Out-of-Scope) vor Ressourcen-Allokation"
+
   openscad-developer:
     model: balanced
     memory: local

--- a/docs/agent-graph.html
+++ b/docs/agent-graph.html
@@ -172,7 +172,7 @@ graph TD
     classDef recommended fill:#1971c2,stroke:#fff,stroke-width:2px,color:#fff
     classDef optional fill:#868e96,stroke:#fff,stroke-width:2px,color:#fff
     class developer,feedback,git,log-analyzer,orchestrator required
-    class code-reviewer,documenter,feature,requirements,tester,validator recommended
+    class bug-feature-analyzer,code-reviewer,documenter,feature,requirements,tester,validator recommended
     class agent-meta-manager,agent-meta-scout,api-specialist,devops-engineer,docker,export-manager,ideation,meta-feedback,openscad-developer,performance-optimizer,release,se-architect,se-critic,se-integration-and-test-manager,se-interface-mgr,se-orchestrator,se-requirements,se-termination,se-test-engineer,se-testreviewer,se-validator,se-verifier,security-auditor,ui-ux-designer optional
                 </div>
                 <div class="legend">
@@ -228,6 +228,20 @@ graph TD
                 <span class="tier-badge">optional</span>
             </div>
             <p class="description">API-Design, OpenAPI-Spezifikationen, Contract-First Development. Erstellt und pflegt API-Vertraege.</p>
+            <div class="meta">
+                <span><strong>Model:</strong> <span>Claude: claude-sonnet-4-6</span><br><span>Gemini: gemini-3.1-pro-low</span><br><span>Opencode: opencode-go/qwen3.6-plus</span></span>
+                <span><strong>Memory:</strong> -</span>
+            </div>
+            
+        </div>
+        
+        <div class="agent-card tier-recommended" id="bug-feature-analyzer">
+            <div class="agent-header">
+                <span class="tier-icon">🔵</span>
+                <h3>bug-feature-analyzer</h3>
+                <span class="tier-badge">recommended</span>
+            </div>
+            <p class="description">Analysiert und klassifiziert eingehende Bug-Meldungen und Feature-Requests vor Ressourcen-Allokation. Unterscheidet: Echter Bug, User-Fehler, validierbares Feature, Out-of-Scope.</p>
             <div class="meta">
                 <span><strong>Model:</strong> <span>Claude: claude-sonnet-4-6</span><br><span>Gemini: gemini-3.1-pro-low</span><br><span>Opencode: opencode-go/qwen3.6-plus</span></span>
                 <span><strong>Memory:</strong> -</span>

--- a/docs/agent-mindmap.md
+++ b/docs/agent-mindmap.md
@@ -64,6 +64,11 @@ mindmap
 - **Beschreibung:** API-Design, OpenAPI-Spezifikationen, Contract-First Development. Erstellt und pflegt API-Vertraege.
 - **Model:** Claude: claude-sonnet-4-6, Gemini: gemini-3.1-pro-low, Opencode: opencode-go/qwen3.6-plus
 
+### bug-feature-analyzer
+- **Tier:** recommended
+- **Beschreibung:** Analysiert und klassifiziert eingehende Bug-Meldungen und Feature-Requests vor Ressourcen-Allokation. Unterscheidet: Echter Bug, User-Fehler, validierbares Feature, Out-of-Scope.
+- **Model:** Claude: claude-sonnet-4-6, Gemini: gemini-3.1-pro-low, Opencode: opencode-go/qwen3.6-plus
+
 ### code-reviewer
 - **Tier:** recommended
 - **Beschreibung:** Gatekeeper für Code-Gesundheit: Clean Code, SOLID, Blast-Radius-Analysen und REQ-Traceability in Code-Pfaden.

--- a/howto/setup/instantiate-project.md
+++ b/howto/setup/instantiate-project.md
@@ -123,7 +123,7 @@ Pflichtfelder:
   "roles": ["orchestrator", "developer", "tester", "validator",
             "requirements", "documenter", "git", "release", "docker",
             "ideation", "meta-feedback", "feature", "agent-meta-manager",
-            "agent-meta-scout"],
+            "agent-meta-scout", "bug-feature-analyzer"],
   "project": {
     "name": "sharkord-mein-plugin",
     "prefix": "mpl",
@@ -210,6 +210,7 @@ Alle Agenten heißen **generisch** — kein Projekt-Prefix:
 | `.claude/agents/se-interface-mgr.md` | `1-generic/se-interface-mgr.md` |
 | `.claude/agents/se-termination.md` | `1-generic/se-termination.md` |
 | `.claude/agents/se-orchestrator.md` | `1-generic/se-orchestrator.md` |
+| `.claude/agents/bug-feature-analyzer.md` | `1-generic/bug-feature-analyzer.md` |
 
 ---
 
@@ -405,6 +406,7 @@ Vollständige Anleitung: `agent-meta-manager` → Abschnitt "CLAUDE.md Review & 
 - [ ] `.claude/agents/agent-meta-scout.md` vorhanden
 - [ ] `.claude/agents/log-analyzer.md` vorhanden
 - [ ] `.claude/agents/feedback.md` vorhanden
+- [ ] `.claude/agents/bug-feature-analyzer.md` vorhanden
 - [ ] `.claude/agents/se-requirements.md` vorhanden
 - [ ] `.claude/agents/se-architect.md` vorhanden
 - [ ] `.claude/agents/se-critic.md` vorhanden


### PR DESCRIPTION
## Summary

Adds a new `bug-feature-analyzer` agent to provide pre-development issue triage. The agent classifies incoming bug reports and feature requests before the orchestrator allocates development resources.

## Changes

- **New agent template:** `agents/1-generic/bug-feature-analyzer.md` (v1.0.0)
  - Classifications: BUG, USER-ERROR, FEATURE, OUT-OF-SCOPE, UNKLAR
  - 4-step triage workflow with escalation paths to `requirements`, `se-critic`, or `ideation`
  - Structured output format for orchestrator consumption
  - Fully provider-agnostic
- **Orchestrator integration:** Updated `agents/1-generic/orchestrator.md` (v3.3.0 → v3.4.0)
  - New intent-routing entry for bug/feature triage
  - New workflow J: bug-feature-analyzer → classification → routing
- **Config & docs:** Updated `config/role-defaults.yaml`, `CLAUDE.md`, `howto/setup/instantiate-project.md`
- **Generated outputs:** Synced across `.claude/`, `.opencode/`, `.continue/`, `.gemini/` platforms

## Activation

Projects must add `bug-feature-analyzer` to their `.meta-config/project.yaml` roles list and re-run `sync.py`.
