### PR TITLE
feat: add Gemini Auto-Handoff methodology to orchestrator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,6 +502,17 @@ Jeder Provider-Agent liest diese Datei als System-Instruktion ein. Sobald ein au
 
 **Entscheidungsregel:** Native Umgebung mit Subagent-Tool? → Native Tool-Calls verwenden. Nur reines Text-Chat-Frontend? → `@orchestrator` Fallback.
 
+**Provider-spezifische Implementierungsdetails:**
+
+| Provider | Dispatch-Mechanismus | Dokumentation |
+|----------|---------------------|---------------|
+| Opencode | `task()` Tool-Call | Native Subagent-Dispatch |
+| Gemini/Antigravity | `define_subagent` + `invoke_subagent` | Siehe `2-platform/gemini-orchestrator.md` |
+| Claude | `background` Tool-Call | Native Subagent-Dispatch |
+| Continue | Sequenziell (kein Parallel-Dispatch) | Fallback-Modus |
+
+Für Gemini-spezifische Auto-Handoff-Details → `agents/2-platform/gemini-orchestrator.md`.
+
 ## Hauptchat ohne Orchestrator (Fallback)
 
 Wenn der Orchestrator nicht verfügbar ist:

--- a/agents/2-platform/gemini-orchestrator.md
+++ b/agents/2-platform/gemini-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: template-orchestrator
-version: "1.0.0"
-based-on: "1-generic/orchestrator.md@3.7.0"
+version: "1.1.0"
+based-on: "1-generic/orchestrator.md@3.8.0"
 description: "Gemini/Antigravity-spezifischer Orchestrator-Override: Mention-Interception und Tool-Dispatch."
 tools:
   - Agent
@@ -35,3 +35,33 @@ patches:
 
       **Oder über Tool-Call (bevorzugt):**
       Verwende das native `task()`-Tool des Orchestrators — das umgeht Mention-Parsing komplett.
+  - op: append
+    content: |
+      ### Gemini Auto-Handoff Methodik
+
+      **`define_subagent` / `invoke_subagent` Blueprint:**
+
+      Gemini/Antigravity verwendet native Subagent-Dispatch-Mechanismen die sich von anderen Providern unterscheiden.
+
+      ```
+      # Gemini Subagent-Dispatch Pattern
+      1. define_subagent: Definiere den Agent-Typ mit Rolle und Kontext
+      2. invoke_subagent: Starte den Agenten mit spezifischer Aufgabe
+      3. Collect results: Warte auf Ergebnis und aggregiere
+      ```
+
+      **Pflicht-Regeln:**
+      - Orchestrator verwendet IMMER `define_subagent` + `invoke_subagent` für Worker-Delegation
+      - KEIN text-basierter `@orchestrator` Fallback wenn native Subagent-Tools verfügbar
+      - Planning-Mode darf Delegation NICHT unterdrücken
+
+      **Planning-Mode Anti-Konflikt-Regel:**
+
+      Wenn die Umgebung einen nativen Planungsmodus erzwingt (z.B. Gemini "planning" oder "thinking" Phase):
+
+      1. Planning-Phase läuft NUR im Orchestrator — nicht im Worker
+      2. Planning-Mode darf die eigentliche Delegation NICHT blockieren oder unterdrücken
+      3. Nach Planning-Phase SOFORT `invoke_subagent` aufrufen — kein zusätzlicher Bestätigungsschritt
+      4. Wenn Planning-Mode einen "approval" Schritt verlangt: Dieser gilt NUR für den Orchestrator→Worker Dispatch, nicht für interne Worker-Operationen
+
+      **Warum:** Ohne diese Regel kann der Planning-Mode die Delegation in eine Endlosschleife bringen (Plan → Bestätigung → Plan → ...) oder komplett unterdrücken.


### PR DESCRIPTION
Closes #208

## Changes
- Gemini Auto-Handoff Methodik Sektion in 2-platform/gemini-orchestrator.md
- define_subagent / invoke_subagent Blueprint dokumentiert
- Planning-Mode Anti-Konflikt-Regel hinzugefügt
- Provider-spezifische Dispatch-Tabelle in AGENTS.md ergänzt
- based-on auf orchestrator@3.8.0 aktualisiert
- Version 1.0.0 → 1.1.0