### PR TITLE
feat(#223): document unsupported Gemini tools in provider-tools.yaml

### DIFF
--- a/config/provider-tools.yaml
+++ b/config/provider-tools.yaml
@@ -43,6 +43,13 @@ gemini:
   - Glob                # implicit in sandbox
   - Grep                # implicit in sandbox
 
+  # === UNSUPPORTED TOOLS (explicitly documented for clarity) ===
+  # The following tools are NOT supported by Gemini and will be filtered/ignored during sync:
+  # - Agent              # Gemini has no subagent dispatch
+  # - TodoWrite          # Gemini has no todo/task list feature
+  # - Task               # Gemini has no task orchestration
+  # - mcp__*             # Gemini MCP support varies by version
+
 continue:
   # Continue has no frontmatter tools model. All tools are available by default.
   # The 'tools' field is removed during generation.

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -72,7 +72,7 @@ def _validate_tools_against_whitelist(
             valid.append(t)
         else:
             log.warn(
-                f"{provider}/{role}: tool '{t}' not in provider whitelist — excluded from frontmatter",
+                f"{provider}/{role}: tool '{t}' not supported by {provider} — skipping (see config/provider-tools.yaml)",
             )
     return valid
 


### PR DESCRIPTION
## Issue #223\n\n- Kommentar-Block mit unsupported Gemini Tools (Agent, TodoWrite, Task, mcp__) in provider-tools.yaml ergänzt\n- Warnmeldung in scripts/lib/agents.py verbessert mit Provider-Name und Referenz auf provider-tools.yaml\n- sync.py --dry-run: keine neuen Fehler, nur erwartete TodoWrite-Warnungen für Gemini