### PR TITLE
fix: add exceptions-reference to orchestrator entry-point sentence

### DIFF
--- a/docs/concepts/orchestrator-first-architecture.md
+++ b/docs/concepts/orchestrator-first-architecture.md
@@ -609,7 +609,7 @@ skills:
 Generiert von agent-meta v0.46.2 — 2026-05-21
 DoD-Preset: rapid-prototyping | REQ-Traceability: false | Tests: false | ...
 
-> Einstiegspunkt: Starte mit dem orchestrator-Agenten für alle Entwicklungsaufgaben.
+> Einstiegspunkt: Starte mit dem orchestrator-Agenten für alle Entwicklungsaufgaben — Ausnahmen siehe Abschnitt »Orchestrator — Universal Router«.
 
 | Agent | Zuständigkeit |
 |-------|--------------|

--- a/howto/setup/first-steps.md
+++ b/howto/setup/first-steps.md
@@ -267,5 +267,5 @@ Checkliste:
 - [ ] Bei `"Continue"`: `.continue/rules/project-context.md` vorhanden
 - [ ] Committed
 
-**Nächster Schritt:** Starte mit dem `orchestrator`-Agenten in Claude Code:
+**Nächster Schritt:** Starte mit dem `orchestrator`-Agenten in Claude Code (Ausnahmen siehe »Orchestrator — Universal Router«):
 `> Use orchestrator`

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -1089,7 +1089,7 @@ def build_agent_hints(config: dict, agent_meta_root: Path) -> str:
     )
     if has_orchestrator:
         lines.append(
-            "> **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben."
+            "> **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben — Ausnahmen siehe Abschnitt »Orchestrator — Universal Router«."
         )
         lines.append("")
 


### PR DESCRIPTION
The previous sentence might cause the LLM to over-delegate to the orchestrator even for trivial non-development queries. Added an explicit reference to the exceptions section (" Orchestrator —