### PR TITLE
fix: Gemini bugs — orchestrator tools, PAL warnings, settings.json, docs

### DIFF
--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,9 +1,10 @@
 ---
 name: template-orchestrator
-version: "3.17.0"
+version: "3.18.0"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
+  - Bash
   - TodoWrite
   - Agent
 ---

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -51,8 +51,7 @@ providers:
     context_template: howto/configs/GEMINI.project-template.md
     has_rules: true
     rules_dir: .gemini/rules
-    has_hooks: true
-    hooks_dir: .gemini/hooks
+    has_hooks: false
     has_commands: true
     commands_dir: .gemini/commands
     commands_ext: .toml

--- a/config/provider-tools.yaml
+++ b/config/provider-tools.yaml
@@ -49,7 +49,6 @@ gemini:
   # === UNSUPPORTED TOOLS (explicitly documented for clarity) ===
   # The following tools are NOT supported by Gemini and will be filtered/ignored during sync:
   # - Agent              # Gemini has no subagent dispatch
-  # - TodoWrite          # Gemini has no todo/task list feature
   # - Task               # Gemini has no task orchestration
   # - mcp__*             # Gemini MCP support varies by version
 

--- a/docs/issues/provider-gemini-missing-rules.md
+++ b/docs/issues/provider-gemini-missing-rules.md
@@ -1,7 +1,13 @@
 ---
 title: "[provider] Gemini skips 5 rules, reducing agent context significantly"
 labels: [provider, Gemini, P1]
+status: resolved
+resolved-in: "Removed all `gemini: skip` entries from `minimal` and `silent` presets. Closes #71, #80."
 ---
+
+> **RESOLVED** — All `gemini: skip` entries have been removed from `config/rules-presets.yaml`.
+> Gemini now gets all rules like Claude. Rules are generated into `.gemini/rules/`.
+> See `CHANGELOG.md` for details.
 
 ## Summary
 The Gemini rules-preset skips 5 important rules: `dod-criteria`, `issue-lifecycle`, `lifecycle-tasks`, `use-orchestrator`, `sync-interface`. This means Gemini agents operate with significantly less context than Claude agents.
@@ -36,9 +42,9 @@ Either:
 3. **Create Gemini-specific rule variants** without `alwaysApply`
 
 ## Acceptance Criteria
-- [ ] All 5 rules are available to Gemini agents in some form
-- [ ] `GEMINI.md` includes full rule context
-- [ ] `sync.log` shows no `[SKIP] (rules-preset: gemini: skip)` for these rules
+- [x] All 5 rules are available to Gemini agents in some form
+- [x] `GEMINI.md` includes full rule context
+- [x] `sync.log` shows no `[SKIP] (rules-preset: gemini: skip)` for these rules
 
 ## Related
 - `docs/reviews/framework-provider-review-2026-05-07.md` — Finding #8

--- a/docs/providers/gemini-cli.md
+++ b/docs/providers/gemini-cli.md
@@ -49,7 +49,7 @@ Unterstützt `@./path/file.md` für Modularisierung.
 | Kontext-Datei | `CLAUDE.md` | `GEMINI.md` |
 | Config-Verzeichnis | `.claude/` | `.gemini/` |
 | Sub-Agenten | `.claude/agents/*.md` | `.gemini/agents/*.md` |
-| Rules (auto-load) | `.claude/rules/` | **Nicht vorhanden** (alles in GEMINI.md) |
+| Rules (auto-load) | `.claude/rules/` | `.gemini/rules/` |
 | Slash-Commands | `.claude/commands/*.md` | `.gemini/commands/*.toml` |
 | Hooks | `.claude/hooks/*.sh` + `settings.json` | `.gemini/hooks/*.sh` + `settings.json` |
 | Frontmatter: model | `model:` | `model:` |
@@ -83,11 +83,10 @@ Entfernt im Vergleich zu Claude: `memory`, `permissionMode`.
 
 ## Rules
 
-Gemini CLI hat **kein `.gemini/rules/`-Verzeichnis**. Regeln werden direkt in
-`GEMINI.md` eingebettet. agent-meta generiert deshalb:
+Gemini CLI unterstützt `.gemini/rules/` für Rule-Dateien. agent-meta generiert:
 
-- Keine separaten Rule-Dateien für Gemini
-- `has_rules: false` in `config/ai-providers.yaml`
+- Rule-Dateien in `.gemini/rules/`
+- `has_rules: true` in `config/ai-providers.yaml`
 
 **Workaround:** Wichtige Regeln als eigene `@./`-Referenzen in GEMINI.md einbinden:
 
@@ -191,13 +190,13 @@ model-overrides:
 | `.gemini/settings.json` | ❌ Einmalig angelegt (Skeleton) |
 | `.gemini/commands/*.toml` | ✅ Aus `commands/` transformiert, stale gelöscht |
 | `.gemini/hooks/*.sh` | ✅ Kopiert, stale gelöscht |
-| Rules | ❌ Nicht vorhanden (kein `.gemini/rules/`) |
+| Rules | ✅ Generiert in `.gemini/rules/`, stale gelöscht |
 
 ---
 
 ## Bekannte Einschränkungen
 
-1. **Kein Rules-System** — Regeln nur über GEMINI.md einbindbar
+1. **Rules werden wie bei Claude generiert** — `.gemini/rules/` wird von sync.py befüllt
 2. **Kein persistentes Agenten-Gedächtnis** — `memory:`-Feld wird entfernt
 3. **Kein permissionMode** — Berechtigungen über Google-Account gesteuert
 4. **Sub-Agenten inoffiziell** — Gemini kennt `.gemini/agents/` nicht nativ; die Dateien sind für zukünftige Kompatibilität vorbereitet

--- a/howto/configs/GEMINI.project-template.md
+++ b/howto/configs/GEMINI.project-template.md
@@ -14,7 +14,7 @@ DoD-Preset: **{{DOD_PRESET}}** | REQ-Traceability: {{DOD_REQ_TRACEABILITY}} | Te
 
 ## Agents
 
-Agent files are in `.gemini/agents/`. Use them with `@agent-name` in Gemini CLI.
+Agent files are in `.gemini/agents/`. Agents must be registered at session start via the bootstrap instructions above. `@agent` text mentions are not intercepted by Gemini.
 
 ## Project Setup
 

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -439,6 +439,10 @@ def substitute(text: str, variables: dict, source_label: str, log: SyncLog) -> s
     # Second pass: substitute real {{VAR}} placeholders
     def replacer(match):
         key = match.group(1)
+        # PAL_* placeholders are handled by the delegation syntax engine,
+        # not by general substitution — skip silently.
+        if key.startswith("PAL_"):
+            return match.group(0)
         if key in variables:
             return variables[key]
         log.warn(f"Variable {key} not in config — placeholder remains in: {source_label}")

--- a/scripts/lib/context.py
+++ b/scripts/lib/context.py
@@ -153,6 +153,38 @@ def sync_context_for_provider(
                 else:
                     log.skip(str(target_path.relative_to(project_root)), "managed block unchanged")
 
+        # .gemini/settings.json — skeleton created once, never overwritten
+        settings_file = pc.get("settings_file")
+        if settings_file:
+            settings_path = safe_path(project_root, settings_file)
+            if settings_path.exists():
+                log.skip(str(settings_path.relative_to(project_root)),
+                         "already exists — not overwritten")
+            else:
+                settings_template_rel = pc.get("settings_template")
+                settings_template_path = (
+                    agent_meta_root / settings_template_rel if settings_template_rel else None
+                )
+                if settings_template_path and settings_template_path.exists():
+                    json_content = settings_template_path.read_text(encoding="utf-8")
+                    source_label = settings_template_rel
+                else:
+                    json_content = (
+                        '{\n'
+                        '  "//": "Gemini settings — https://ai.google.dev/gemini-api/docs"\n'
+                        '}\n'
+                    )
+                    source_label = "minimal fallback"
+                    if settings_template_rel:
+                        log.warn(
+                            f"{settings_template_rel} not found "
+                            f"— using minimal fallback for {settings_file}"
+                        )
+                log.action("INIT", str(settings_path.relative_to(project_root)), source_label)
+                if not dry_run:
+                    settings_path.parent.mkdir(parents=True, exist_ok=True)
+                    settings_path.write_text(json_content, encoding="utf-8")
+
     elif provider == "Opencode":
         context_file = pc["context_file"]  # "AGENTS.md"
         target_path = safe_path(project_root, context_file)


### PR DESCRIPTION
## Gemini Bug Fixes

### Commit 1 — Orchestrator & Sync Cleanup
- **orchestrator had zero tools in Gemini** — added `Bash` to generic template (`1-generic/orchestrator.md` v3.17.0 → v3.18.0), maps to `code_execution`. Before: only `TodoWrite` + `Agent`, both filtered.
- **12 PAL_FANOUT/PAL_PARALLEL_GROUP warnings per sync** — `substitute()` now skips `PAL_`-prefixed placeholders (handled by delegation engine later)
- **Contradictory TodoWrite comment** — removed duplicate from `provider-tools.yaml`
- **gemini-cli.md outdated** — updated Rules section (has_rules is true, .gemini/rules/ exists)
- **provider-gemini-missing-rules.md** — archived as resolved

### Commit 2 — Settings & Config
- **`.gemini/settings.json` never initialized** — added init from `GEMINI.settings-template.json` on first sync (was dead code)
- **Conflicting hooks config** — `ai-providers.yaml`: `has_hooks: false` for Gemini (was true, contradicted `provider-capabilities.yaml`)
- **Wrong template instruction** — `GEMINI.project-template.md` said `@agent-name` works (it doesn't in Gemini; agents need `define_subagent` bootstrap)

### Verification
`sync.py --dry-run` passes with no regressions, 0 PAL warnings, hooks correctly skipped for Gemini.

Related: #271, #277, #209