### PR TITLE
Fix #203: Clarify update-meta vs upgrade-meta in agent-meta-manager

### DIFF
--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-manager
-version: "1.8.1"
+version: "1.9.0"
 description: "agent-meta verwalten: Upgrades, Sync, Feedback-Delegation, projektspezifische Agenten, External-Skill-Lifecycle und Erweiterungen anlegen."
 hint: "agent-meta verwalten: Upgrade, Sync, Feedback, projektspezifische Agenten anlegen"
 tools:
@@ -82,7 +82,34 @@ head -5 sync.log
 
 ---
 
-## 2. Upgrade
+## 1a. Update vs Upgrade — Klare Trennung
+
+**Diese beiden Operationen sind NICHT austauschbar.** Verwende die korrekte Bezeichnung und Commit-Message.
+
+| Operation | Wann | Was passiert | Commit-Message |
+|-----------|------|-------------|----------------|
+| **`update-meta`** (Re-Sync) | Generierte Agenten mit **aktueller** Version neu generieren | `sync.py` läuft, kein Versionswechsel | `chore: regenerate agents` |
+| **`upgrade-meta`** (Version bump) | Auf **neues Tag** wechseln + Sync | `git checkout v<X.Y.Z>` + `sync.py` | `chore: upgrade agent-meta to v<X.Y.Z>` |
+
+### Entscheidungsregel
+
+```
+User will neue Version?  → upgrade-meta (git checkout tag + sync)
+User will nur Agenten neu generieren? → update-meta (nur sync)
+Bereits auf neuestem Tag? → update-meta (nur sync, KEIN upgrade commit)
+```
+
+### Sonderfall: Bereits auf neuestem Version
+
+Wenn `git describe --tags --abbrev=0` dasselbe Tag liefert wie das neueste Remote-Tag:
+
+1. Klare Meldung: "Bereits auf neuester Version `<tag>`, führe Re-Sync durch."
+2. **Nur** `sync.py` ausführen (update-meta, NICHT upgrade-meta)
+3. Commit-Message: `chore: regenerate agents` (niemals `upgrade` verwenden)
+
+---
+
+## 2. Upgrade (`upgrade-meta`)
 
 ```bash
 # Verfügbare Versionen
@@ -102,15 +129,25 @@ git add .agent-meta
 
 → Dann Sync (Abschnitt 3) + `git commit -m "chore: upgrade agent-meta to v<ZIEL>"`
 
+**Wichtig:** Dies ist `upgrade-meta` — ein Versionswechsel. Verwende NIEMALS diese Commit-Message für einen reinen Re-Sync ohne Versionswechsel.
+
 ---
 
-## 3. Sync
+## 3. Update (`update-meta` / Re-Sync)
 
 ```bash
 py .agent-meta/scripts/sync.py --config .meta-config/project.yaml
 ```
 
 Danach: `sync.log` auf `[WARN]` prüfen und dem User erklären.
+
+Commit-Message für reinen Re-Sync (ohne Versionswechsel):
+```bash
+git add -A
+git commit -m "chore: regenerate agents"
+```
+
+**Wichtig:** Dies ist `update-meta` — KEIN Versionswechsel. Verwende NIEMALS `upgrade` in der Commit-Message wenn sich die Version nicht geändert hat.
 
 ---
 


### PR DESCRIPTION
Closes #203

## Changes
- Added new section **1a. Update vs Upgrade — Klare Trennung** with clear decision table
- \update-meta\ (Re-Sync): \chore: regenerate agents\
- \upgrade-meta\ (Version bump): \chore: upgrade agent-meta to v<X.Y.Z>\
- Added special case handling when already on latest tag
- Bumped version to 1.9.0