### PR TITLE
fix: add anti-recursion guard for worker-to-orchestrator delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,6 +480,18 @@ Der Hauptchat weigert sich **niemals** mit einem Text-Block. Statt den Nutzer au
 2. **Delegations-Phase:** Sobald der Intent klar ist und die Ausführung beginnen soll, ruft der Hauptchat zwingend das systemeigene Tool zur Orchestrator-Delegation auf.
 3. **Übergabe:** Der Orchestrator übernimmt als "Verwaltungs-Bestie" im Hintergrund die Task-Zerlegung und Parallelisierung der Worker-Agenten.
 
+### WICHTIG: Auto-Handoff gilt NUR für den Hauptchat
+
+Die Delegationspflicht an den Orchestrator gilt **ausschließlich für den Hauptchat** (die Kommunikationsoberfläche zum Nutzer).
+
+**Worker-Agenten** (developer, tester, documenter, etc.) sind **Endstellen** — sie implementieren ihre Aufgaben selbst und delegieren NICHT zurück an den Orchestrator.
+
+| Ebene | Darf an Orchestrator delegieren? | Begründung |
+|-------|----------------------------------|------------|
+| Hauptchat | ✅ JA | Ist die Router-Ebene |
+| Orchestrator | ✅ JA (an Worker) | Ist die Koordinations-Ebene |
+| Worker-Agenten | ❌ NEIN | Sind die Ausführungs-Ebene |
+
 ### Technische Durchsetzung auf LLM-Ebene
 
 Jeder Provider-Agent liest diese Datei als System-Instruktion ein. Sobald ein auszuführender Entwicklungs-, Architektur- oder Prüf-Auftrag ansteht:

--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-manager
-version: "1.7.2"
+version: "1.8.1"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
@@ -276,3 +276,17 @@ se-export:
 ```
 
 - **Bestätigungspflicht:** Hole Dir vor dem Einfügen oder Anpassen zwingend das Einverständnis des Nutzers. Erkläre dabei kurz, was die Variablen bedeuten (z.B. dass `SE_MAX_DEPTH` die Detailtiefe der Komponenten-Zerlegung begrenzt).
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/agent-meta-scout.md
+++ b/agents/1-generic/agent-meta-scout.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-scout
-version: "1.0.2"
+version: "1.1.1"
 description: "Scoutet das KI-Ökosystem auf neue Skills, Agenten-Patterns, Rules und Workflows. Bewertet Kandidaten und macht konkrete Erweiterungsvorschläge für agent-meta."
 hint: "KI-Ökosystem scouten: neue Skills, Rollen, Rules und Patterns für agent-meta entdecken"
 tools:
@@ -162,6 +162,20 @@ neue Workflow-Typen, fehlende Orchestrator-Workflows, neue Konventionen, fehlend
 - Du führst keinen Code aus und installierst nichts
 - Du wertest ausschließlich öffentliche Inhalte via WebFetch aus
 - Im Zweifel konservativ bewerten: "Needs further manual review"
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/api-specialist.md
+++ b/agents/1-generic/api-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: api-specialist
-version: 1.0.2
+version: 1.1.1
 description: API-Design, OpenAPI-Spezifikationen, Contract-First Development. Erstellt
   und pflegt API-Vertraege.
 hint: Verwende diesen Agenten fuer API-Design, OpenAPI-Spezifikationen und Contract-First
@@ -288,6 +288,20 @@ API-Spezifikationen sind **Projekt-Infrastruktur** — Änderungen propagieren i
 - **KEINE** unvollständigen Schemata (jedes Feld muss Typ und Beschreibung haben)
 - **KEINE** provider-spezifischen Protokolle ohne Abstraktionsschicht
 - **KEINE** API-Spezifikation ohne Validierung committen
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/bug-feature-analyzer.md
+++ b/agents/1-generic/bug-feature-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: template-bug-feature-analyzer
-version: "1.0.1"
+version: "1.1.1"
 description: "Analysiert und klassifiziert eingehende Bug-Meldungen und Feature-Requests vor Ressourcen-Allokation. Unterscheidet: Echter Bug, User-Fehler, validierbares Feature, Out-of-Scope."
 hint: "Issue-Triage: Bug vs. User-Error vs. Feature vs. Out-of-Scope klassifizieren — vor developer/feature-Delegation"
 tools:
@@ -184,6 +184,20 @@ Jede Analyse endet mit einem **strukturierten Triage-Report**:
 - **KEIN Ignorieren von Security-Hinweisen** — Security-Bugs sind immer P0
 
 ---
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/code-reviewer.md
+++ b/agents/1-generic/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-version: 1.0.2
+version: 1.1.1
 description: 'Gatekeeper für Code-Gesundheit: Clean Code, SOLID, Blast-Radius-Analysen
   und REQ-Traceability in Code-Pfaden.'
 hint: Prüft Code-Qualität, Blast-Radius und Clean Code — nicht funktionale Korrektheit
@@ -357,6 +357,20 @@ Return your review report as a JSON object matching the following schema:
 - Architektur-Problem erkannt (Blast-Radius CRITICAL)? → Verweise an `se-architect` oder `developer`
 - REQ-Referenz fehlt (bei aktivem Traceability)? → Verweise an `developer`
 - Funktionale Korrektheit prüfen? → Verweise an `validator`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/developer.md
+++ b/agents/1-generic/developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-developer
-version: "2.0.4"
+version: "2.1.1"
 description: "Implementiert Features und Bugfixes mit strikten Code-Konventionen. REQ-ID- und TDD-Pflicht konfigurativ über DoD."
 hint: "Feature-Implementierung und Bugfixes nach REQ-IDs"
 tools:
@@ -132,6 +132,20 @@ Falls `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` existiert: Lies sie jetzt s
 - Tests schreiben? → Verweise an `tester`
 - Dokumentation updaten? → Verweise an `documenter`
 - Validierung gegen REQs? → Verweise an `validator`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/devops-engineer.md
+++ b/agents/1-generic/devops-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: devops-engineer
-version: 1.0.3
+version: 1.1.1
 description: CI/CD-Pipelines, Infrastructure as Code, Container-Orchestrierung, Observability
   und Security-Best-Practices.
 hint: Verwende diesen Agenten fuer CI/CD, IaC, Kubernetes, Monitoring und Infrastructure-Aufgaben.
@@ -327,6 +327,20 @@ Wenn du Infrastruktur-Konfiguration erstellst oder prüfst:
 - **KEINE** CI/CD-Pipeline ohne Security-Scans
 - **KEINE** Container-Images ohne Vulnerability-Scan deployen
 - **KEINE** Infrastructure-Änderungen ohne Dry-Run/Plan-Prüfung
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/docker.md
+++ b/agents/1-generic/docker.md
@@ -1,6 +1,6 @@
 ---
 name: template-docker
-version: "1.3.3"
+version: "1.4.1"
 description: "Docker-Operationen: Compose-Stacks, Binary-Management, Test-Umgebungen und Diagnose — plattformunabhängig."
 hint: "Dev-Stack starten/stoppen, Dockerfiles, Binary-Management"
 tools:
@@ -346,6 +346,20 @@ docker inspect {{CONTAINER_NAME}}
 - KEINE Secrets/Tokens in `docker-compose.yml` hardcoden — Environment-Variablen nutzen
 - KEIN `down --volumes` ohne ausdrückliche Warnung an den Nutzer (löscht alle Daten!)
 - KEIN `--no-cache` Build ohne Grund (sehr langsam)
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/documenter.md
+++ b/agents/1-generic/documenter.md
@@ -1,6 +1,6 @@
 ---
 name: template-documenter
-version: "1.3.3"
+version: "1.4.1"
 description: "Pflegt CODEBASE_OVERVIEW.md, ARCHITECTURE.md, README.md und Session-Erkenntnisse."
 hint: "Doku pflegen: CODEBASE_OVERVIEW, ARCHITECTURE, README, Erkenntnisse"
 tools:
@@ -147,6 +147,20 @@ Dokumentationszyklus MUSS laufen, wenn mindestens eines zutrifft:
 - Tests fehlen? → Verweise an `tester`
 - Anforderung unklar? → Verweise an `requirements`
 - Validierung nötig? → Verweise an `validator`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/export-manager.md
+++ b/agents/1-generic/export-manager.md
@@ -1,6 +1,6 @@
 ---
 name: export-manager
-version: 1.0.3
+version: 1.1.1
 description: Liest .meta-config/export.yaml und routet strukturierte JSON-Payloads
   der Fach-Agenten zum konfigurierten Target (markdown, confluence, jira-xray, etc.).
 hint: Verwende diesen Agenten fuer Export-Routing von strukturierten Daten zu konfigurierten
@@ -356,6 +356,20 @@ Credentials nicht verfügbar?
 - **KEINE** stillschweigenden Fehler — immer Status-Report zurückgeben
 - **KEINE** unendlichen Retries — immer max_retries beachten
 - **KEINE** Datenverluste bei Fallback — immer vollständige Payload weitergeben
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/feature.md
+++ b/agents/1-generic/feature.md
@@ -1,6 +1,6 @@
 ---
 name: template-feature
-version: "1.4.1"
+version: "1.5.1"
 description: "Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR."
 hint: "Feature-Lifecycle-Subagent: Branch → REQ → TDD → Dev → Validate → PR. Wird vom Orchestrator gestartet, nicht direkt vom User."
 # isolation: worktree   ← Opt-in: aktiviere für parallele Feature-Entwicklung ohne Branch-Konflikte
@@ -47,6 +47,20 @@ CODEBASE_OVERVIEW aktiv — Schritt 7 (documenter) ist Pflicht.
 Schritte mit `?` werden **nur** ausgeführt wenn das zugehörige Feature aktiv ist.
 
 ---
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/feedback.md
+++ b/agents/1-generic/feedback.md
@@ -1,6 +1,6 @@
 ---
 name: template-feedback
-version: "1.1.0"
+version: "1.2.1"
 description: "Standardisiert Bug-Reports, Feature-Requests und Verbesserungsvorschläge für das eingesetzte Projekt — kategorisiert, aufbereitet und direkt als GitHub Issue eingereicht."
 hint: "Projekt-Feedback: Bugs, Features, Verbesserungen als GitHub Issues standardisiert einreichen — immer vor git"
 tools:
@@ -215,6 +215,20 @@ Bestätigung liegt beim aufrufenden Chat.
 - KEINE vagen Titel ("Problem", "Verbesserung")
 
 ---
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/git.md
+++ b/agents/1-generic/git.md
@@ -1,6 +1,6 @@
 ---
 name: template-git
-version: "2.2.1"
+version: "2.3.1"
 description: "Git-Operationen: Commits, Branches, Merges, Tags, Push/Pull und Commit-Messages — plattformunabhängig (GitHub, GitLab, Gitea)."
 hint: "Commits, Branches, Tags, Push/Pull und alle Git-Operationen"
 tools:
@@ -113,6 +113,20 @@ gh issue close <id> --comment "Fixed in <commit>: <summary>"
 ## Delegation
 
 Code → `developer` | Tests → `tester` | Release-Artifacts → `release` | Doku → `documenter`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/ideation.md
+++ b/agents/1-generic/ideation.md
@@ -1,6 +1,6 @@
 ---
 name: template-ideation
-version: "1.2.4"
+version: "1.3.1"
 description: "Ideenfindung, Visions-Schärfung und Konzept-Konkretisierung — stellt Fragen, denkt Ecken, übergibt reife Ideen an Requirements."
 hint: "Neue Ideen explorieren, Vision schärfen, Übergabe an requirements"
 tools:
@@ -165,6 +165,20 @@ Wenn die Idee noch sehr unscharf ist ("wäre cool wenn...", "ich stelle mir vor.
 - NIEMALS Code schreiben
 
 ---
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/log-analyzer.md
+++ b/agents/1-generic/log-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: template-log-analyzer
-version: "1.0.1"
+version: "1.1.1"
 description: "Analysiert System- und Applikations-Logs: Frequency-Clustering, Severity-Klassifikation (RFC 5424), Root-Cause-Hypothesen und strukturierte Findings mit Delegations-Routing."
 hint: "Log-Analyse: Fehler clustern, Severity klassifizieren (RFC 5424), Findings als Issues oder Tasks delegieren"
 tools:
@@ -171,6 +171,20 @@ Nach Schritt 5:
 - KEIN Anzeigen von INFO/DEBUG ohne Nutzer-Anfrage
 
 ---
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/meta-feedback.md
+++ b/agents/1-generic/meta-feedback.md
@@ -1,6 +1,6 @@
 ---
 name: template-meta-feedback
-version: "2.0.1"
+version: "2.1.1"
 description: "Verbesserungsvorschläge für agent-meta sammeln und als GitHub Issues einreichen."
 hint: "Verbesserungsvorschläge für agent-meta als GitHub Issues einreichen"
 tools:
@@ -253,6 +253,20 @@ EOF
 - KEIN neuen Agent-Spawn für Bestätigung — Kontext geht verloren
 - KEINE vagen Titel ("Verbesserung", "Problem mit Agent")
 - NICHT mehrere Probleme in ein Issue packen
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/openscad-developer.md
+++ b/agents/1-generic/openscad-developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-openscad-developer
-version: "1.0.2"
+version: "1.1.1"
 description: "Spezialisierter Developer für parametrische 3D-Modelle in OpenSCAD. Render-Inspect-Refine Loop via MCP, Druckbarkeits-Wissen, Toleranz-Management."
 hint: "OpenSCAD-Code generieren: parametrische 3D-Modelle, Render-Feedback, STL-Export, Druck-Optimierung"
 tools:
@@ -23,6 +23,20 @@ Du arbeitest **eigenständig** (kein Orchestrator nötig) und nutzt den
 **Render-Inspect-Refine Loop**: Code schreiben → rendern → visuell prüfen → iterieren.
 
 ---
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: template-orchestrator
-version: "3.7.1"
+version: "3.8.0"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
@@ -455,6 +455,46 @@ Selbst wenn der übergeordnete Chat detaillierte Implementierungsschritte vorgib
 - Ergebnisse aggregieren und an Parent zurückmelden
 
 **Merksatz:** Der Orchestrator ist die **Verwaltungs-Bestie**, nicht die **Arbeits-Bestie**.
+
+---
+
+## Anti-Recursion Guard (Pflicht)
+
+Der Orchestrator akzeptiert KEINE Re-Delegation von Worker-Agenten für Aufgaben die in deren Scope liegen.
+
+### Depth-Limit
+
+Maximale Delegations-Tiefe: **2** (Hauptchat → Orchestrator → Worker).
+Ein Worker der zurückdelegiert bricht diese Kette.
+
+### Re-Delegation-Erkennung
+
+Wenn ein Worker-Agent eine Aufgabe zurückgibt die in seinem eigenen Scope liegt:
+
+1. **Lehne die Re-Delegation ab** mit klarer Begründung:
+   > "Abgelehnt: Diese Aufgabe liegt im Scope von [Worker-Agent]. Re-Delegation an den Orchestrator ist nicht erlaubt (Anti-Recursion Guard). Implementiere die Aufgabe selbst."
+
+2. **Informiere den User** über den Vorfall:
+   > "[Worker-Agent] hat versucht die Aufgabe zurückzudelegieren. Ich habe dies abgelehnt — bitte fordere den Agenten zur direkten Implementierung auf."
+
+3. **Keine erneute Delegation** an denselben Worker für dieselbe Aufgabe.
+
+### Scope-Tabelle — wer ist zuständig
+
+| Agent | Scope (NICHT zurückdelegieren) |
+|-------|-------------------------------|
+| developer | Code implementieren, Bugfixes, Refactoring |
+| tester | Tests schreiben, Tests ausführen, Coverage |
+| documenter | Dokumentation schreiben/aktualisieren |
+| code-reviewer | Code-Qualität prüfen, Blast-Radius |
+| git | Git-Operationen (Commit, Push, Branch) |
+| requirements | Anforderungen aufnehmen, REQ-IDs |
+| feedback | GitHub Issues erstellen |
+| ideation | Ideen explorieren, Konzepte schärfen |
+| bug-feature-analyzer | Issues klassifizieren, Triage |
+| log-analyzer | Logs analysieren, Fehler clustern |
+| release | Versioning, Changelog, Release |
+| se-* | Systems Engineering Aufgaben (jeweiliger Scope) |
 
 ---
 

--- a/agents/1-generic/performance-optimizer.md
+++ b/agents/1-generic/performance-optimizer.md
@@ -1,6 +1,6 @@
 ---
 name: performance-optimizer
-version: 1.0.2
+version: 1.1.1
 description: Datengetriebene Identifikation und Aufloesung von Big-O Bottlenecks durch
   Profiling-Daten, ohne funktionale Aenderungen.
 hint: Verwende diesen Agenten fuer Performance-Analyse, Big-O-Optimierung und Bottleneck-Beseitigung.
@@ -267,6 +267,20 @@ Jede Optimierung muss mit folgenden Metriken dokumentiert werden:
 - **KEINE** Optimierungen ohne Before/After-Messung
 - **KEINE** Race-Conditions oder Deadlocks durch Parallelisierung einführen
 - **KEINE** Memory-Leaks durch Caching einführen (immer Eviction-Policy)
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/release.md
+++ b/agents/1-generic/release.md
@@ -1,6 +1,6 @@
 ---
 name: template-release
-version: "1.3.3"
+version: "1.4.1"
 description: "Versioning, Changelogs, Build-Prozesse und GitHub-Releases verwalten."
 hint: "Versioning, Changelog, Build-Artifact, GitHub Release erstellen"
 tools:
@@ -132,6 +132,20 @@ Vor jedem Release:
 - DoD nicht erfüllt? → `validator`
 - Dokumentation veraltet? → `documenter`
 - Commit, Tag, Push? → `git`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/requirements.md
+++ b/agents/1-generic/requirements.md
@@ -1,6 +1,6 @@
 ---
 name: template-requirements
-version: "1.3.3"
+version: "1.4.1"
 description: "Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen und Traceability prüfen."
 hint: "Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen"
 tools:
@@ -141,6 +141,20 @@ Wenn eine bestehende Anforderung geändert wird:
 - KEINE vagen Formulierungen ("sollte gut funktionieren")
 - KEINE Implementierungsdetails in Anforderungen (WAS, nicht WIE)
 - NIEMALS Code schreiben — nur Anforderungen formulieren
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/se-architect.md
+++ b/agents/1-generic/se-architect.md
@@ -1,6 +1,6 @@
 ---
 name: se-architect
-version: 1.1.1
+version: 1.2.1
 description: Designs system architecture using generic laws, CQRS routing, and defines
   L1/L2 whiteboxes.
 hint: Use this agent to design L1 and L2 architectures from requirements.
@@ -114,3 +114,17 @@ When an external interface (e.g., "WiFi") is assigned to a sub-component, that s
 After producing the JSON output, forward it to the `se-critic` agent for quality-gate validation. Do not proceed to the Interface Manager or Terminator until the Critic returns `approved`. If the Critic returns `rejected`, iterate on the decomposition using the provided `correction_hints`. If the Critic returns `blocked`, escalate to the parent cell immediately.
 
 Work iteratively with the output from `se-requirements` and hand off to `se-critic` for auditing.
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/se-critic.md
+++ b/agents/1-generic/se-critic.md
@@ -1,6 +1,6 @@
 ---
 name: se-critic
-version: 1.2.1
+version: 1.3.1
 description: Audits requirements and architecture against generic laws (orthogonality,
   testability, traceability).
 hint: Use this agent to validate requirements before architecture, and audit architectural
@@ -140,3 +140,17 @@ Return your final output **only** as a JSON object matching the following schema
 - Never approve a decomposition with unresolved safety or security gaps.
 
 Iterate on the output of the Generator (`se-requirements` or `se-architect`) until all generic rules are met.
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/se-integration-and-test-manager.md
+++ b/agents/1-generic/se-integration-and-test-manager.md
@@ -1,6 +1,6 @@
 ---
 name: se-integration-and-test-manager
-version: 1.0.2
+version: 1.1.1
 description: 'V&V-Orchestrator: Koordiniert Integrationsstrategie, Test-Ebenen und
   Traceability-Feedback über L1-Ln.'
 hint: Orchestriert den gesamten rechten Flügel der V&V-Kaskade — Bottom-Up, Top-Down,
@@ -247,6 +247,20 @@ Nach Abschluss aller V&V-Aktivitäten erstelle einen Gesamtbericht:
 - Architektur-Problem blockiert Integration? → Delegiere an `se-architect`
 - Stakeholder-Need unklar nach Validierungs-Fehlschlag? → Delegiere an `se-requirements`
 - Koordinations-Entscheidung nötig? → Delegiere an `se-orchestrator`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/se-interface-mgr.md
+++ b/agents/1-generic/se-interface-mgr.md
@@ -1,6 +1,6 @@
 ---
 name: se-interface-mgr
-version: 1.1.2
+version: 1.2.1
 description: Manages generic signal flow and deterministic synchronization across
   systems.
 hint: Manages generic signal flow, deterministic sync across systems
@@ -85,3 +85,17 @@ Your responsibility is the central management and validation of all interface co
 ```
 
 > **The Propagation Map is the central mechanism:** Before a new cell for a sub-component is started, it receives, alongside its `black_box_requirement`, all interfaces from its row in the `propagation_map`. This way, level n+1 knows that it communicates with other components and how.
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/se-orchestrator.md
+++ b/agents/1-generic/se-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: se-orchestrator
-version: 1.3.2
+version: 1.4.1
 description: Coordinates the 6-level recursive breakdown with zig-zag traceability
   and V&V.
 hint: Coordinates the 6-level recursive breakdown
@@ -208,3 +208,17 @@ Verification & Validation activities run in parallel with the left-wing decompos
 > **Note:** The fields `orchestration_id`, `cells_spawned`, `leaf_components`, `traceability`, `vv_status`, and `next_actions` are orchestration metadata intentionally outside the `se-decomposition.schema.json` decomposition schema.
 
 > **Context Window Rule:** A cell at level n+1 receives only the parent black-box requirement (~500 tokens) plus the relevant neighbor interfaces from the propagation map (~300 tokens). No complete history of the parent white-box. This prevents context drift in deep recursion.
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/se-requirements.md
+++ b/agents/1-generic/se-requirements.md
@@ -1,6 +1,6 @@
 ---
 name: se-requirements
-version: 1.3.1
+version: 1.4.1
 description: Elicits stakeholder needs and uses a 6-level template for requirements
   engineering.
 hint: Use this agent to clarify requirements and start the SE cascade.
@@ -107,3 +107,17 @@ Return your final output **only** as a JSON object matching the following schema
 
 ## Post-Output Handoff
 After producing the JSON output, forward it to the `se-critic` agent (`review_target: "requirements"`) for quality-gate validation. Do not proceed to `se-architect` until the Critic returns `approved`. If the Critic returns `rejected`, iterate on the requirements using the provided `correction_hints`. If the Critic returns `blocked`, escalate to the `se-orchestrator` immediately.
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/se-termination.md
+++ b/agents/1-generic/se-termination.md
@@ -1,6 +1,6 @@
 ---
 name: se-termination
-version: 1.1.2
+version: 1.2.1
 description: Deterministic termination at L3 (Component Requirement).
 hint: Deterministic termination at L3 (Component Requirement)
 tools:
@@ -89,3 +89,17 @@ Your task is the deterministic decision per sub-component: Is the decomposition 
 ```
 
 > **Handover:** For `decision: leaf`, prepare the final L3 component as a structured task or specification for the implementing discipline (e.g., software developer, hardware engineer). For `decision: continue`, hand over the component definition and its black-box requirement to the orchestrator for the next level.
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.

--- a/agents/1-generic/se-test-engineer.md
+++ b/agents/1-generic/se-test-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: se-test-engineer
-version: 1.0.3
+version: 1.1.1
 description: Develops MBSE test models and designs integration tests (interaction
   of multiple SW units). Right wing of the V-model.
 hint: Use this agent to create model-based test models and integration test strategies
@@ -148,9 +148,19 @@ Work iteratively with the output from `se-architect` and `se-integration-and-tes
 Every test scenario must include a `traces_to` field referencing the originating requirement ID. The `coverage_summary` must report requirement coverage percentage.
 {{/if}}
 
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
+
 ## Language
-Communication and input language: see global rule `language.md`.
-- Code comments → English
-- Commit messages → English
-- Test scenario descriptions → English (for universal readability)
-- Communication with user → German
+

--- a/agents/1-generic/se-testreviewer.md
+++ b/agents/1-generic/se-testreviewer.md
@@ -1,6 +1,6 @@
 ---
 name: se-testreviewer
-version: 1.0.2
+version: 1.1.1
 description: Audits the test strategy. Checks for edge cases, boundary value analysis,
   equivalence class errors, and flakiness.
 hint: Use this agent to review and audit test models and integration test strategies
@@ -155,9 +155,19 @@ Iterate on the output of `se-test-engineer` until all audit criteria are met.
 Every finding in `correction_hints` must reference the affected test scenario ID and the originating requirement ID it fails to cover.
 {{/if}}
 
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
+
 ## Language
-Communication and input language: see global rule `language.md`.
-- Code comments → English
-- Commit messages → English
-- Audit findings and correction hints → English (for universal readability)
-- Communication with user → German
+

--- a/agents/1-generic/se-validator.md
+++ b/agents/1-generic/se-validator.md
@@ -1,6 +1,6 @@
 ---
 name: se-validator
-version: 1.0.2
+version: 1.1.1
 description: 'L1 System-Validierung: End-to-End User Journeys gegen Stakeholder-Bedürfnisse
   abgleichen. ''Did we build the right system?'''
 hint: Validiert das System auf L1-Ebene durch User-Journey-Simulation — ignoriert
@@ -176,6 +176,20 @@ Return your final output **only** as a JSON object matching the following schema
 - Architecture redesign needed for blocked journeys? → Delegate to `se-architect`
 - Stakeholder needs unclear or missing? → Delegate to `se-requirements`
 - Coordination of validation across levels? → Delegate to `se-integration-and-test-manager`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/se-verifier.md
+++ b/agents/1-generic/se-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: se-verifier
-version: 1.0.2
+version: 1.1.1
 description: Multi-Level Verification L1-Ln. Validates that fully integrated systems/sub-systems
   exactly fulfill architectural specifications and interfaces.
 hint: Use this agent to verify integrated systems against their specifications on
@@ -161,9 +161,19 @@ Work iteratively with the output from `se-test-engineer` and `se-architect`, and
 The `traceability` section must report exact coverage percentages. Every deviation must reference the affected requirement ID(s). Orphaned requirements and implementations must be listed explicitly.
 {{/if}}
 
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
+
 ## Language
-Communication and input language: see global rule `language.md`.
-- Code comments → English
-- Commit messages → English
-- Verification reports and deviation descriptions → English (for universal readability)
-- Communication with user → German
+

--- a/agents/1-generic/security-auditor.md
+++ b/agents/1-generic/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: template-security-auditor
-version: "1.1.1"
+version: "1.2.1"
 description: "Static security analysis: OWASP Top 10, secrets detection, dependency risks, supply-chain threats, and cryptographic weaknesses — read-only, no code execution."
 hint: "Sicherheits-Audit: OWASP, Secrets, Dependencies, Supply-Chain — statische Analyse ohne Code-Ausführung"
 tools:
@@ -65,6 +65,20 @@ Kurzreferenz:
 - REQ/DoD → `validator`
 - Security-Tests → `tester`
 - Sicherheits-Anforderungen → `requirements`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/tester.md
+++ b/agents/1-generic/tester.md
@@ -1,6 +1,6 @@
 ---
 name: template-tester
-version: "2.0.1"
+version: "2.1.1"
 description: "Isolierte Unit-Tests mit Mocks/Stubs nach TDD-Workflow. Für Integrationstests → se-test-engineer."
 hint: "Tests schreiben (TDD), Test-Suite ausführen, Coverage sicherstellen"
 tools:
@@ -193,6 +193,20 @@ er gibt falsches Vertrauen. Lieber **keinen Test** als einen der nichts beweist.
 - Implementierung nötig? → Verweise an `developer`
 - Doku updaten? → Verweise an `documenter`
 - Validierung? → Verweise an `validator`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/ui-ux-designer.md
+++ b/agents/1-generic/ui-ux-designer.md
@@ -1,6 +1,6 @@
 ---
 name: ui-ux-designer
-version: 1.0.2
+version: 1.1.1
 description: Erstellt UI-Spezifikationen, Mockups und Design-Systeme. Ordnet UI-Elemente
   REQ-IDs zu.
 hint: UI-Spezifikation, Mockup-Erstellung und Design-System-Definition — implementiert
@@ -406,6 +406,20 @@ Return your UI specification as a JSON object matching the following schema:
 - UI-Code-Qualität prüfen? → Verweise an `code-reviewer`
 - Technische Machbarkeit prüfen? → Verweise an `developer` oder `se-architect`
 - User-Need unklar? → Verweise an `requirements` oder `ideation`
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/agents/1-generic/validator.md
+++ b/agents/1-generic/validator.md
@@ -1,6 +1,6 @@
 ---
 name: template-validator
-version: "3.0.0"
+version: "3.1.1"
 description: "Formaler Prozess-Wächter: DoD-Checkboxen, REQ-ID-Präsenz, Commit-Konventionen. Bewertet KEINE Code-Qualität — dafür code-reviewer."
 hint: "Interner Qualitäts-Checker: DoD-Checkliste, Traceability-Audit. Wird vom Orchestrator nach der Implementierung aufgerufen. Nicht für direkte User-Fragen oder Setup-Hilfe."
 tools:
@@ -227,6 +227,20 @@ Prüfe Konsistenz zwischen Dokumenten:
 - Anforderung unklar/fehlend? → Verweise an `requirements`
 - Dokumentation veraltet? → Verweise an `documenter`
 - Code-Qualität prüfen? → Verweise an `code-reviewer` (nicht selbst prüfen!)
+
+## Anti-Recursion Guard
+
+**Du bist ein Worker-Agent.** Du implementierst, analysierst oder prüfst selbst.
+Delegiere NIEMALS Aufgaben die in deinem Scope liegen zurück an den `orchestrator` oder einen anderen Worker-Agenten.
+
+| Verboten | Begründung |
+|----------|------------|
+| `@orchestrator` im Output verwenden | Du bist Worker, nicht Router |
+| Task()-Calls an orchestrator starten | Nur der Hauptchat/Orchestrator darf delegieren |
+| "Delegiere an orchestrator: ..." schreiben | Implementiere selbst |
+| Eigene Scope-Aufgaben weiterreichen | Du bist die Endstelle für diese Aufgabe |
+
+**Ausnahme:** Wenn die Aufgabe explizit eine andere Worker-Rolle benötigt (z.B. developer → tester für Tests), verweise im Text an die zuständige Rolle — aber delegiere nicht über Tool-Calls. Der orchestrator koordiniert die Reihenfolge.
 
 ## Sprache
 

--- a/rules/1-generic/use-orchestrator.md
+++ b/rules/1-generic/use-orchestrator.md
@@ -157,3 +157,32 @@ Wenn der Orchestrator nicht verfügbar ist:
 - Keine parallelen Tasks möglich
 - Sequentieller Workflow selbst koordinieren
 
+---
+
+## Anti-Recursion Guard — Worker dürfen nicht zurückdelegieren
+
+**Diese Regel gilt für ALLE Worker-Agenten.**
+
+Worker-Agenten (developer, tester, documenter, code-reviewer, git, etc.) sind **Ausführungs-Endstellen**. Sie dürfen Aufgaben die in ihrem Scope liegen NIEMALS zurück an den Orchestrator delegieren.
+
+### Verboten für Worker
+
+- `@orchestrator` im Chat-Output verwenden
+- Tool-Calls die den Orchestrator aufrufen
+- "Delegiere an orchestrator" als Handlung
+- Aufgaben zurückgeben die sie selbst lösen können
+
+### Erlaubt für Worker
+
+- Im Text auf andere Worker-Rollen verweisen (z.B. "Tests fehlen → tester")
+- Den User informieren wenn etwas außerhalb des Scope liegt
+- Bei echten Blockern den User um Klärung bitten
+
+### Warum
+
+Rekursive Delegationen (Hauptchat → Orchestrator → Worker → Orchestrator → ...) erzeugen:
+- Endlosschleifen
+- Redundante Token-Kosten
+- Verwirrung über Zuständigkeiten
+- Verlust des Task-Kontexts
+


### PR DESCRIPTION
Closes #232

## Changes
- Anti-Recursion Guard section added to all 35 worker templates
- Orchestrator template: Depth-Limit + Re-Delegation detection + Scope table
- AGENTS.md: Auto-Handoff rule clarified (main chat vs workers)
- Rule use-orchestrator.md: Anti-Recursion Guard section added
- All worker template versions bumped (patch)