### PR TITLE
fix(#236): remove Agent tool from template frontmatter to eliminate sync warnings

### DIFF
--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-manager
-version: "1.7.1"
+version: "1.7.2"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
@@ -11,7 +11,6 @@ tools:
   - Glob
   - Grep
   - WebFetch
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/bug-feature-analyzer.md
+++ b/agents/1-generic/bug-feature-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: template-bug-feature-analyzer
-version: "1.0.0"
+version: "1.0.1"
 description: "Analysiert und klassifiziert eingehende Bug-Meldungen und Feature-Requests vor Ressourcen-Allokation. Unterscheidet: Echter Bug, User-Fehler, validierbares Feature, Out-of-Scope."
 hint: "Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope klassifizieren — vor developer/feature-Delegation"
 tools:
@@ -8,7 +8,6 @@ tools:
   - Glob
   - Grep
   - Bash
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/developer.md
+++ b/agents/1-generic/developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-developer
-version: "2.0.3"
+version: "2.0.4"
 description: "Implementiert Features und Bugfixes mit strikten Code-Konventionen. REQ-ID- und TDD-Pflicht konfigurativ über DoD."
 hint: "Feature-Implementierung und Bugfixes nach REQ-IDs"
 tools:
@@ -10,7 +10,6 @@ tools:
   - Edit
   - Glob
   - Grep
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/feature.md
+++ b/agents/1-generic/feature.md
@@ -1,6 +1,6 @@
 ---
 name: template-feature
-version: "1.4.0"
+version: "1.4.1"
 description: "Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR."
 hint: "Feature-Lifecycle-Subagent: Branch → REQ → TDD → Dev → Validate → PR. Wird vom Orchestrator gestartet, nicht direkt vom User."
 # isolation: worktree   ← Opt-in: aktiviere für parallele Feature-Entwicklung ohne Branch-Konflikte
@@ -9,7 +9,6 @@ hint: "Feature-Lifecycle-Subagent: Branch → REQ → TDD → Dev → Validate �
 tools:
   - Bash
   - Read
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/ideation.md
+++ b/agents/1-generic/ideation.md
@@ -1,6 +1,6 @@
 ---
 name: template-ideation
-version: "1.2.3"
+version: "1.2.4"
 description: "Ideenfindung, Visions-Schärfung und Konzept-Konkretisierung — stellt Fragen, denkt Ecken, übergibt reife Ideen an Requirements."
 hint: "Neue Ideen explorieren, Vision schärfen, Übergabe an requirements"
 tools:
@@ -10,7 +10,6 @@ tools:
   - Grep
   - WebFetch
   - WebSearch
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/log-analyzer.md
+++ b/agents/1-generic/log-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: template-log-analyzer
-version: "1.0.0"
+version: "1.0.1"
 description: "Analysiert System- und Applikations-Logs: Frequency-Clustering, Severity-Klassifikation (RFC 5424), Root-Cause-Hypothesen und strukturierte Findings mit Delegations-Routing."
 hint: "Log-Analyse: Fehler clustern, Severity klassifizieren (RFC 5424), Findings als Issues oder Tasks delegieren"
 tools:
@@ -10,7 +10,6 @@ tools:
   - Grep
   - WebSearch
   - WebFetch
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,10 +1,9 @@
 ---
 name: template-orchestrator
-version: "3.7.0"
+version: "3.7.1"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/1-generic/se-integration-and-test-manager.md
+++ b/agents/1-generic/se-integration-and-test-manager.md
@@ -1,6 +1,6 @@
 ---
 name: se-integration-and-test-manager
-version: 1.0.1
+version: 1.0.2
 description: 'V&V-Orchestrator: Koordiniert Integrationsstrategie, Test-Ebenen und
   Traceability-Feedback über L1-Ln.'
 hint: Orchestriert den gesamten rechten Flügel der V&V-Kaskade — Bottom-Up, Top-Down,
@@ -8,7 +8,6 @@ hint: Orchestriert den gesamten rechten Flügel der V&V-Kaskade — Bottom-Up, T
 tools:
 - Read
 - Write
-- Agent
 - TodoWrite
 ---
 

--- a/agents/1-generic/tester.md
+++ b/agents/1-generic/tester.md
@@ -1,6 +1,6 @@
 ---
 name: template-tester
-version: "2.0.0"
+version: "2.0.1"
 description: "Isolierte Unit-Tests mit Mocks/Stubs nach TDD-Workflow. Für Integrationstests → se-test-engineer."
 hint: "Tests schreiben (TDD), Test-Suite ausführen, Coverage sicherstellen"
 tools:
@@ -10,7 +10,6 @@ tools:
   - Edit
   - Glob
   - Grep
-  - Agent
   - TodoWrite
 ---
 

--- a/agents/2-platform/agent-meta-developer.md
+++ b/agents/2-platform/agent-meta-developer.md
@@ -1,7 +1,7 @@
 ---
 name: agent-meta-developer
-version: "1.0.0"
-based-on: "1-generic/developer.md@2.0.1"
+version: "1.0.1"
+based-on: "1-generic/developer.md@2.0.4"
 description: "Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur, Rollen-Anlegen-Prozess und Sync-Interface."
 hint: "Feature-Implementierung und Bugfixes im agent-meta Framework (Python, Markdown, YAML)"
 tools:
@@ -11,7 +11,6 @@ tools:
   - Edit
   - Glob
   - Grep
-  - Agent
   - TodoWrite
 extends: "1-generic/developer.md"
 patches:

--- a/config/provider-tools.yaml
+++ b/config/provider-tools.yaml
@@ -28,7 +28,6 @@ opencode:
   - Grep
   - WebFetch
   - WebSearch
-  - Agent
   - TodoWrite
 
 gemini:


### PR DESCRIPTION
## Issue #236\n\n- Agent aus 9 Templates in agents/1-generic/ entfernt\n- Agent aus 2-platform/agent-meta-developer.md entfernt\n- Agent aus config/provider-tools.yaml Opencode-Whitelist entfernt\n- Patch-Versionen in allen betroffenen Templates erhöht\n- sync.py --dry-run: 0 Agent-bezogene Warnungen