### PR TITLE
refactor: complete PAL wiring — move all provider syntax to templates

### DIFF
--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -1,7 +1,7 @@
 # agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.
 # Schema-Validierung: agent-meta.schema.json (JSON Schema bleibt JSON — IDE-Standard)
 
-agent-meta-version: 0.56.0
+agent-meta-version: 0.57.0
 
 # agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
 # Provider isolation must be disabled here — the meta-repo intentionally

--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: template-orchestrator
-version: "3.17.0"
+version: "3.18.0"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
@@ -150,15 +150,14 @@ Wenn `ORCHESTRATOR_OUTCOME_CACHING` aktiviert:
 
 ## Parallel Execution Engine
 
-```
-FANOUT(N, AgentType, [tasks]):      N gleiche Agenten parallel starten
-PARALLEL_GROUP([(AgentType, task)]): Verschiedene Agenten parallel starten
+{{PAL_DELEGATE}}
+{{PAL_FANOUT}}
+{{PAL_PARALLEL_GROUP}}
 BARRIER():                           Warten bis alle fertig; Ergebnisse sammeln
 REPEAT_UNTIL(gen, critic, max):     Generator → Critic → Revision bis max
 PIPELINE(name, stages):             Vordefinierte Pipeline sequentiell/parallel
-```
 
-**Capability Detection:** `{{PARALLEL_PATTERN}}` enthält Provider-Anweisungen. "not supported" → sequentieller Fallback.
+**Capability Detection:** {{PAL_PARALLEL_PATTERN}}
 
 ---
 
@@ -386,7 +385,7 @@ Alle anderen Agenten werden **ausschließlich** über das native Tool-Call-Inter
 - Worker-Agenten antworten **nie** mit `@<anderer-agent>` im Chat
 - Der Hauptchat delegiert **nie** mit `@<agent>` — er verwendet das native Dispatch-Tool oder `@orchestrator` als Fallback
 
-**Fallback:** Falls Tool-Calls nicht verfügbar → `@orchestrator <Aufgabe>`.
+**Fallback:** Falls Tool-Calls nicht verfügbar → {{PAL_FALLBACK}}.
 
 ---
 
@@ -533,6 +532,14 @@ Wenn eine Delegation fehlschlägt (Permission denied, Tool unavailable, Timeout)
 **Grundregel:** Nach 2 gescheiterten Delegationen für denselben Intent → User um Klärung bitten. **Niemals selbst Workarounds implementieren.**
 
 <!-- ===== END MANAGED ===== -->
+
+{{#if PAL_TOOL_PREAMBLE}}
+---
+
+## Tools
+
+Verwende die verfügbaren Tools entsprechend deiner Aufgabe.
+{{/if}}
 
 ## Sprache
 

--- a/config/delegation-syntax.yaml
+++ b/config/delegation-syntax.yaml
@@ -9,7 +9,8 @@ delegation_syntax:
     parallel_group: "{{foreground}}\n\n# Gleichzeitig im Hintergrund (in derselben Antwort):\n{{background}}"
     fallback: "Delegiere folgende Aufgabe an den Orchestrator: {{task}}"
     bootstrap: "file-based"
-    tool_preamble: true
+    tool_preamble: "true"
+    parallel_pattern: "**Parallel-Pattern (konkret):**\n```\n# Vordergrund:\nAgent(subagent_type=\"validator\", prompt=\"DoD-Check für ...\")\n# Gleichzeitig im Hintergrund:\nAgent(subagent_type=\"documenter\", prompt=\"Update CODEBASE_OVERVIEW ...\", run_in_background=True)\n# Dann warten bis Hintergrund fertig, dann:\nAgent(subagent_type=\"git\", prompt=\"Commit und PR erstellen ...\")\n```\n"
 
   Opencode:
     delegate: 'task(subagent_type="{{agent}}", description="{{short_desc}}", prompt="{{task}}")'
@@ -17,7 +18,8 @@ delegation_syntax:
     parallel_group: "{{foreground}}\n\n# Parallel:\n{{background}}"
     fallback: "@orchestrator {{task}}"
     bootstrap: "file-based"
-    tool_preamble: true
+    tool_preamble: "true"
+    parallel_pattern: "**Parallel-Dispatch (Opencode):**\nFANOUT: Alle N task()-Calls in EINER Antwort-Nachricht. Kein separater Background-Marker.\nPARALLEL_GROUP: Mehrere task()-Calls mit verschiedenen subagent_type in einer Antwort.\nBARRIER: Automatisch — die Antwort kommt erst wenn alle Tasks fertig sind.\n\n```\n# FANOUT(3, developer, [\"Fix A\", \"Fix B\", \"Fix C\"]):\ntask(subagent_type=\"developer\", description=\"Fix Bug A\", prompt=\"...\")\ntask(subagent_type=\"developer\", description=\"Fix Bug B\", prompt=\"...\")\ntask(subagent_type=\"developer\", description=\"Fix Bug C\", prompt=\"...\")\n# Alle drei Calls in derselben Antwort → parallele Ausführung\n# Ergebnisse: task_results als Array [result_A, result_B, result_C]\n```\n\nLimit: Kein hartes Limit. MAX_PARALLEL_AGENTS steuert die Anzahl.\n"
 
   Gemini:
     delegate: 'Rufe den **{{agent}}-Agenten** auf mit der Aufgabe: "{{task}}"'
@@ -28,8 +30,9 @@ delegation_syntax:
     bootstrap_sequence:
       - type: "api_call"
         template: 'define_subagent(name="{{name}}", description="{{description}}", system_prompt="{{prompt}}")'
-    tool_preamble: false
+    tool_preamble: "false"
     auto_parallel: true
+    parallel_pattern: "**Parallel-Pattern (konkret):**\nGemini Code Assist führt unabhängige Tool-Aufrufe parallel aus.\nDelegiere an mehrere Agenten in einem einzigen Prompt — die Ausführung erfolgt automatisch parallelisiert.\n"
 
   Continue:
     delegate: "@{{agent}} {{task}}"
@@ -40,8 +43,9 @@ delegation_syntax:
     bootstrap_sequence:
       - type: "config_update"
         target: ".continue/config.yaml"
-    tool_preamble: false
+    tool_preamble: "false"
     auto_parallel: false
+    parallel_pattern: "**Parallel-Pattern:**\nContinue unterstützt keine native parallele Subagent-Ausführung.\nFühre parallele Schritte sequentiell aus oder verwende separate Continue-Sessions.\n"
 
   Copilot:
     delegate: "@{{agent}} Führe folgende Aufgabe aus: {{task}}"
@@ -49,5 +53,6 @@ delegation_syntax:
     parallel_group: "Bearbeite diese Aufgaben:\n{{tasks_list}}"
     fallback: "Bearbeite: {{task}}"
     bootstrap: "file-based"
-    tool_preamble: false
+    tool_preamble: "false"
     auto_parallel: false
+    parallel_pattern: "**Parallel-Pattern:**\nGitHub Copilot unterstützt keine native parallele Subagent-Ausführung.\nFühre parallele Schritte sequentiell aus oder verwende separate VS Code-Sessions.\n"

--- a/howto/configs/GEMINI.project-template.md
+++ b/howto/configs/GEMINI.project-template.md
@@ -16,6 +16,9 @@ DoD-Preset: **{{DOD_PRESET}}** | REQ-Traceability: {{DOD_REQ_TRACEABILITY}} | Te
 
 Agent files are in `.gemini/agents/`. Use them with `@agent-name` in Gemini CLI.
 
+<!-- agent-meta:bootstrap-begin -->
+<!-- agent-meta:bootstrap-end -->
+
 ## Project Setup
 
 - **Build:** `{{BUILD_COMMAND}}`

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -77,54 +77,6 @@ def _validate_tools_against_whitelist(
             )
     return valid
 
-# Provider-specific parallel execution patterns (injected as {{PARALLEL_PATTERN}})
-_PROVIDER_PARALLEL_PATTERNS: dict[str, str] = {
-    "Claude": (
-        "**Parallel-Pattern (konkret):**\n"
-        "```\n"
-        '# Vordergrund:\n'
-        'Agent(subagent_type="validator", prompt="DoD-Check für ...")\n'
-        "# Gleichzeitig im Hintergrund:\n"
-        'Agent(subagent_type="documenter", prompt="Update CODEBASE_OVERVIEW ...", run_in_background=True)\n'
-        "# Dann warten bis Hintergrund fertig, dann:\n"
-        'Agent(subagent_type="git", prompt="Commit und PR erstellen ...")\n'
-        "```\n"
-    ),
-    "Opencode": (
-        "**Parallel-Dispatch (Opencode):**\n"
-        "FANOUT: Alle N task()-Calls in EINER Antwort-Nachricht. Kein separater Background-Marker.\n"
-        "PARALLEL_GROUP: Mehrere task()-Calls mit verschiedenen subagent_type in einer Antwort.\n"
-        "BARRIER: Automatisch — die Antwort kommt erst wenn alle Tasks fertig sind.\n"
-        "\n"
-        "```\n"
-        "# FANOUT(3, developer, [\"Fix A\", \"Fix B\", \"Fix C\"]):\n"
-        "task(subagent_type=\"developer\", description=\"Fix Bug A\", prompt=\"...\")\n"
-        "task(subagent_type=\"developer\", description=\"Fix Bug B\", prompt=\"...\")\n"
-        "task(subagent_type=\"developer\", description=\"Fix Bug C\", prompt=\"...\")\n"
-        "# Alle drei Calls in derselben Antwort → parallele Ausführung\n"
-        "# Ergebnisse: task_results als Array [result_A, result_B, result_C]\n"
-        "```\n"
-        "\n"
-        "Limit: Kein hartes Limit. MAX_PARALLEL_AGENTS steuert die Anzahl.\n"
-    ),
-    "Gemini": (
-        "**Parallel-Pattern (konkret):**\n"
-        "Gemini Code Assist führt unabhängige Tool-Aufrufe parallel aus.\n"
-        "Delegiere an mehrere Agenten in einem einzigen Prompt — die Ausführung erfolgt automatisch parallelisiert.\n"
-    ),
-    "Continue": (
-        "**Parallel-Pattern:**\n"
-        "Continue unterstützt keine native parallele Subagent-Ausführung.\n"
-        "Führe parallele Schritte sequentiell aus oder verwende separate Continue-Sessions.\n"
-    ),
-    "Copilot": (
-        "**Parallel-Pattern:**\n"
-        "GitHub Copilot unterstützt keine native parallele Subagent-Ausführung.\n"
-        "Führe parallele Schritte sequentiell aus oder verwende separate VS Code-Sessions.\n"
-    ),
-}
-
-
 def _update_frontmatter_dict(content: str, updates: dict, removes: list = None) -> str:
     """Update YAML frontmatter fields in content using PyYAML.
 
@@ -1062,7 +1014,6 @@ def sync_agents_for_provider(
             'SNIPPETS_DIR': pc.get('snippets_dir', '.claude/snippets'),
             'PENDING_TASKS_FILE': pc.get('pending_tasks_file', '.claude/pending-tasks.md'),
             'SKILLS_DIR': pc.get('skills_dir', '.claude/skills'),
-            'PARALLEL_PATTERN': _PROVIDER_PARALLEL_PATTERNS.get(provider, _PROVIDER_PARALLEL_PATTERNS['Claude']),
         }
         merged_vars = {**variables, **provider_vars}
 
@@ -1083,14 +1034,6 @@ def sync_agents_for_provider(
         from .delegation_syntax import DelegationSyntaxEngine
         pal_engine = DelegationSyntaxEngine(config_dir=agent_meta_root / "config")
         content = pal_engine.apply(content, provider)
-
-        # Inject platform-specific orchestrator patches (Issue #250)
-        if role == "orchestrator":
-            from .config import PLATFORM_ORCHESTRATOR_PATCHES
-            patches = PLATFORM_ORCHESTRATOR_PATCHES.get(provider, [])
-            for patch in patches:
-                content = apply_patch(content, patch, log, f"{provider}-orchestrator-patch")
-                log.info(str(target_path.relative_to(project_root)), f"applied {provider} orchestrator patch")
 
         name = Path(filename).stem
         layer = source_path.parts[-2]

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -441,6 +441,9 @@ def substitute(text: str, variables: dict, source_label: str, log: SyncLog) -> s
         key = match.group(1)
         if key in variables:
             return variables[key]
+        # Skip PAL_* placeholders — they are handled by DelegationSyntaxEngine downstream
+        if key.startswith("PAL_"):
+            return match.group(0)
         log.warn(f"Variable {key} not in config — placeholder remains in: {source_label}")
         return match.group(0)
 
@@ -453,101 +456,4 @@ def substitute(text: str, variables: dict, source_label: str, log: SyncLog) -> s
     return text
 
 
-# ---------------------------------------------------------------------------
-# Platform Orchestrator Patches — provider-specific orchestrator instructions
-# injected by sync.py during agent generation (Issue #250).
-# ---------------------------------------------------------------------------
 
-PLATFORM_ORCHESTRATOR_PATCHES: dict[str, list[dict]] = {
-    "Gemini": [
-        {
-            "op": "append-after",
-            "anchor": "## Mention-Interception Policy (Pflicht)",
-            "content": (
-                "### Gemini/Antigravity-spezifische Hinweise\n"
-                "\n"
-                "**Technische Einschränkung:** Die Gemini/Antigravity UI interceptet **ausschließlich** den `@orchestrator`-Mention.\n"
-                "Alle anderen `@<agent>`-Mentions (`@git`, `@feedback`, `@meta-feedback`, `@developer`, etc.) werden als\n"
-                "reiner Text gerendert und lösen **keine** Subagent-Invocation aus.\n"
-                "\n"
-                "**Pflicht-Regeln für Gemini:**\n"
-                "1. Verwende IMMER `@orchestrator <Aufgabe>` für alle Delegationsaufrufe\n"
-                "2. Verwende NIEMALS `@git`, `@feedback`, `@developer` oder andere Agent-Mentions\n"
-                "3. Wenn der Hauptchat delegieren muss: `@orchestrator Delegiere an git: \"Commit message...\"`\n"
-                "4. Die \"Ausnahmen — direkter Dispatch\" aus use-orchestrator.md gelten in Gemini **nicht** als User-Mentions — sie sind rein interne Delegationsentscheidungen\n"
-                "\n"
-                "**Wichtiger Hinweis zur Delegation:**\n"
-                "Gemini/Antigravity unterstützt kein natives Subagent-Dispatch-Tool wie andere Umgebungen.\n"
-                "Die ausgelieferten `.gemini/agents/*.md`-Dateien werden von Antigravity **nicht** automatisch geladen.\n"
-                "Siehe Bootstrap-Instruktionen in `GEMINI.md` für die Session-Start-Registrierung.\n"
-                "\n"
-                "**Beispiel — Falsch (funktioniert nicht in Gemini):**\n"
-                "> \"@meta-feedback Bitte erstelle ein Issue für...\"\n"
-                "\n"
-                "**Beispiel — Richtig:**\n"
-                "> \"@orchestrator Delegiere an meta-feedback: Erstelle ein Issue für...\""
-            ),
-        },
-        {
-            "op": "append",
-            "content": (
-                "## Gemini/Antigravity — SE-Cascade Workaround\n"
-                "\n"
-                "Gemini unterstützt kein natives Subagent-Dispatch-Tool. "
-                "Für SE-Cascades verwende `scripts/run-cascade.py`:\n"
-                "1. `python scripts/run-cascade.py --input \"<Stakeholder Need>\"`\n"
-                "2. Prompt-Dateien aus `.se-cascade/<session>/prompts/` in Gemini einfügen\n"
-                "3. Ergebnisse in `.se-cascade/<session>/` speichern\n"
-                "4. `--resume <session-id>` für Fortsetzung nach Unterbrechung\n"
-                "\n"
-                "Dokumentation: `howto/SE_CASCADE_GEMINI.md`\n"
-            ),
-        },
-    ],
-    "Continue": [
-        {
-            "op": "append-after",
-            "anchor": "## Mention-Interception Policy (Pflicht)",
-            "content": (
-                "### Continue-spezifische Delegation\n"
-                "\n"
-                "Continue unterstützt **kein** natives Subagent-Dispatch-Tool.\n"
-                "Delegation erfolgt ausschließlich über `@agent`-Text-Mentions:\n"
-                "\n"
-                "**Syntax:**\n"
-                "- `@developer Implementiere Feature X`\n"
-                "- `@git Commit und push`\n"
-                "- `@code-reviewer Prüfe die Änderungen`\n"
-                "\n"
-                "**Einschränkungen:**\n"
-                "- Keine parallele Subagent-Ausführung — Aufgaben sequentiell abarbeiten\n"
-                "- Agent-Dateien müssen in `.continue/prompts/` liegen\n"
-                "- Der `@orchestrator`-Mention wird von Continue unterstützt\n"
-                "\n"
-                "**Pflicht-Regeln für Continue:**\n"
-                "1. Verwende `@agent <Aufgabe>` für alle Delegationen\n"
-                "2. Keine parallelen Delegationen — sequentiell abarbeiten\n"
-                "3. Prüfe nach jeder Delegation das Ergebnis vor der nächsten\n"
-            ),
-        },
-    ],
-    "Copilot": [
-        {
-            "op": "append-after",
-            "anchor": "## Mention-Interception Policy (Pflicht)",
-            "content": (
-                "### Copilot-spezifische Delegation\n"
-                "\n"
-                "Copilot verwendet `@agent`-Text-Mentions für Agenten-Dispatch:\n"
-                "\n"
-                "**Syntax:**\n"
-                "- `@developer Implementiere Feature X`\n"
-                "- `@git Commit und push`\n"
-                "\n"
-                "**Einschränkungen:**\n"
-                "- Keine parallele Subagent-Ausführung — sequentiell\n"
-                "- Agenten werden aus `.github/copilot/agents/` geladen\n"
-            ),
-        },
-    ],
-}

--- a/scripts/lib/context.py
+++ b/scripts/lib/context.py
@@ -792,7 +792,7 @@ def sync_prompts_for_continue(
     """
     from .agents import (collect_sources, extract_frontmatter_field, compose_agent,
                           target_filename, _strip_frontmatter, _strip_claude_specific_lines,
-                          _make_slim_body, AGENTS_DIR, _PROVIDER_PARALLEL_PATTERNS)
+                          _make_slim_body, AGENTS_DIR)
     from .config import substitute, strip_inactive_conditional_blocks
     from .providers import resolve_provider_options
     from .roles import build_role_map
@@ -807,7 +807,6 @@ def sync_prompts_for_continue(
         'SNIPPETS_DIR': pc.get('snippets_dir', '.continue/snippets'),
         'PENDING_TASKS_FILE': pc.get('pending_tasks_file', '.continue/pending-tasks.md'),
         'SKILLS_DIR': pc.get('skills_dir', '.continue/skills'),
-        'PARALLEL_PATTERN': _PROVIDER_PARALLEL_PATTERNS.get("Continue", _PROVIDER_PARALLEL_PATTERNS["Claude"]),
     }
     merged_vars = {**variables, **provider_vars}
 
@@ -843,6 +842,11 @@ def sync_prompts_for_continue(
         rel_source = str(source_path.relative_to(agent_meta_root))
         content = substitute(content, merged_vars, rel_source, log)
         content = strip_inactive_conditional_blocks(content, merged_vars)
+
+        # Apply PAL delegation syntax for Continue prompts
+        from .delegation_syntax import DelegationSyntaxEngine
+        pal_engine = DelegationSyntaxEngine(config_dir=agent_meta_root / "config")
+        content = pal_engine.apply(content, "Continue")
 
         template_description = extract_frontmatter_field(content, "description") or f"Agent for {role}."
         template_description = template_description.replace("{{PROJECT_NAME}}", config["project"]["name"])

--- a/scripts/lib/delegation_syntax.py
+++ b/scripts/lib/delegation_syntax.py
@@ -29,6 +29,7 @@ class DelegationSyntaxEngine:
         "PAL_PARALLEL_GROUP": "parallel_group",
         "PAL_FALLBACK": "fallback",
         "PAL_TOOL_PREAMBLE": "tool_preamble",
+        "PAL_PARALLEL_PATTERN": "parallel_pattern",
     }
 
     def __init__(self, config_dir: Path | None = None) -> None:


### PR DESCRIPTION
Complete PAL (Provider Abstraction Layer) wiring: moved all provider-specific delegation syntax from hardcoded Python into abstract `{{PAL_*}}` template placeholders.

**Changes:**
- Removed `_PROVIDER_PARALLEL_PATTERNS` (agents.py, ~45 lines) and `PLATFORM_ORCHESTRATOR_PATCHES` (config.py, ~97 lines) — now in `config/delegation-syntax.yaml`
- Added `{{PAL_DELEGATE}}`, `{{PAL_FALLBACK}}`, `{{PAL_PARALLEL_PATTERN}}`, `{{#if PAL_TOOL_PREAMBLE}}` to orchestrator template
- Single source of truth: `config/delegation-syntax.yaml` for all 5 providers (Claude, Opencode, Gemini, Continue, Copilot)
- Dry-run: 373 actions, 0 PAL errors, no regressions