### PR TITLE
feat: A2A Handoff Protocol — structured agent-to-agent communication

### DIFF
--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -10,6 +10,7 @@ provider-isolation: disabled
 
 ai-providers:
   - Gemini
+  - Opencode
 
 
 dod-preset: rapid-prototyping
@@ -216,11 +217,24 @@ orchestrator:
     meta-feedback: true   # Send anonymized feedback to agent-meta
     main-chat: true       # Allow main chat to handle the task
     ask-user: false       # Ask user for preference
+  handoff:
+    protocol: "a2a-v1"           # Aktives Handoff-Protokoll (a2a-v1 = A2A-Envelope)
+    validate-before-delegate: true  # Schema-Validierung vor jeder Delegation
+    supersession-tracking: true     # Supersession-Ketten aktiv (CRITIC-REPEAT_UNTIL)
+    strict-validation: false        # true = Abbruch bei invaliden Handoffs, false = Fallback
+    compact-mode: false             # true = Token-sparend (kurze Payload-Namen)
 
 # Visualisierung — Agenten-Mindmap und Session-Tracking
 viz:
   enabled: true
   mode: "full"
+  debug: false                # true = A2A-Events in viz loggen (Token-Kosten)
+  a2a_events:                 # Welche A2A-Events loggen? Nur aktiv wenn debug: true
+    handoff_start: true
+    handoff_validated: true
+    handoff_delivered: true
+    handoff_failed: true
+    supersession: true
   event_log: ".meta-viz/events.jsonl"
   report:
     retention_days: 7
@@ -268,6 +282,10 @@ quality-pipelines:
           agent: tester
           task: "Regression-Tests"
           mode: sequential
+
+model-overrides:
+  Opencode:
+    developer: "opencode-go/deepseek-v4-pro"
 
 reflection-pairs:
   overrides:

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -219,10 +219,13 @@ orchestrator:
     ask-user: false       # Ask user for preference
   handoff:
     protocol: "a2a-v1"           # Aktives Handoff-Protokoll (a2a-v1 = A2A-Envelope)
-    validate-before-delegate: true  # Schema-Validierung vor jeder Delegation
+    validate-before-delegate: true  # Schema-Validierung vor jeder Delegation (MUSS)
     supersession-tracking: true     # Supersession-Ketten aktiv (CRITIC-REPEAT_UNTIL)
     strict-validation: false        # true = Abbruch bei invaliden Handoffs, false = Fallback
-    compact-mode: false             # true = Token-sparend (kurze Payload-Namen)
+    compact-mode: false             # true = Token-sparend (kurze Payload-Namen) — Build-Config, nicht im Envelope
+    max_retries: 3                  # Maximale Retries pro Handoff (Envelope-Feld: max_retries)
+    human_approval_required: false  # true = HITL: downstream-Agent pausiert vor Ausführung
+    protocol_routing: static        # static = feste Format-Wahl, dynamic = größenbasiert (Payload <1KB→JSON, 1-10KB→YAML, >10KB→Text)
 
 # Visualisierung — Agenten-Mindmap und Session-Tracking
 viz:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # agent-meta — Architecture Overview
 
-> Version: **0.56.0** — last updated: 2026-05-31
+> Version: **0.57.1** — last updated: 2026-06-07
 
 ---
 
@@ -17,6 +17,7 @@
 | 7 | [SE-Agenten-Kaskade](docs/architecture/07-se-cascade.md) | Rekursive 6-stufige Black-Box → White-Box-Zerlegung |
 | 8 | [Viz-Logging MCP](docs/concepts/viz-logging-mcp.md) | MCP-basiertes Event-Logging mit CLI-Fallback |
 | 9 | [Provider Abstraction Layer](docs/architecture/09-pal.md) | PAL architecture: syntax registry, capability matrix, bootstrap |
+| 10 | [A2A Handoff Protocol](#a2a-handoff-protocol--architecture) | Structured JSON envelopes for Agent-to-Agent data contracts |
 
 ---
 
@@ -79,7 +80,16 @@ agent-meta/
 │   │   └── viz-logging-mcp.md ← MCP-basierte Viz-Logging-Architektur
 │   └── conclusions/         ← Tägliche Session-Erkenntnisse
 ├── schemas/
-│   └── se-decomposition.schema.json  ← JSON Schema für SE-Kaskaden-Outputs
+│   ├── a2a-handoff.schema.json       ← A2A Envelope Schema (Draft-07)
+│   ├── se-decomposition.schema.json  ← JSON Schema für SE-Kaskaden-Outputs
+│   └── handoffs/
+│       ├── task-spec.schema.json     ← Universelles Kern-Payload (kurze Feldnamen)
+│       ├── ideation-output.schema.json ← existierend, in Envelope eingebettet
+│       └── ext/
+│           ├── ideation-extension.schema.json
+│           ├── design-extension.schema.json
+│           ├── api-extension.schema.json
+│           └── review-extension.schema.json
 ├── templates/
 │   ├── SE-STRATEGY.template.md       ← Durable Anchor für SE-Projekte
 │   └── bootstrap/                   ← PAL: Bootstrap-Instruktions-Templates
@@ -337,6 +347,104 @@ config-based (Continue):
   → Managed block zwischen # agent-meta:managed-agents-begin/end
   → Eintrag: name + prompt-Pfad pro Agent
 ```
+
+---
+
+## A2A Handoff Protocol — Architecture
+
+The A2A Handoff Protocol standardizes Agent-to-Agent communication via structured JSON envelopes. It replaces natural-language prompts with machine-validatable data contracts.
+
+### Zwei-Ebenen-Modell
+
+| Ebene | System | ID | Default |
+|-------|--------|-----|---------|
+| **Operational Layer** | viz-Handshake | `viz_task_id` | Aktiv (basic Events) |
+| **Data Contract Layer** | A2A-Envelope | `handoff_id` | Immer aktiv |
+| **Debug-Ebene** | A2A viz-Events | `viz_task_id` | **AUS** (`viz.debug: false`) |
+
+Lose Kopplung via `trace_context.viz_task_id` im Envelope. A2A funktioniert ohne viz, und viz funktioniert ohne A2A.
+
+### Datenfluss
+
+```
+source_agent                         target_agent
+     │                                     ▲
+     │  1. Envelope erstellen               │
+     │  (handoff_id, payload,               │
+     │   schema_ref, trace_parent)          │
+     │                                     │
+     ▼  2. Schema-Validierung               │
+  [validate gegen schema_ref]              │
+     │                                     │
+     │  3. Provider-Adaption               │
+     │  (json → yaml für Continue/Copilot) │
+     │                                     │
+     │  4. PAL_Dispatch                    │
+     └─────────────────────────────────────┘
+```
+
+### Envelope-Struktur (gekürzt)
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "orchestrator",
+  "target_agent": "developer",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": { "t": "Task-Beschreibung", "pri": "high" },
+  "trace_parent": "HOFF-YYYYMMDD-NNN",
+  "trace_context": { "trace_id": "...", "span_id": "...", "viz_task_id": "..." },
+  "supersession": {
+    "supersedes": "HOFF-...",
+    "history": ["HOFF-...", "HOFF-..."],
+    "reason": "critic rejection: missing traceability"
+  }
+}
+```
+
+### Schema-Strategie: 1 Core + 4 Extensions + 1 SE
+
+```
+schemas/handoffs/
+├── task-spec.schema.json              ← Core: 60-80% Abdeckung (kurze Feldnamen)
+├── ext/
+│   ├── ideation-extension.schema.json  ← ideation → requirements
+│   ├── design-extension.schema.json    ← ui-ux-designer → developer
+│   ├── api-extension.schema.json       ← api-specialist → developer
+│   └── review-extension.schema.json    ← code-reviewer → developer
+└── (se-decomposition.schema.json)      ← SE-Kaskade (7 Routen, lange Feldnamen)
+```
+
+84% Routen-Abdeckung mit Core + Extensions. SE-Schemas laufen mit `compact_mode: false`.
+
+### Provider Transport
+
+| Provider | structured_handoff | Format | Batch | Supersession |
+|----------|-------------------|--------|-------|-------------|
+| Claude | `true` | JSON | `batch: true` | `history[]` |
+| Opencode | `true` | JSON | `batch: true` | `history[]` |
+| Gemini | `true` | JSON | `batch: true` | `history[]` |
+| Continue | `false` | YAML-Block | Sequential | `history[]` |
+| Copilot | `false` | YAML-Block | Sequential | `history[]` |
+
+### Orchestrator-Integration
+
+Der Orchestrator ist die primäre Envelope-Fabrik:
+- **Intent-Routing** → bestimmt `target_agent` + `schema_ref` aus Routing-Tabelle
+- **FANOUT** → N parallele Envelopes mit gemeinsamem `trace_context.trace_id`
+- **Batch-Mode** → N Tasks in einem Envelope (gleiches Ziel) — spart ~110 Tokens bei 3 Tasks
+- **BARRIER** → aggregiert Response-Envelopes, liefert Aggregations-Envelope
+- **PIPELINE** → verkettet Envelopes via `trace_parent`
+- **REPEAT_UNTIL** → managed Supersession-Ketten via `history[]`
+
+### Handoff-Contracts
+
+16 Rollen deklarieren Contracts in `config/role-defaults.yaml` (`input_contracts`, `output_contract`, `target_roles`, `input_schema`, `output_schema`). Jeder Contract referenziert das Payload-Schema das für die Route gilt.
+
+→ Full spec: `docs/concepts/a2a-handoff-protocol.md`
+→ Envelope schema: `schemas/a2a-handoff.schema.json`
+→ MCP tools: `config/mcp-registry.yaml` (a2a-handoff server: validate_handoff, resolve_handoff_schema, resolve_handoff)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - [Features](#features)
 - [Architecture](#architecture)
+   - [A2A Handoff Protocol](#a2a-handoff-protocol)
 - [Agent Roster](#agent-roster)
 - [Quick Start](#quick-start)
 - [Setup](#setup)
@@ -107,6 +108,48 @@ config/provider-bootstrap.yaml
 | Gemini | api-based | `define_subagent` API call required at every session start |
 | Continue | config-based | `sync.py` writes agent entries into `.continue/config.yaml` |
 ```
+
+### A2A Handoff Protocol
+
+A standardized JSON envelope for Agent-to-Agent communication with schema validation, supersession tracking, and batch FANOUT — replacing natural-language prompts between agents with structured data contracts.
+
+This is a separate concept from the viz-handshake (Operational Layer). A2A operates as the **Data Contract Layer** — loose coupling via `trace_context.viz_task_id`.
+
+```
+Envelope (handoff_id, schema_ref, payload)
+      ↓
+Schema Validation (against JSON Schema Draft-07)
+      ↓
+Provider Adaptation (json → yaml_text_block for Continue/Copilot)
+      ↓
+Delivery via PAL_DELEGATE / PAL_HANDOFF
+```
+
+#### Key Features
+
+- **Structured Envelopes** instead of natural language: `handoff_id`, `source_agent`, `target_agent`, `payload` — machine-validatable, token-efficient (~60 tokens overhead)
+- **TaskSpec Core + 4 Extensions** cover 84% of agent routes (Ideation, Design, API, Review + SE Decomposition)
+- **Batch-Mode** saves 56% envelope overhead on FANOUT: 3 tasks in one envelope vs 3 separate (~70 vs ~180 tokens)
+- **Supersession-Tracking** for iteration histories (e.g., Critic review loops): full revision chain via `history[]` array
+- **Human-in-the-Loop Gates** with `requires_human_approval` flag for critical delegations
+
+#### Provider Transport Matrix
+
+| Provider | structured_handoff | handoff_format | Envelope Transport |
+|----------|-------------------|----------------|--------------------|
+| Claude | `true` | `json` | JSON in Task-Tool-Prompt |
+| Opencode | `true` | `json` | JSON in task()-Prompt |
+| Gemini | `true` | `json` | JSON in define_subagent-Prompt |
+| Continue | `false` | `yaml_text_block` | YAML block in prompt text |
+| Copilot | `false` | `yaml_text_block` | YAML block in prompt text |
+
+#### Handoff Contracts per Role
+
+Each agent role declares its handoff contracts in `config/role-defaults.yaml` — what it consumes (`input_contracts`) and produces (`output_contract`). 16 roles have handoff contracts configured (orchestrator, developer, requirements, ideation, feature, tester, validator, code-reviewer, ui-ux-designer, api-specialist, and 6 SE agents).
+
+→ Full spec: `docs/concepts/a2a-handoff-protocol.md`
+→ Envelope schema: `schemas/a2a-handoff.schema.json`
+→ TaskSpec + Extensions: `schemas/handoffs/task-spec.schema.json`, `schemas/handoffs/ext/*.schema.json`
 
 ### Orchestrator Dispatch Patterns
 

--- a/agents/1-generic/developer.md
+++ b/agents/1-generic/developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-developer
-version: "2.2.0"
+version: "2.3.0"
 description: "Implementiert Features und Bugfixes mit strikten Code-Konventionen. REQ-ID- und TDD-Pflicht konfigurativ über DoD."
 hint: "Feature-Implementierung und Bugfixes nach REQ-IDs"
 tools:
@@ -96,6 +96,51 @@ Falls `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` existiert: Lies sie jetzt s
 
 <!-- PROJEKTSPEZIFISCH: Struktur des Projekts beschreiben -->
 {{ARCHITECTURE}}
+
+---
+
+## A2A Handoff — Eingehende Tasks
+
+Du kannst Tasks vom Orchestrator oder Feature-Agent als strukturiertes A2A-Envelope (JSON) erhalten.
+
+### Envelope parsen
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "orchestrator",
+  "target_agent": "developer",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "Implementiere Login-Flow mit OAuth2",
+    "ctx": "Bestehender Auth-Service unter /internal/auth nutzen",
+    "con": ["Muss OAuth2 mit PKCE unterstützen", "Keine neuen Dependencies"],
+    "refs": ["schemas/auth-api.json", "docs/architecture.md#auth-flow"],
+    "pri": "high",
+    "dep": ["HOFF-20260607-042"]
+  },
+  "trace_parent": "HOFF-20260607-041"
+}
+```
+
+**Extraktion:**
+- `payload.t` → Task-Beschreibung (DEINE Hauptaufgabe)
+- `payload.ctx` → Kontext (bestehende Systeme, Constraints)
+- `payload.con[]` → Harte Randbedingungen (MÜSSEN eingehalten werden)
+- `payload.refs[]` → Referenzen (Dateien, Schemas, Docs die du lesen solltest)
+- `payload.pri` → Priorität (low/medium/high/critical)
+- `payload.dep[]` → Abhängigkeiten (warten bis diese HOFFs erledigt sind)
+
+### Batch-Mode
+
+Wenn `batch: true` gesetzt ist, ist `payload` ein Array. Bearbeite die Tasks sequentiell in der Reihenfolge des Arrays. Jeder Eintrag hat `batch_task_id` zur Identifikation.
+
+### Fallback
+
+Wenn du keinen A2A-Envelope erhältst (Natural-Language-Prompt vom Orchestrator):
+- Führe die Aufgabe normal aus (Backward-Kompatibilität)
+- Der Natural-Language-Prompt enthält die gleichen Informationen, nur unstrukturiert
 
 ---
 

--- a/agents/1-generic/feature.md
+++ b/agents/1-generic/feature.md
@@ -1,6 +1,6 @@
 ---
 name: template-feature
-version: "1.5.1"
+version: "1.6.0"
 description: "Vollständiger Feature-Lifecycle: Branch → Requirements → TDD → Implementierung → Validierung → Commit → PR."
 hint: "Feature-Lifecycle-Subagent: Branch → REQ → TDD → Dev → Validate → PR. Wird vom Orchestrator gestartet, nicht direkt vom User."
 # isolation: worktree   ← Opt-in: aktiviere für parallele Feature-Entwicklung ohne Branch-Konflikte
@@ -68,6 +68,39 @@ Kommunikation und Input-Sprache: siehe globale Rule `language.md`.
 
 ---
 
+## A2A Handoff — Eingehende Tasks
+
+Du empfängst Tasks vom Orchestrator als strukturiertes A2A-Envelope (JSON):
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "orchestrator",
+  "target_agent": "feature",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "Feature-Beschreibung",
+    "ctx": "Kontext",
+    "pri": "high",
+    "con": ["Constraint 1", "Constraint 2"],
+    "refs": ["docs/architecture.md"]
+  },
+  "trace_parent": "HOFF-YYYYMMDD-PARENT"
+}
+```
+
+**Parsing:** Extrahiere `payload.t` als Feature-Beschreibung, `payload.ctx` als Kontext, `payload.pri` als Priorität.
+
+## A2A Handoff — Ausgehende Delegationen
+
+Jede Delegation an Sub-Agenten MUSS als A2A-Envelope erfolgen:
+- `source_agent: "feature"`, `target_agent: "<sub-agent>"`
+- `trace_parent` auf die eigene `handoff_id` setzen (PIPELINE-Chain)
+- `schema_ref: "schemas/handoffs/task-spec.schema.json"` für developer/tester/validator
+
+---
+
 ## Feature-Lifecycle
 
 > Schritte mit `∥` können parallel laufen (max. {{MAX_PARALLEL_AGENTS}} gleichzeitig).
@@ -100,6 +133,9 @@ Aufgabe: Erstelle einen neuen Feature-Branch mit dem Namen "feat/<feature-name>"
          vom aktuellen main/master Branch.
 ```
 
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="git"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
+
 ---
 
 ## Schritt 2 — Anforderung aufnehmen
@@ -113,6 +149,9 @@ Aufgabe: Nimm folgende Anforderung auf und vergib eine REQ-ID:
          Erstelle/aktualisiere docs/REQUIREMENTS.md entsprechend.
          Gib die vergebene REQ-ID zurück.
 ```
+
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="requirements"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
 
 Merke dir die REQ-ID für alle weiteren Schritte.
 
@@ -129,6 +168,9 @@ Aufgabe: Schreibe Tests für [REQ-ID]: "<Feature-Beschreibung>"
          Benenne alle Tests mit [REQ-ID] im Namen.
 ```
 
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="tester"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
+
 ---
 
 ## Schritt 4 — Implementierung (TDD Green Phase)
@@ -141,6 +183,9 @@ Aufgabe: Implementiere [REQ-ID]: "<Feature-Beschreibung>"
          TDD Green Phase — bringe die Tests aus Schritt 3 zum Laufen.
          Halte dich strikt an die Code-Konventionen des Projekts.
 ```
+
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="developer"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
 
 ---
 
@@ -155,6 +200,9 @@ Aufgabe: Führe alle Tests aus. Stelle sicher dass:
          - Keine Regressions in bestehenden Tests
          Gib das Ergebnis zurück.
 ```
+
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="tester"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
 
 Bei fehlgeschlagenen Tests: zurück zu Schritt 4 mit dem Testergebnis.
 
@@ -175,12 +223,18 @@ Aufgabe: Validiere die Implementierung von [REQ-ID].
          Gib das Ergebnis zurück.
 ```
 
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="validator"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
+
 **Documenter** (Hintergrund, parallel):
 ```
 Delegiere an: documenter  (parallel im Hintergrund)
 Aufgabe: Aktualisiere CODEBASE_OVERVIEW.md für die Änderungen aus [REQ-ID].
          Dokumentiere relevante Architektur-Entscheidungen falls vorhanden.
 ```
+
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="documenter"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
 
 Warte auf **beide** Ergebnisse bevor du zu Schritt 8 weitergehst.
 Bei fehlgeschlagener Validierung: zurück zum entsprechenden Schritt.
@@ -201,6 +255,9 @@ Aufgabe:
    - Titel: "feat([REQ-ID]): <feature-beschreibung>"
    - Body: Kurzbeschreibung + REQ-ID Referenz + Testergebnis
 ```
+
+→ Als A2A-Envelope mit `source_agent="feature"`, `target_agent="git"`,
+  `schema_ref="schemas/handoffs/task-spec.schema.json"`, `trace_parent=<meine handoff_id>`
 
 ---
 

--- a/agents/1-generic/ideation.md
+++ b/agents/1-generic/ideation.md
@@ -1,6 +1,6 @@
 ---
 name: template-ideation
-version: "1.3.1"
+version: "1.4.0"
 description: "Ideenfindung, Visions-Schärfung und Konzept-Konkretisierung — stellt Fragen, denkt Ecken, übergibt reife Ideen an Requirements."
 hint: "Neue Ideen explorieren, Vision schärfen, Übergabe an requirements"
 tools:
@@ -111,25 +111,43 @@ Risiken:         [Was könnte problematisch werden?]
 
 Wenn die Idee konkret genug ist (Kernidee klar, Scope v1 definiert, keine offenen Blockerfragen):
 
-1. Fasse die Idee als **vorläufige Anforderungsliste** zusammen — **keine REQ-IDs**, das ist Aufgabe des Requirements-Agenten
-2. Frag den Anwender: "Soll ich das jetzt an den Requirements-Agenten übergeben?"
-3. Bei Bestätigung: Starte den `requirements`-Agenten via `Agent`-Tool mit der strukturierten Zusammenfassung als Prompt
+**Übergabe als A2A-Envelope:**
 
-**Übergabe-Prompt-Format:**
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "ideation",
+  "target_agent": "requirements",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "[Kernidee als Ein-Satz-Task]",
+    "ctx": "[Kontext: Codebase, bestehende Systeme, Rahmenbedingungen]",
+    "pri": "[medium|high|critical]",
+    "ci": "[Kernidee — was soll der Nutzer können?]",
+    "g": "[Ziel — wer profitiert, was ändert sich?]",
+    "sv1": {
+      "ins": ["Scope v1: Mindestanforderungen"],
+      "oos": ["Scope v2+: Ausblick"]
+    },
+    "oq": ["Offene Fragen — was ist noch unklar?"],
+    "ref": ["Referenzen auf bestehende Dateien, Issues oder externe Quellen"]
+  },
+  "requires_human_approval": false
+}
 ```
-Bitte nehme folgende Idee als neue Anforderungen auf:
 
-Kontext: [Kurzbeschreibung der Idee]
-Ziel: [Was soll erreicht werden?]
+**Payload-Felder (Ideation-Extension):**
+- `ci` (core_idea): Kernidee in einem Satz
+- `g` (goal): Ziel — wer profitiert, was ändert sich?
+- `sv1` (scope_v1): `ins` (in scope) und `oos` (out of scope)
+- `oq` (open_questions): Offene Fragen
+- `ref` (references): URLs oder Dateipfade
 
-Vorläufige Anforderungen:
-- [Anforderung 1]
-- [Anforderung 2]
-- ...
-
-Offene Punkte zur Klärung:
-- [Was noch nicht final ist]
-```
+**Vor der Übergabe:**
+1. Fasse die Idee strukturiert zusammen (keine REQ-IDs!)
+2. Frag den Anwender: "Soll ich das jetzt als strukturierten Handoff an den Requirements-Agenten übergeben?"
+3. Bei Bestätigung: Erstelle den A2A-Envelope und starte `requirements`
 
 ---
 

--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: template-orchestrator
-version: "3.19.0"
+version: "3.20.0"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
@@ -60,36 +60,36 @@ Dateien nach Analyse selbst editieren → **streng verboten**.
 
 ## Intent-Routing
 
-| User-Intent | Ziel-Agent | Tier / Parallel |
-|-------------|-----------|-----------------|
-| Neues Feature / Bugfix / Refactoring | `feature` (komplex) oder `developer` (klar, ≤3 Dateien) | `balanced`→`powerful` / Ja |
-| Codebase analysieren / Dependencies / Impact | `ideation` | `balanced` / Ja |
-| Design / Konzept / Architektur | `ideation` | `balanced`→`powerful` / Ja |
-| Implementierung / Code schreiben | `developer` | `balanced`→`powerful` / Ja |
-| Git-Operationen | `git` | `fast` / Nein |
-| Dokumentation aktualisieren | `documenter` | `balanced` / Ja |
-| Anforderungen / REQ-ID | `requirements` | `balanced` / Nein |
-| Tests schreiben oder ausführen | `tester` | `balanced` / Ja |
-| Code validieren / DoD prüfen | `code-reviewer`{{#if VALIDATOR_ENABLED}} oder `validator`{{/if}} | `balanced` / Nein |
-| Meta-Fragen (Agent-Setup, Sync, Rules) | `agent-meta-manager` | `fast`→`balanced` / Nein |
-| Projekt-Feedback als GitHub Issue | `feedback` | `fast` / Nein |
-| Bug/Feature triagieren | `bug-feature-analyzer` | `balanced` / Ja |
-| Log-Analyse | `log-analyzer` | `balanced` / Ja |
-| Release / Version bump | `release` | `balanced` / Nein |
+| User-Intent | Ziel-Agent | Handoff-Contract | Tier / Parallel |
+|-------------|-----------|------------------|-----------------|
+| Neues Feature / Bugfix / Refactoring | `feature` (komplex) oder `developer` (klar, ≤3 Dateien) | `task-spec-v1` | `balanced`→`powerful` / Ja |
+| Codebase analysieren / Dependencies / Impact | `ideation` | `task-spec-v1` | `balanced` / Ja |
+| Design / Konzept / Architektur | `ideation` | `task-spec-v1` | `balanced`→`powerful` / Ja |
+| Implementierung / Code schreiben | `developer` | `task-spec-v1` | `balanced`→`powerful` / Ja |
+| Git-Operationen | `git` | — | `fast` / Nein |
+| Dokumentation aktualisieren | `documenter` | `task-spec-v1` | `balanced` / Ja |
+| Anforderungen / REQ-ID | `requirements` | `task-spec-v1` | `balanced` / Nein |
+| Tests schreiben oder ausführen | `tester` | `task-spec-v1` | `balanced` / Ja |
+| Code validieren / DoD prüfen | `code-reviewer`{{#if VALIDATOR_ENABLED}} oder `validator`{{/if}} | `task-spec-v1` | `balanced` / Nein |
+| Meta-Fragen (Agent-Setup, Sync, Rules) | `agent-meta-manager` | — | `fast`→`balanced` / Nein |
+| Projekt-Feedback als GitHub Issue | `feedback` | — | `fast` / Nein |
+| Bug/Feature triagieren | `bug-feature-analyzer` | `task-spec-v1` | `balanced` / Ja |
+| Log-Analyse | `log-analyzer` | `task-spec-v1` | `balanced` / Ja |
+| Release / Version bump | `release` | — | `balanced` / Nein |
 {{#if SE_ENABLED}}
-| Systems Engineering / SE-Kaskade | `se-orchestrator` | `balanced`→`powerful` / Nein |
-| Code-Qualitäts-Audit / Clean Code | `code-reviewer` | `powerful` / Nein |
-| UI-Design / Mockups | `ui-ux-designer` | `balanced` / Ja |
-| API-Design / OpenAPI | `api-specialist` | `balanced` / Nein |
-| CI/CD / Infrastruktur | `devops-engineer` | `fast` / Ja |
-| Performance / Bottlenecks | `performance-optimizer` | `powerful` / Nein |
-| Export / Target-Routing | `export-manager` | `fast` / Nein |
+| Systems Engineering / SE-Kaskade | `se-orchestrator` | — | `balanced`→`powerful` / Nein |
+| Code-Qualitäts-Audit / Clean Code | `code-reviewer` | `task-spec-v1` | `powerful` / Nein |
+| UI-Design / Mockups | `ui-ux-designer` | `task-spec-v1` | `balanced` / Ja |
+| API-Design / OpenAPI | `api-specialist` | `task-spec-v1` | `balanced` / Nein |
+| CI/CD / Infrastruktur | `devops-engineer` | `task-spec-v1` | `fast` / Ja |
+| Performance / Bottlenecks | `performance-optimizer` | `task-spec-v1` | `powerful` / Nein |
+| Export / Target-Routing | `export-manager` | `task-spec-v1` | `fast` / Nein |
 {{/if}}
-| Plattform-Fragen / Provider-Integration | `claude-expert`, `opencode-expert`, `gemini-expert`, `continue-expert`, `copilot-expert` | `powerful` / Nein |
-| Batch-Operationen (mehrere gleiche Tasks) | — | — / Ja |
-| Aufwandsschätzung | `effort-estimator` | `fast` / Nein |
-| Iterativer Review / Reflection-Loop | `orchestrator` → REPEAT_UNTIL | `balanced`→`powerful` / Nein |
-| Nicht in Tabelle | Frag den User | — / — |
+| Plattform-Fragen / Provider-Integration | `claude-expert`, `opencode-expert`, `gemini-expert`, `continue-expert`, `copilot-expert` | — | `powerful` / Nein |
+| Batch-Operationen (mehrere gleiche Tasks) | — | `task-spec-v1` (batch: true) | — / Ja |
+| Aufwandsschätzung | `effort-estimator` | — | `fast` / Nein |
+| Iterativer Review / Reflection-Loop | `orchestrator` → REPEAT_UNTIL | supersession | `balanced`→`powerful` / Nein |
+| Nicht in Tabelle | Frag den User | — | — / — |
 
 Intent nicht exakt in Tabelle → User fragen, nicht raten. `bug-feature-analyzer` nur durch Orchestrator, nie direkt.
 
@@ -123,6 +123,91 @@ Nach BARRIER(): Ergebnisse sammeln, Konsistenz prüfen, Widersprüche → User i
 
 ---
 
+## A2A Handoff Protocol
+
+**Jede Delegation MUSS als strukturiertes A2A-Envelope erfolgen.** Der Orchestrator ist die Envelope-Fabrik.
+
+### Envelope-Erstellung (vor jeder Delegation)
+
+1. **`handoff_id` generieren:** `HOFF-YYYYMMDD-NNN` (Datum + fortlaufende Nummer)
+2. **`schema_ref` bestimmen:** Aus Intent-Routing-Tabelle (Handoff-Contract-Spalte) oder implizit via Route
+3. **`payload` aus User-Request + Kontext extrahieren:**
+   - `t`: Task-Beschreibung (Pflicht)
+   - `ctx`: Zusätzlicher Kontext (optional)
+   - `con`: Constraints (optional)
+   - `pri`: Priority (optional, default: medium)
+   - `refs`: Referenzen (optional)
+4. **Envelope zusammenbauen:**
+   ```json
+   {
+     "protocol_version": "1.0.0",
+     "handoff_id": "HOFF-YYYYMMDD-NNN",
+     "source_agent": "orchestrator",
+     "target_agent": "<ziel>",
+     "schema_ref": "<schema-uri>",
+     "payload": { "t": "...", "pri": "..." },
+     "trace_parent": "<parent-HOFF>"
+   }
+   ```
+
+### FANOUT — Batch-Mode
+
+Wenn mehrere Tasks an den GLEICHEN Agententyp delegiert werden:
+- `batch: true` setzen
+- `payload` als Array mit `batch_task_id` pro Eintrag
+
+```json
+{
+  "batch": true,
+  "payload": [
+    { "batch_task_id": "T1", "t": "Fix A", "pri": "high" },
+    { "batch_task_id": "T2", "t": "Fix B", "pri": "medium" }
+  ]
+}
+```
+
+Token-Ersparnis vs. separate Envelopes: ~110 Tokens pro FANOUT(3).
+
+### HITL — Human-in-the-Loop
+
+`requires_human_approval: true` setzen bei:
+- Kritischen Änderungen (DELETE-Operationen, Schema-Migrationen)
+- Unsicherheits-Flag: Orchestrator erkennt Ambiguität
+- Security-sensiblen Operationen
+
+Downstream-Agent pausiert vor Ausführung und wartet auf User-Bestätigung.
+
+### Retry-Logik
+
+- Jeder Envelope führt `retry_count` (Start: 0) und `max_retries` (Default: 3)
+- Bei Delegation-Failure: `retry_count` inkrementieren, erneut senden
+- Wenn `retry_count >= max_retries` → Abbruch, User benachrichtigen
+
+### PIPELINE — trace_parent-Verkettung
+
+Bei Pipeline-Delegationen (z.B. requirements→tester→developer):
+- Jeder Schritt setzt `trace_parent` auf die `handoff_id` des vorherigen Schritts
+- Ermöglicht vollständige Chain-of-custody bei Fehlschlägen
+
+### REPEAT_UNTIL — Supersession
+
+Bei Reflection-Loops (z.B. developer↔code-reviewer):
+- Erste Delegation: `supersession` nicht gesetzt, `history: []`
+- Bei Critic-Rejection: neue `handoff_id` mit `supersession.supersedes` auf vorherige ID
+- `supersession.history[]` enthält alle vorherigen handoff_ids (NUR IDs, keine Payloads)
+- `version = history.length + 1`
+
+### Provider-Transport
+
+| Provider | structured_handoff | Transport |
+|----------|-------------------|-----------|
+| Claude, Opencode, Gemini | `true` | JSON-Envelope im Prompt |
+| Continue, Copilot | `false` | YAML-Text-Block (kein natives JSON-Tool-Call) |
+
+Bei `structured_handoff: false`: YAML-Text-Block statt JSON, aber gleiche Struktur.
+
+---
+
 ## Outcome Caching
 
 Wenn aktiviert: Cache-Key = SHA256(agent + prompt[:200]). Read-only, idempotent, keine Side-Effects. Invalidierung nach git-commit.
@@ -134,6 +219,7 @@ Wenn aktiviert: Cache-Key = SHA256(agent + prompt[:200]). Read-only, idempotent,
 {{PAL_DELEGATE}}
 {{PAL_FANOUT}}
 {{PAL_PARALLEL_GROUP}}
+{{PAL_HANDOFF}}
 BARRIER(): Warten bis alle fertig; Ergebnisse sammeln
 REPEAT_UNTIL(gen, critic, max): Generator → Critic → Revision bis max
 PIPELINE(name, stages): Vordefinierte Pipeline sequentiell/parallel

--- a/agents/1-generic/se-architect.md
+++ b/agents/1-generic/se-architect.md
@@ -1,6 +1,6 @@
 ---
 name: se-architect
-version: 1.3.0
+version: 1.4.0
 description: Designs system architecture using generic laws, CQRS routing, and defines
   L1/L2 whiteboxes.
 hint: Use this agent to design L1 and L2 architectures from requirements.
@@ -23,6 +23,57 @@ To prevent Context Drift, you receive **only** the following context (max ~2k to
 - `neighbor_contracts`: Interface contracts from the Interface Manager for parallel neighbor components.
 
 You **must NOT** see or assume context from higher levels (e.g., Level 1 or 2). Do not hallucinate requirements not present in your input payload. If information is missing, derive only from the provided `parent_requirement`.
+
+## A2A Handoff — Input
+
+Du empfängst deinen Auftrag als A2A-Envelope. Der `payload` enthält die SE-Decomposition-Daten:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-orchestrator",
+  "target_agent": "se-architect",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "feature_id": "REQ-L1-SH-001",
+    "stakeholder_requirement": "...",
+    "l1_system": { "blackbox": "...", "whitebox": ["..."] },
+    "sub_components": [ ... ],
+    "internal_interfaces": [ ... ],
+    "architectural_rationale": "..."
+  },
+  "trace_parent": "HOFF-YYYYMMDD-PARENT"
+}
+```
+
+**Bei Supersession (Critic-Rejection):** Wenn `supersession.supersedes` gesetzt ist, erhältst du die vorherige Version + Critic-Feedback. `supersession.history[]` enthält alle vorherigen handoff_ids (nur IDs, keine Payloads). Nutze `supersession.reason` um die Critic-Beanstandungen zu verstehen.
+
+## A2A Handoff — Output
+
+Dein Architektur-Output MUSS als A2A-Envelope an den Critic übergeben werden:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-architect",
+  "target_agent": "se-critic",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "feature_id": "...",
+    "stakeholder_requirement": "...",
+    "l1_system": { ... },
+    "sub_components": [ ... ],
+    "internal_interfaces": [ ... ],
+    "architectural_rationale": "...",
+    "decomposition_completeness": "..."
+  },
+  "trace_parent": "<eingehende handoff_id>"
+}
+```
+
+Bei Supersession (nach Critic-Rejection): `supersession`-Block setzen mit `supersedes` auf die abgelehnte HOFF und `history` aus der vorherigen Chain + der abgelehnten HOFF.
 
 ## Responsibilities:
 1. **ANALYZE** the input requirement for functional, non-functional, and constraint aspects. Identify what the Black-Box must achieve versus how it is built.

--- a/agents/1-generic/se-critic.md
+++ b/agents/1-generic/se-critic.md
@@ -1,6 +1,6 @@
 ---
 name: se-critic
-version: 1.4.0
+version: 1.5.0
 description: Audits requirements and architecture against generic laws (orthogonality,
   testability, traceability).
 hint: Use this agent to validate requirements before architecture, and audit architectural
@@ -29,6 +29,36 @@ You receive a `review_target` field indicating what is being reviewed:
 - The original Black-Box requirement (input of the Architect).
 - The complete Architect Output (White-Box with sub-components, interfaces, rationale).
 - The Interface Registry (from the Interface Manager, for consistency checks).
+
+### A2A-Envelope-Format
+
+Du empfängst Input als A2A-Envelope:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-architect",
+  "target_agent": "se-critic",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "feature_id": "...",
+    "stakeholder_requirement": "...",
+    "sub_components": [ ... ],
+    "internal_interfaces": [ ... ],
+    "architectural_rationale": "..."
+  },
+  "trace_parent": "HOFF-YYYYMMDD-PARENT",
+  "supersession": {
+    "supersedes": "HOFF-YYYYMMDD-PREV",
+    "history": ["HOFF-YYYYMMDD-FIRST", "HOFF-YYYYMMDD-PREV"],
+    "reason": "critic rejection: missing traceability for COMP-001-03",
+    "timestamp": "2026-06-07T14:30:00Z"
+  }
+}
+```
+
+Bei `supersession`: Prüfe ob die beanstandeten Issues aus `supersession.reason` behoben wurden.
 
 ## Audit Criteria
 Perform the following four checks on every output. Each check must yield a boolean `passed` and a list of `issues` (empty if passed).
@@ -140,6 +170,57 @@ Return your final output **only** as a JSON object matching the following schema
 - Never approve a decomposition with unresolved safety or security gaps.
 
 Iterate on the output of the Generator (`se-requirements` or `se-architect`) until all generic rules are met.
+
+## A2A Handoff — Output
+
+### Bei Approval (passed: true)
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-critic",
+  "target_agent": "se-interface-mgr",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "verdict": "approved",
+    "review_target": "architecture",
+    "checks": { ... },
+    "approved_output": { ... }
+  },
+  "trace_parent": "<eingehende handoff_id>",
+  "supersession": {
+    "history": ["<alle vorherigen HOFFs aus der Chain>"]
+  }
+}
+```
+
+### Bei Rejection (passed: false)
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-critic",
+  "target_agent": "se-architect",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "verdict": "rejected",
+    "review_target": "architecture",
+    "checks": { ... },
+    "issues": ["missing traceability for COMP-001-03", "interface type mismatch"]
+  },
+  "trace_parent": "<eingehende handoff_id>",
+  "supersession": {
+    "supersedes": "<abgelehnte HOFF>",
+    "history": ["<bisherige Chain + abgelehnte HOFF>"],
+    "reason": "critic rejection: [kurze Begründung]",
+    "timestamp": "<ISO 8601>"
+  }
+}
+```
+
+**Wichtig:** `supersession.history[]` enthält NUR handoff_id-Strings, keine Payloads. Version = history.length + 1.
 
 ## Anti-Recursion Guard
 

--- a/agents/1-generic/se-interface-mgr.md
+++ b/agents/1-generic/se-interface-mgr.md
@@ -1,6 +1,6 @@
 ---
 name: se-interface-mgr
-version: 1.2.1
+version: 1.3.0
 description: Manages generic signal flow and deterministic synchronization across
   systems.
 hint: Manages generic signal flow, deterministic sync across systems
@@ -41,6 +41,47 @@ Your responsibility is the central management and validation of all interface co
 4. **Interface Spec per Component:**
    - For each sub-component: list of all interfaces it is involved in (incoming and outgoing).
    - This spec becomes the input payload for the cell at level n+1.
+
+## A2A Handoff — Input/Output
+
+### Eingehender Envelope
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-critic",
+  "target_agent": "se-interface-mgr",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "verdict": "approved",
+    "approved_output": {
+      "sub_components": [ ... ],
+      "internal_interfaces": [ ... ],
+      "architectural_rationale": "..."
+    }
+  },
+  "trace_parent": "HOFF-YYYYMMDD-PARENT"
+}
+```
+
+### Ausgehender Envelope (an se-termination)
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-interface-mgr",
+  "target_agent": "se-termination",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "Termination-Entscheidung für Sub-Components treffen",
+    "propagation_map": { ... },
+    "interface_specs": [ ... ]
+  },
+  "trace_parent": "<eingehende handoff_id>"
+}
+```
 
 ## Rules & Compliance
 

--- a/agents/1-generic/se-orchestrator.md
+++ b/agents/1-generic/se-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: se-orchestrator
-version: 1.5.0
+version: 1.6.0
 description: Coordinates the 6-level recursive breakdown with zig-zag traceability
   and V&V.
 hint: Coordinates the 6-level recursive breakdown
@@ -33,6 +33,35 @@ You delegate and control the information flow between the following agents:
 - `se-verifier` (multi-level verification)
 - `se-test-engineer` (MBSE test models)
 - `se-integration-and-test-manager` (V&V orchestration)
+
+## A2A Handoff — Eingehende Tasks
+
+Du empfängst den SE-Auftrag vom Haupt-Orchestrator als A2A-Envelope:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "orchestrator",
+  "target_agent": "se-orchestrator",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "SE-Kaskade für Feature X starten",
+    "ctx": "Stakeholder-Bedürfnis: ...",
+    "pri": "high"
+  }
+}
+```
+
+## A2A Handoff — Ausgehende Delegationen
+
+Jede Delegation an SE-Subagenten MUSS als A2A-Envelope erfolgen:
+- `source_agent: "se-orchestrator"`, `target_agent: "<se-subagent>"`
+- `trace_parent` auf die eigene `handoff_id` setzen
+- `schema_ref: "schemas/se-decomposition.schema.json"` für se-architect, se-critic
+- `schema_ref: "schemas/handoffs/task-spec.schema.json"` für se-interface-mgr, se-termination
+
+Bei Zell-Spawning (decision: continue): Jede neue Zelle erhält einen eigenen Envelope mit `trace_parent` auf die Zellen-HOFF.
 
 ### Recursive System Cell (Fractal n → n+1)
 

--- a/agents/1-generic/se-termination.md
+++ b/agents/1-generic/se-termination.md
@@ -1,6 +1,6 @@
 ---
 name: se-termination
-version: 1.2.1
+version: 1.3.0
 description: Deterministic termination at L3 (Component Requirement).
 hint: Deterministic termination at L3 (Component Requirement)
 tools:
@@ -41,6 +41,49 @@ Your task is the deterministic decision per sub-component: Is the decomposition 
    - `max_depth`: Enforce leaf node when current depth >= configured limit.
    - `max_total_cells`: Enforce leaf node when total cell count >= limit.
    - **Circular Reference:** Enforce leaf node when the `parent_id` chain contains a cycle.
+
+## A2A Handoff — Input/Output
+
+### Eingehender Envelope
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-interface-mgr",
+  "target_agent": "se-termination",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "Termination-Entscheidung für Sub-Components",
+    "sub_components": [ ... ],
+    "propagation_map": { ... },
+    "current_depth": 2,
+    "max_depth": 3
+  },
+  "trace_parent": "HOFF-YYYYMMDD-PARENT"
+}
+```
+
+### Ausgehender Envelope (deterministische Entscheidung)
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-YYYYMMDD-NNN",
+  "source_agent": "se-termination",
+  "target_agent": "se-orchestrator",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "Termination-Entscheidung",
+    "decisions": [
+      {"component_id": "COMP-001-01", "decision": "leaf", "reason": "Atomic Code Unit"},
+      {"component_id": "COMP-001-02", "decision": "continue", "reason": "Multi-domain"}
+    ],
+    "summary": "2 components: 1 leaf, 1 continue"
+  },
+  "trace_parent": "<eingehende handoff_id>"
+}
+```
 
 ## Rules & Compliance
 

--- a/agents/1-generic/validator.md
+++ b/agents/1-generic/validator.md
@@ -1,6 +1,6 @@
 ---
 name: template-validator
-version: "3.1.1"
+version: "3.2.0"
 description: "Formaler Prozess-Wächter: DoD-Checkboxen, REQ-ID-Präsenz, Commit-Konventionen. Bewertet KEINE Code-Qualität — dafür code-reviewer."
 hint: "Interner Qualitäts-Checker: DoD-Checkliste, Traceability-Audit. Wird vom Orchestrator nach der Implementierung aufgerufen. Nicht für direkte User-Fragen oder Setup-Hilfe."
 tools:
@@ -227,6 +227,41 @@ Prüfe Konsistenz zwischen Dokumenten:
 - Anforderung unklar/fehlend? → Verweise an `requirements`
 - Dokumentation veraltet? → Verweise an `documenter`
 - Code-Qualität prüfen? → Verweise an `code-reviewer` (nicht selbst prüfen!)
+
+## A2A Handoff — validate_handoff
+
+Wenn du einen eingehenden A2A-Envelope erhältst, validiere ihn VOR der inhaltlichen Prüfung:
+
+### Validierungs-Checkliste
+
+1. **Pflichtfelder prüfen:** `protocol_version`, `handoff_id`, `source_agent`, `target_agent`, `payload`
+2. **handoff_id-Format:** `HOFF-YYYYMMDD-NNN` (Regex: `^HOFF-\d{8}-\d{3,6}$`)
+3. **protocol_version:** Muss `1.0.0` sein (oder höhere kompatible Version)
+4. **schema_ref:** Wenn gesetzt, prüfe ob die referenzierte Schema-Datei existiert
+5. **payload:** Muss ein Object sein (oder Array wenn `batch: true`)
+6. **trace_parent:** Wenn gesetzt, Format wie handoff_id prüfen
+
+### Rückgabeformat
+
+```json
+{
+  "valid": true|false,
+  "handoff_id": "HOFF-...",
+  "errors": [
+    {"field": "handoff_id", "message": "Format nicht eingehalten"},
+    {"field": "payload", "message": "Fehlt (Pflichtfeld)"}
+  ],
+  "warnings": [
+    {"field": "schema_ref", "message": "Schema-Datei nicht gefunden, fahre ohne Validierung fort"}
+  ]
+}
+```
+
+### Fallback
+
+Wenn kein Envelope empfangen wurde (Natural-Language-Prompt):
+- Führe die Aufgabe normal aus
+- Gib einen Warning-Hinweis: "Kein A2A-Envelope empfangen — Natural-Language-Fallback"
 
 ## Anti-Recursion Guard
 

--- a/config/delegation-syntax.yaml
+++ b/config/delegation-syntax.yaml
@@ -11,6 +11,14 @@ delegation_syntax:
     bootstrap: "file-based"
     tool_preamble: "true"
     parallel_pattern: "**Parallel-Pattern (konkret):**\n```\n# Vordergrund:\nAgent(subagent_type=\"validator\", prompt=\"DoD-Check für ...\")\n# Gleichzeitig im Hintergrund:\nAgent(subagent_type=\"documenter\", prompt=\"Update CODEBASE_OVERVIEW ...\", run_in_background=True)\n# Dann warten bis Hintergrund fertig, dann:\nAgent(subagent_type=\"git\", prompt=\"Commit und PR erstellen ...\")\n```\n"
+    handoff: |
+      **A2A Handoff Protocol:**
+      Jede Delegation MUSS als strukturiertes A2A-Envelope (JSON) erfolgen.
+      Füge den JSON-Envelope VOR dem Agent()-Tool-Call in den Prompt ein:
+      ```json
+      {"protocol_version":"1.0.0","handoff_id":"HOFF-YYYYMMDD-NNN","source_agent":"<quelle>","target_agent":"<ziel>","schema_ref":"<schema-uri>","payload":{...},"trace_parent":"<parent-HOFF>"}
+      ```
+      FANOUT mit gleichem target: batch:true, payload als Array.
 
   Opencode:
     delegate: 'task(subagent_type="{{agent}}", description="{{short_desc}}", prompt="{{task}}")'
@@ -20,6 +28,14 @@ delegation_syntax:
     bootstrap: "file-based"
     tool_preamble: "true"
     parallel_pattern: "**Parallel-Dispatch (Opencode):**\nFANOUT: Alle N task()-Calls in EINER Antwort-Nachricht. Kein separater Background-Marker.\nPARALLEL_GROUP: Mehrere task()-Calls mit verschiedenen subagent_type in einer Antwort.\nBARRIER: Automatisch — die Antwort kommt erst wenn alle Tasks fertig sind.\n\n```\n# FANOUT(3, developer, [\"Fix A\", \"Fix B\", \"Fix C\"]):\ntask(subagent_type=\"developer\", description=\"Fix Bug A\", prompt=\"...\")\ntask(subagent_type=\"developer\", description=\"Fix Bug B\", prompt=\"...\")\ntask(subagent_type=\"developer\", description=\"Fix Bug C\", prompt=\"...\")\n# Alle drei Calls in derselben Antwort → parallele Ausführung\n# Ergebnisse: task_results als Array [result_A, result_B, result_C]\n```\n\nLimit: Kein hartes Limit. MAX_PARALLEL_AGENTS steuert die Anzahl.\n"
+    handoff: |
+      **A2A Handoff Protocol:**
+      Jede Delegation MUSS als strukturiertes A2A-Envelope (JSON) erfolgen.
+      Füge den JSON-Envelope VOR dem task()-Call in den Prompt ein:
+      ```json
+      {"protocol_version":"1.0.0","handoff_id":"HOFF-YYYYMMDD-NNN","source_agent":"<quelle>","target_agent":"<ziel>","schema_ref":"<schema-uri>","payload":{...},"trace_parent":"<parent-HOFF>"}
+      ```
+      FANOUT mit gleichem target: batch:true, payload als Array.
 
   Gemini:
     delegate: 'Rufe den **{{agent}}-Agenten** auf mit der Aufgabe: "{{task}}"'
@@ -33,6 +49,14 @@ delegation_syntax:
     tool_preamble: "false"
     auto_parallel: true
     parallel_pattern: "**Parallel-Pattern (konkret):**\nGemini Code Assist führt unabhängige Tool-Aufrufe parallel aus.\nDelegiere an mehrere Agenten in einem einzigen Prompt — die Ausführung erfolgt automatisch parallelisiert.\n"
+    handoff: |
+      **A2A Handoff Protocol:**
+      Jede Delegation MUSS als strukturiertes A2A-Envelope (JSON) erfolgen.
+      Füge den JSON-Envelope VOR dem Agenten-Aufruf in den Prompt ein:
+      ```json
+      {"protocol_version":"1.0.0","handoff_id":"HOFF-YYYYMMDD-NNN","source_agent":"<quelle>","target_agent":"<ziel>","schema_ref":"<schema-uri>","payload":{...},"trace_parent":"<parent-HOFF>"}
+      ```
+      FANOUT mit gleichem target: batch:true, payload als Array.
 
   Continue:
     delegate: "@{{agent}} {{task}}"
@@ -46,6 +70,22 @@ delegation_syntax:
     tool_preamble: "false"
     auto_parallel: false
     parallel_pattern: "**Parallel-Pattern:**\nContinue unterstützt keine native parallele Subagent-Ausführung.\nFühre parallele Schritte sequentiell aus oder verwende separate Continue-Sessions.\n"
+    handoff: |
+      **A2A Handoff Protocol — YAML-Fallback:**
+      Continue: kein natives JSON-Tool. Verwende YAML-Text-Block:
+      ```yaml
+      a2a_handoff:
+        protocol_version: "1.0.0"
+        handoff_id: "HOFF-YYYYMMDD-NNN"
+        source_agent: "<quelle>"
+        target_agent: "<ziel>"
+        schema_ref: "<schema-uri>"
+        trace_parent: "<parent-HOFF>"
+        payload:
+          t: "<task>"
+          pri: "<priority>"
+      ```
+      Dann: @<ziel> Bearbeite diesen strukturierten Handoff.
 
   Copilot:
     delegate: "@{{agent}} Führe folgende Aufgabe aus: {{task}}"
@@ -56,3 +96,19 @@ delegation_syntax:
     tool_preamble: "false"
     auto_parallel: false
     parallel_pattern: "**Parallel-Pattern:**\nGitHub Copilot unterstützt keine native parallele Subagent-Ausführung.\nFühre parallele Schritte sequentiell aus oder verwende separate VS Code-Sessions.\n"
+    handoff: |
+      **A2A Handoff Protocol — YAML-Fallback:**
+      Copilot: kein natives JSON-Tool. Verwende YAML-Text-Block:
+      ```yaml
+      a2a_handoff:
+        protocol_version: "1.0.0"
+        handoff_id: "HOFF-YYYYMMDD-NNN"
+        source_agent: "<quelle>"
+        target_agent: "<ziel>"
+        schema_ref: "<schema-uri>"
+        trace_parent: "<parent-HOFF>"
+        payload:
+          t: "<task>"
+          pri: "<priority>"
+      ```
+      Dann: @<ziel> Bearbeite diesen strukturierten Handoff.

--- a/config/mcp-registry.yaml
+++ b/config/mcp-registry.yaml
@@ -100,3 +100,26 @@ mcp-servers:
         - "scripts/viz-logger.py"
         - "--mcp"
     secrets: []
+
+  a2a-handoff:
+    description: "A2A Handoff Protocol tools: Schema-Validierung und Route-Resolution"
+    category: agent-meta
+    enabled-by-default: true
+    tools:
+      allowed:
+        - validate_handoff
+        - resolve_handoff_schema
+        - resolve_handoff
+    agent-hint: |
+      validate_handoff: Prüft A2A-Envelope gegen referenziertes Schema.
+      resolve_handoff_schema: Liefert Schema-URI für source-target Route.
+      resolve_handoff: Rekonstruiert Envelope aus Event-Log (für Supersession-History).
+    connection:
+      type: stdio
+      command: python
+      args:
+        - "scripts/viz-logger.py"
+        - "--mcp"
+        - "--mode"
+        - "a2a"
+    secrets: []

--- a/config/provider-capabilities.yaml
+++ b/config/provider-capabilities.yaml
@@ -10,6 +10,8 @@ capabilities:
     text_mentions: true
     hooks: true
     native_agent_tools: ["Agent", "Task"]
+    structured_handoff: true
+    handoff_format: "json"
     description: "Vollständige Agent-Orchestrierung mit nativen Tool-Calls und Hooks."
 
   Opencode:
@@ -19,6 +21,8 @@ capabilities:
     text_mentions: false
     hooks: false
     native_agent_tools: ["task"]
+    structured_handoff: true
+    handoff_format: "json"
     description: "Agent-Orchestrierung via task() tool, dateibasierte Agent-Registrierung."
 
   Gemini:
@@ -28,6 +32,8 @@ capabilities:
     text_mentions: false
     hooks: false
     native_agent_tools: ["define_subagent", "send_message", "invoke_subagent"]
+    structured_handoff: true
+    handoff_format: "json"
     description: "API-basierte Agent-Registrierung, ephemere Runtime."
     bootstrap_required: true
     special_notes:
@@ -42,6 +48,8 @@ capabilities:
     text_mentions: true
     hooks: false
     native_agent_tools: []
+    structured_handoff: false
+    handoff_format: "yaml_text_block"
     description: "Text-basierte Agent-Mentions (@agent). Keine native Subagent-API."
     special_notes:
       - "@agent Text-Mentions als Subagent-Dispatch."
@@ -55,6 +63,8 @@ capabilities:
     text_mentions: true
     hooks: false
     native_agent_tools: []
+    structured_handoff: false
+    handoff_format: "yaml_text_block"
     description: "Dateibasierte Agenten (.github/copilot/agents/). @agent Text-Mentions."
     special_notes:
       - "Dateien in .github/copilot/agents/ werden automatisch geladen."

--- a/config/provider-capabilities.yaml
+++ b/config/provider-capabilities.yaml
@@ -12,6 +12,7 @@ capabilities:
     native_agent_tools: ["Agent", "Task"]
     structured_handoff: true
     handoff_format: "json"
+    handoff_envelope_support: true
     description: "Vollständige Agent-Orchestrierung mit nativen Tool-Calls und Hooks."
 
   Opencode:
@@ -23,6 +24,7 @@ capabilities:
     native_agent_tools: ["task"]
     structured_handoff: true
     handoff_format: "json"
+    handoff_envelope_support: true
     description: "Agent-Orchestrierung via task() tool, dateibasierte Agent-Registrierung."
 
   Gemini:
@@ -34,6 +36,7 @@ capabilities:
     native_agent_tools: ["define_subagent", "send_message", "invoke_subagent"]
     structured_handoff: true
     handoff_format: "json"
+    handoff_envelope_support: true
     description: "API-basierte Agent-Registrierung, ephemere Runtime."
     bootstrap_required: true
     special_notes:
@@ -50,6 +53,7 @@ capabilities:
     native_agent_tools: []
     structured_handoff: false
     handoff_format: "yaml_text_block"
+    handoff_envelope_support: false
     description: "Text-basierte Agent-Mentions (@agent). Keine native Subagent-API."
     special_notes:
       - "@agent Text-Mentions als Subagent-Dispatch."
@@ -65,6 +69,7 @@ capabilities:
     native_agent_tools: []
     structured_handoff: false
     handoff_format: "yaml_text_block"
+    handoff_envelope_support: false
     description: "Dateibasierte Agenten (.github/copilot/agents/). @agent Text-Mentions."
     special_notes:
       - "Dateien in .github/copilot/agents/ werden automatisch geladen."

--- a/config/role-defaults.yaml
+++ b/config/role-defaults.yaml
@@ -38,36 +38,58 @@ roles:
     memory: ""
     workflow_tier: required
     description: "Einstiegspunkt für alle Entwicklungsaufgaben — koordiniert alle anderen Agenten. Wählt automatisch das kosteneffizienteste Model-Tier für jede Delegation (nano/fast/balanced/powerful/max)."
+    handoff:
+      output_contract: "task-spec-v1"
+      handoff_routing: "static"
 
   developer:
     model: powerful          # erbt — oft das stärkste verfügbare Modell gewünscht
     memory: ""
     workflow_tier: required
     description: "Feature-Implementierung und Bugfixes"
+    handoff:
+      input_contracts: ["task-spec-v1"]
+      output_contract: "dev-result-v1"
+      input_schema: "schemas/handoffs/task-spec.schema.json"
+      timeout_sec: 300
 
   requirements:
     model: balanced
     memory: project
     workflow_tier: recommended
     description: "Anforderungen aufnehmen, REQ-IDs vergeben, REQUIREMENTS.md pflegen"
+    handoff:
+      input_contracts: ["ideation-output-v1", "task-spec-v1"]
+      output_contract: "req-output-v1"
+      target_roles: ["developer", "tester"]
 
   ideation:
     model: ""           # erbt
     memory: ""
     workflow_tier: optional
     description: "Neue Ideen explorieren, Vision schärfen, Übergabe an requirements"
+    handoff:
+      output_contract: "ideation-output-v1"
+      output_schema: "schemas/handoffs/ext/ideation-extension.schema.json"
+      target_roles: ["requirements"]
 
   feature:
     model: ""           # erbt — koordiniert andere Agenten, kein eigenes Coding
     memory: ""
     workflow_tier: recommended
     description: "Feature-Lifecycle-Subagent: Branch → REQ → TDD → Dev → Validate → PR. Wird vom Orchestrator gestartet, nicht direkt vom User."
+    handoff:
+      input_contracts: ["task-spec-v1"]
+      output_contract: "feature-result-v1"
 
   tester:
     model: balanced
     memory: ""
     workflow_tier: recommended
     description: "TDD, Test-Suite ausführen, Testabdeckung sichern"
+    handoff:
+      input_contracts: ["task-spec-v1", "req-output-v1"]
+      output_contract: "test-result-v1"
 
   validator:
     model: balanced
@@ -75,6 +97,10 @@ roles:
     permission_mode: plan
     workflow_tier: recommended
     description: "Code gegen REQs prüfen, DoD-Checkliste, Traceability-Audit"
+    handoff:
+      input_contracts: ["task-spec-v1", "dev-result-v1"]
+      validate_handoff: true
+      output_schema: "schemas/a2a-handoff.schema.json"
 
   documenter:
     model: fast
@@ -154,36 +180,60 @@ roles:
     memory: project
     workflow_tier: optional
     description: "Nimmt Stakeholder-Bedürfnisse auf und erstellt das formale L1-Blackbox-Requirement."
+    handoff:
+      input_contracts: ["task-spec-v1"]
+      output_contract: "se-req-output-v1"
+      target_roles: ["se-critic"]
 
   se-architect:
     model: powerful
     memory: project
     workflow_tier: optional
     description: "Zerlegt Blackboxes in Whiteboxes nach strengen Architekturgesetzen (CQRS, Orthogonalität)."
+    handoff:
+      input_contracts: ["task-spec-v1"]
+      output_contract: "se-arch-output-v1"
+      output_schema: "schemas/se-decomposition.schema.json"
+      target_roles: ["se-critic"]
 
   se-critic:
     model: powerful
     memory: ""
     workflow_tier: optional
     description: "Prüft Architekturentscheidungen iterativ auf Vollständigkeit, Konsistenz und Testbarkeit."
+    handoff:
+      input_contracts: ["se-arch-output-v1"]
+      output_contract: "critic-result-v1"
+      target_roles: ["se-architect", "se-interface-mgr"]
 
   se-interface-mgr:
     model: balanced
     memory: project
     workflow_tier: optional
     description: "Verwaltet und validiert alle Schnittstellenverträge domänenübergreifend."
+    handoff:
+      input_contracts: ["critic-result-v1"]
+      output_contract: "interface-result-v1"
+      target_roles: ["se-termination"]
 
   se-termination:
     model: fast
     memory: ""
     workflow_tier: optional
     description: "Entscheidet deterministisch, ob der L3-Component-Leaf-Node erreicht wurde."
+    handoff:
+      input_contracts: ["interface-result-v1"]
+      output_contract: "termination-result-v1"
 
   se-orchestrator:
     model: balanced
     memory: ""
     workflow_tier: optional
     description: "Koordiniert den gesamten 6-stufigen rekursiven Systems-Engineering-Herunterbruch."
+    handoff:
+      input_contracts: ["task-spec-v1"]
+      output_contract: "task-spec-v1"
+      target_roles: ["se-architect", "se-requirements"]
 
   se-test-engineer:
     model: balanced
@@ -222,18 +272,31 @@ roles:
     permission_mode: plan
     workflow_tier: recommended
     description: "Clean Code Gatekeeper: Blast-Radius-Analyse, SOLID/DRY Prüfung, Code-Qualitäts-Audit."
+    handoff:
+      input_contracts: ["dev-result-v1"]
+      output_contract: "review-output-v1"
+      output_schema: "schemas/handoffs/ext/review-extension.schema.json"
+      target_roles: ["developer"]
 
   ui-ux-designer:
     model: balanced
     memory: project
     workflow_tier: optional
     description: "UI-Spezifikationen, Mockups und Design-Systeme erstellen."
+    handoff:
+      output_contract: "design-spec-v1"
+      output_schema: "schemas/handoffs/ext/design-extension.schema.json"
+      target_roles: ["developer"]
 
   api-specialist:
     model: balanced
     memory: project
     workflow_tier: optional
     description: "OpenAPI/Contract-First API Design, Schnittstellen-Spezifikationen."
+    handoff:
+      output_contract: "api-spec-v1"
+      output_schema: "schemas/handoffs/ext/api-extension.schema.json"
+      target_roles: ["developer"]
 
   devops-engineer:
     model: fast

--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -1,6 +1,6 @@
 # CODEBASE_OVERVIEW — agent-meta
 
-> Letzte Aktualisierung: 2026-05-31
+> Letzte Aktualisierung: 2026-06-07
 
 ---
 
@@ -15,6 +15,7 @@
 7. [Howto-Dokumentation](#7-howto-dokumentation)
 8. [Scripts](#8-scripts)
 9. [Provider Abstraction Layer (PAL)](#9-provider-abstraction-layer-pal)
+10. [A2A-Handoff-Protokoll](#10-a2a-handoff-protokoll)
 
 ---
 
@@ -446,10 +447,80 @@ Die Provider-Expert-Agenten wurden in v0.55.0 eingeführt und bieten Provider-sp
 
 ## 5. Schemas
 
-### `schemas/se-decomposition.schema.json`
+### 5.0 A2A-Handoff-Envelope — Das EINZIGE Austauschformat
+
+**A2A-Envelopes sind das einzige Format für Agent-zu-Agent-Daten.** Natural-Language-Prompts zwischen Agenten werden vollständig durch strukturierte Envelopes ersetzt. Alle bisherigen Payload-Schemas (ideation-output, se-decomposition, se-orchestrator) werden unverändert als `payload` in den Envelope eingebettet.
+
+Neue Payload-Schemas (TaskSpec + Extensions) verwenden **kurze Feldnamen** (2–3 Zeichen) mit ausführlichen `title`/`description` im Schema für Lesbarkeit — Token-Ersparnis: 20–50 Tokens pro Handoff.
+
+**Schema-Strategie:** 1 Core (TaskSpec) + 4 Extensions (Ideation, Design, API, Review) + 1 SE (se-decomposition). Reduziert die Schema-Anzahl von 19 auf 6.
+
+### 5.1 `schemas/a2a-handoff.schema.json` — Envelope
 
 **Version:** Draft-07 JSON Schema
-**Zweck:** Strukturiertes Output-Schema für generische L1-L3 Layer, CQRS-Events und SE-Agent-Konzept rekursive Zell-Outputs.
+**Zweck:** Standardisierter Envelope für ALLE Agent-zu-Agent-Handoffs. Umhüllt jedes domain-spezifische Payload mit Metadaten für Validierung, Supersession-Tracking und Traceability.
+
+**Top-Level Required Fields:**
+| Feld | Typ | Beschreibung |
+|------|-----|-------------|
+| `protocol_version` | string (SemVer) | Version des A2A-Protokolls (default = aktuell, nur explizit bei Major-Change) |
+| `handoff_id` | string (`HOFF-YYYYMMDD-NNN`) | Eindeutige Handoff-ID |
+| `source_agent` | string | Rolle des sendenden Agenten |
+| `target_agent` | string | Rolle des empfangenden Agenten |
+| `payload` | object | Domain-spezifische Daten (validiert gegen `schema_ref`) |
+
+**Optionale Felder:**
+| Feld | Beschreibung |
+|------|-------------|
+| `schema_ref` | URI zum Payload-Schema (implizit aus Route ableitbar — optional für Token-Ersparnis) |
+| `compact_mode` | boolean: `true` = kurze Payload-Feldnamen (default: `false`) |
+| `supersession` | Versionsinfo: `version`, `supersedes`, `history[]`, `reason`, `timestamp` |
+| `trace_parent` | handoff_id des übergeordneten Handoffs (Delegationsbaum-Tracing) |
+| `trace_context` | Erweitertes Tracing: `trace_id`, `span_id`, `parent_span_id`, `viz_task_id` |
+| `metadata` | Extensible Key-Value-Map für provider-spezifische Metadaten |
+
+**Definitionen:**
+- `handoffRoute` — Registrierte Route zwischen zwei Rollen: `source`, `target`, `contract`, `input_schema`
+- `agentContract` — Deklaration was eine Rolle konsumiert/produziert
+- `handoffRegistry` — Vollständige Registry aller Routen
+
+### 5.2 `schemas/handoffs/task-spec.schema.json` (NEU — Universelles Kern-Payload)
+
+**Zweck:** Universelles Payload-Schema für 60-80% aller Delegationen. Kurze Feldnamen (2-3 Zeichen) für Token-Effizienz.
+
+**Feld-Mapping (kurz → lang):**
+| Feld | Key | Typ | Beschreibung |
+|------|-----|-----|-------------|
+| Task | `t` | string (Pflicht) | Task-Beschreibung in Natural Language |
+| Context | `ctx` | string | Zusätzlicher Kontext |
+| Constraints | `con` | string[] | Harte Randbedingungen |
+| References | `refs` | string[] | Referenzen auf Dateien/Schemas/Issues |
+| Priority | `pri` | enum | `low`, `medium`, `high`, `critical` |
+| Depends on | `dep` | HOFF[] | Abhängigkeiten von anderen Handoffs |
+
+**Token-Ersparnis vs. lange Feldnamen:** ~40 Tokens pro Handoff (31% Reduktion).
+
+### 5.3 Extensions (NEU — 4 Dateien unter `schemas/handoffs/ext/`)
+
+Jede Extension erweitert TaskSpec um domain-spezifische Felder via JSON Schema `allOf`:
+
+| Extension | Datei | Route | Zusätzliche Felder |
+|-----------|-------|-------|-------------------|
+| IdeationExtension | `ideation-extension.schema.json` | ideation → requirements | `ci` (core_idea), `g` (goal), `sv1` (scope_v1), `oq`, `ref` |
+| DesignExtension | `design-extension.schema.json` | ui-ux-designer → developer | `ds` (design_spec: components, theme), `lo` (layouts), `wf` (wireframes) |
+| APIExtension | `api-extension.schema.json` | api-specialist → developer | `ct` (contract: endpoints, schemas), `cf`, `vr`, `gw` |
+| ReviewExtension | `review-extension.schema.json` | code-reviewer → developer | `rd` (review_data: verdict, findings[], blast_radius), `ri` |
+
+### 5.4 `schemas/handoffs/ideation-output.schema.json` (Existierend)
+
+**Zweck:** Strukturiertes Payload-Schema für den Handoff von `ideation` → `requirements`. **Bleibt unverändert** — wird als `payload` in A2A-Envelope eingebettet. **Hinweis:** Dieses Schema hat noch lange Feldnamen. Neue Instanzen sollen stattdessen TaskSpec + IdeationExtension mit `compact_mode: true` nutzen.
+
+**Required Fields:** `core_idea`, `goal`, `preliminary_requirements[]`, `scope_v1{in_scope[], out_of_scope[]}`
+
+### 5.5 `schemas/se-decomposition.schema.json` (Existierend)
+
+**Version:** Draft-07 JSON Schema
+**Zweck:** Strukturiertes Output-Schema für generische L1-L3 Layer, CQRS-Events und SE-Agent-Konzept rekursive Zell-Outputs. **Bleibt unverändert** — wird als `payload` in A2A-Envelope eingebettet. `compact_mode: false` (lange Feldnamen erhalten).
 
 **Top-Level Required Fields:**
 - `feature_id` (string) — Eindeutige Feature-ID
@@ -459,27 +530,9 @@ Die Provider-Expert-Agenten wurden in v0.55.0 eingeführt und bieten Provider-sp
 - `l3_components` (array) — `[{component_id, description, refines}]`
 - `cqrs_interfaces` (object) — `{commands[], events[], queries[]}`
 
-**Optionale Felder (Agent-spezifisch):**
+### 5.6 `schemas/se-orchestrator.schema.json` (Existierend)
 
-| Feld | Agent | Typ | Beschreibung |
-|------|-------|-----|-------------|
-| `parent_req_id` | Architect | string | Parent-REQ-ID dieser Dekomposition |
-| `sub_components[]` | Architect | array | Sub-Komponenten mit ID, Name, Domain, BB-REQ |
-| `internal_interfaces[]` | Architect/IFM | array | Interne Interfaces (source, target, type, payload) |
-| `propagation_map` | IFM | object | Per-Component Interface-Mapping |
-| `architectural_rationale` | Architect | string | Begründung der Architekturentscheidungen |
-| `decomposition_completeness` | Architect | string | Vollständigkeitsbestätigung |
-| `termination_decisions[]` | Termination | array | Leaf/Continue pro Komponente |
-| `termination_summary` | Termination | object | Statistik (total, leaf, continue, depth) |
-| `critic_status` | Critic | object | Quality Gate (status, checks, hints, iteration) |
-
-**CQRS-Interface-Struktur:**
-- `commands[]` — `{name, source, target, payload}`
-- `events[]` — `{name, source, payload}`
-- `queries[]` — `{name, source, target, return_type}`
-
-**Definitionen:**
-- `checkResult` — `{passed: boolean, issues: string[]}`
+**Zweck:** Orchestrierungs-Metadaten vom se-orchestrator. **Bleibt unverändert** — wird als `payload` in A2A-Envelope eingebettet.
 
 ---
 
@@ -776,6 +829,121 @@ content = pal_engine.apply(content, provider)
 _inject_gemini_bootstrap(provider, target_dir, ...)  # Gemini: GEMINI.md
 BootstrapEngine.run_bootstrap(...)                    # Continue: config.yaml
 ```
+
+---
+
+---
+
+## 10. A2A-Handoff-Protokoll
+
+> **Status:** Konzept v2.0 — Implementation-nah (Phase 1 abgeschlossen)
+> **Basiert auf:** [GitHub Issue #212](https://github.com/Popoboxxo/agent-meta/issues/212) — W3C ANP White Paper
+> **Dokument:** `docs/concepts/a2a-handoff-protocol.md`
+> **Analyse:** `docs/concepts/a2a-best-practice-analysis.md`
+
+### 10.1 Prinzip: A2A als EINZIGES Format
+
+**A2A-Envelopes sind das einzige Format für Agent-zu-Agent-Daten.** Natural-Language-Prompts zwischen Agenten werden vollständig durch strukturierte Envelopes ersetzt. Dies eliminiert Context Loss, ermöglicht deterministische Validierung und schafft lückenloses Supersession-Tracking.
+
+Ausnahme: Continue/Copilot (`structured_handoff: false`) erhalten einen YAML-Text-Block statt JSON — identisches Konzept, anderes Transport-Format.
+
+### 10.2 Kernkonzepte
+
+| Konzept | Beschreibung |
+|---------|-------------|
+| **A2A-Envelope** | Standardisierter JSON-Wrapper mit Metadaten — das **einzige** Austauschformat |
+| **TaskSpec** | Universelles Kern-Payload-Schema für 60-80% aller Delegationen (kurze Feldnamen) |
+| **Extensions** | 4 domain-spezifische Erweiterungen zu TaskSpec (Ideation, Design, API, Review) |
+| **compact_mode** | Envelope-Flag: `true` = kurze Payload-Namen (Token-sparend), `false` = lesbare Namen |
+| **Supersession** | Version-Tracking mit `history[]`-Array für vollständige Revisionsketten |
+| **Contract** | Jede Route deklariert Schema + Extension + compact_mode in der Routing-Tabelle |
+
+### 10.3 A2A vs. viz-Debug — Separate Konzepte
+
+Das A2A-Protokoll und der viz-Handshake sind **separate Systeme** mit loser Kopplung:
+
+| Ebene | System | ID | Default | Token-Kosten |
+|-------|--------|-----|---------|-------------|
+| **Data Contract Layer** | A2A-Envelope | `handoff_id` | **Immer aktiv** | Envelope-Overhead (~60 Tokens) |
+| **Operational Layer** | viz-Handshake | `viz_task_id` | Aktiv (basic) | 0 (MCP-basiert) |
+| **Debug-Ebene** | viz A2A-Events | `viz_task_id` | **AUS** (`viz.debug: false`) | 0 Tokens |
+
+**Lose Kopplung via `trace_context.viz_task_id`** — das einzige Feld das beide Systeme verbindet. Der A2A-Envelope funktioniert vollständig ohne viz, und viz funktioniert ohne A2A.
+
+### 10.4 Schema-Strategie: 1 Core + 4 Extensions + 1 SE
+
+```
+schemas/handoffs/
+├── task-spec.schema.json              ← Core (60-80% Abdeckung)
+├── ext/
+│   ├── ideation-extension.schema.json  ← ideation → requirements
+│   ├── design-extension.schema.json    ← ui-ux-designer → developer
+│   ├── api-extension.schema.json       ← api-specialist → developer
+│   └── review-extension.schema.json    ← code-reviewer → developer
+└── (se-decomposition.schema.json)      ← SE-Kaskade (existierend, unverändert)
+```
+
+Reduziert die Schema-Anzahl von 19 auf 6 (84% Routen-Abdeckung mit Core + Extensions).
+
+### 10.5 Orchestrator als Envelope-Fabrik
+
+Der Orchestrator ist der primäre Envelope-Produzent:
+
+| Orchestrator-Funktion | A2A-Rolle |
+|-----------------------|-----------|
+| Intent-Routing | Bestimmt `target_agent` + `schema_ref` + `compact_mode` aus Routing-Tabelle |
+| FANOUT | Produziert N parallele Envelopes mit gemeinsamem `trace_context.trace_id` |
+| BARRIER | Konsumiert Response-Envelopes, aggregiert Ergebnisse |
+| PIPELINE | Verkettet Envelopes via `trace_parent` |
+| REPEAT_UNTIL | Managed Supersession-Ketten via `supersession.history[]` |
+
+### 10.6 Provider-Matrix: Transport-Format
+
+| Provider | structured_handoff | handoff_format | Envelope-Transport |
+|----------|-------------------|----------------|-------------------|
+| Claude | `true` | `json` | JSON im Task-Tool-Prompt |
+| Opencode | `true` | `json` | JSON im task()-Prompt |
+| Gemini | `true` | `json` | JSON im define_subagent-Prompt |
+| Continue | `false` | `yaml_text_block` | YAML-Block im Prompt-Text |
+| Copilot | `false` | `yaml_text_block` | YAML-Block im Prompt-Text |
+
+### 10.7 Token-Budget & Optimierungen
+
+| Optimierung | Ersparnis | Status |
+|-------------|-----------|--------|
+| Kurze Payload-Feldnamen (TaskSpec + Extensions) | 20–50 Tokens/Handoff | ✓ Umgesetzt |
+| `schema_ref` optional (implizit aus Route) | ~20 Tokens | ✓ Im Schema |
+| `protocol_version` default = aktuell | ~9 Tokens | ✓ Konvention |
+| `compact_mode`-Flag zur Steuerung | — (schaltet #1) | ✓ Im Envelope |
+| viz.debug: false (default) | 30 Tokens/Handoff | ✓ In Config |
+
+### 10.8 Betroffene Artefakte
+
+| Artefakt | Änderung | Status |
+|----------|----------|--------|
+| `schemas/a2a-handoff.schema.json` | Envelope: `compact_mode`, `supersession.history[]` | ✓ Phase 1 |
+| `schemas/handoffs/task-spec.schema.json` | Universelles Kern-Payload (NEU) | ✓ Phase 1 |
+| `schemas/handoffs/ext/*.schema.json` | 4 Extensions (NEU) | ✓ Phase 1 |
+| `schemas/se-decomposition.schema.json` | **Unverändert** — in Envelope eingebettet | — |
+| `schemas/se-orchestrator.schema.json` | **Unverändert** — in Envelope eingebettet | — |
+| `.meta-config/project.yaml` | `orchestrator.handoff` + `viz.debug` + `viz.a2a_events` | ✓ Phase 1 |
+| `docs/concepts/a2a-handoff-protocol.md` | Implementation-nahes Konzept (v2.0) | ✓ Phase 1 |
+| `docs/CODEBASE_OVERVIEW.md` | Abschnitte 5 + 10 aktualisiert | ✓ Phase 1 |
+| `config/delegation-syntax.yaml` | `{{PAL_HANDOFF}}` Platzhalter | Phase 2 |
+| `config/provider-capabilities.yaml` | `structured_handoff` + `handoff_format` Flags | Phase 2 |
+| `scripts/lib/delegation_syntax.py` | `PLACEHOLDERS` um `PAL_HANDOFF` erweitern | Phase 2 |
+| `agents/1-generic/orchestrator.md` | Handoff-Routing-Tabelle + Envelope-Fabrik | Phase 3 |
+| `agents/1-generic/se-*.md` | Envelope-basierte Handoffs in SE-Kaskade | Phase 3 |
+| `scripts/viz-logger.py` | A2A-Events hinter `viz.debug`-Flag | Phase 4 |
+
+### 10.9 Roadmap
+
+| Phase | Inhalt | Status |
+|-------|--------|--------|
+| 1 — Konzept + Schemas | Core-Schema + 4 Extensions + Envelope-Anpassungen + Config + Doku | ✓ Abgeschlossen |
+| 2 — Provider-Capabilities | `{{PAL_HANDOFF}}`-Platzhalter + `structured_handoff`-Flags + delegation-syntax.yaml | Geplant |
+| 3 — Agent-Updates | Orchestrator-Envelope-Fabrik + ideation, feature, developer, SE-Agenten | Geplant |
+| 4 — MCP & Tooling | MCP-Tools (resolve-handoff-schema, validate-handoff) + viz-Integration | Geplant |
 
 ---
 

--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -1,6 +1,6 @@
 # CODEBASE_OVERVIEW — agent-meta
 
-> Letzte Aktualisierung: 2026-06-07
+> Letzte Aktualisierung: 2026-06-07 (A2A-Status auf Vollständig aktualisiert)
 
 ---
 
@@ -836,7 +836,7 @@ BootstrapEngine.run_bootstrap(...)                    # Continue: config.yaml
 
 ## 10. A2A-Handoff-Protokoll
 
-> **Status:** Konzept v2.0 — Implementation-nah (Phase 1 abgeschlossen)
+> **Status:** Vollständig implementiert (Phasen 1–4) — 22 Dateien, 818 Zeilen
 > **Basiert auf:** [GitHub Issue #212](https://github.com/Popoboxxo/agent-meta/issues/212) — W3C ANP White Paper
 > **Dokument:** `docs/concepts/a2a-handoff-protocol.md`
 > **Analyse:** `docs/concepts/a2a-best-practice-analysis.md`
@@ -921,29 +921,59 @@ Der Orchestrator ist der primäre Envelope-Produzent:
 
 | Artefakt | Änderung | Status |
 |----------|----------|--------|
-| `schemas/a2a-handoff.schema.json` | Envelope: `compact_mode`, `supersession.history[]` | ✓ Phase 1 |
-| `schemas/handoffs/task-spec.schema.json` | Universelles Kern-Payload (NEU) | ✓ Phase 1 |
-| `schemas/handoffs/ext/*.schema.json` | 4 Extensions (NEU) | ✓ Phase 1 |
+| `schemas/a2a-handoff.schema.json` | Envelope: `batch`, `retry_count`, `requires_human_approval`, `negotiated_format`, `supersession.history[]` | ✓ Phase 1 |
+| `schemas/handoffs/task-spec.schema.json` | Universelles Kern-Payload (NEU) — kurze Feldnamen | ✓ Phase 1 |
+| `schemas/handoffs/ext/*.schema.json` | 4 Extensions (NEU): Ideation, Design, API, Review | ✓ Phase 1 |
 | `schemas/se-decomposition.schema.json` | **Unverändert** — in Envelope eingebettet | — |
 | `schemas/se-orchestrator.schema.json` | **Unverändert** — in Envelope eingebettet | — |
-| `.meta-config/project.yaml` | `orchestrator.handoff` + `viz.debug` + `viz.a2a_events` | ✓ Phase 1 |
-| `docs/concepts/a2a-handoff-protocol.md` | Implementation-nahes Konzept (v2.0) | ✓ Phase 1 |
+| `.meta-config/project.yaml` | `orchestrator.handoff`-Block + `viz.debug` + `viz.a2a_events` | ✓ Phase 1 |
+| `docs/concepts/a2a-handoff-protocol.md` | Implementation-nahes Konzept (v2.0, 872 Zeilen) | ✓ Phase 1 |
 | `docs/CODEBASE_OVERVIEW.md` | Abschnitte 5 + 10 aktualisiert | ✓ Phase 1 |
-| `config/delegation-syntax.yaml` | `{{PAL_HANDOFF}}` Platzhalter | Phase 2 |
-| `config/provider-capabilities.yaml` | `structured_handoff` + `handoff_format` Flags | Phase 2 |
-| `scripts/lib/delegation_syntax.py` | `PLACEHOLDERS` um `PAL_HANDOFF` erweitern | Phase 2 |
-| `agents/1-generic/orchestrator.md` | Handoff-Routing-Tabelle + Envelope-Fabrik | Phase 3 |
-| `agents/1-generic/se-*.md` | Envelope-basierte Handoffs in SE-Kaskade | Phase 3 |
-| `scripts/viz-logger.py` | A2A-Events hinter `viz.debug`-Flag | Phase 4 |
+| `config/delegation-syntax.yaml` | `handoff:`-Block für alle 5 Provider (JSON + YAML-Fallback) | ✓ Phase 2 |
+| `config/provider-capabilities.yaml` | `structured_handoff` + `handoff_format` + `handoff_envelope_support` Flags | ✓ Phase 2 |
+| `scripts/lib/delegation_syntax.py` | `PLACEHOLDERS` um `PAL_HANDOFF` erweitert | ✓ Phase 2 |
+| `config/role-defaults.yaml` | 16 Rollen-Contracts: `input_contracts`, `output_contract`, `input_schema`, `output_schema`, `target_roles` | ✓ Phase 3 |
+| `agents/1-generic/orchestrator.md` | Handoff-Routing-Tabelle + Envelope-Fabrik + Supersession-Tracking | ✓ Phase 3 |
+| `agents/1-generic/ideation.md` | Envelope-basierte Handoffs | ✓ Phase 3 |
+| `agents/1-generic/feature.md` | A2A-Handoff-Integration | ✓ Phase 3 |
+| `agents/1-generic/developer.md` | A2A-Envelope-Consumer | ✓ Phase 3 |
+| `agents/1-generic/se-*.md` | Envelope-basierte Handoffs in SE-Kaskade (6 Agenten) | ✓ Phase 3 |
+| `config/mcp-registry.yaml` | `a2a-handoff` MCP-Server: `validate_handoff`, `resolve_handoff_schema`, `resolve_handoff` | ✓ Phase 4 |
+| `scripts/lib/viz.py` | A2A-Events in `inject_viz_prompt_block()` hinter `viz.debug`-Flag | ✓ Phase 4 |
 
 ### 10.9 Roadmap
 
 | Phase | Inhalt | Status |
 |-------|--------|--------|
 | 1 — Konzept + Schemas | Core-Schema + 4 Extensions + Envelope-Anpassungen + Config + Doku | ✓ Abgeschlossen |
-| 2 — Provider-Capabilities | `{{PAL_HANDOFF}}`-Platzhalter + `structured_handoff`-Flags + delegation-syntax.yaml | Geplant |
-| 3 — Agent-Updates | Orchestrator-Envelope-Fabrik + ideation, feature, developer, SE-Agenten | Geplant |
-| 4 — MCP & Tooling | MCP-Tools (resolve-handoff-schema, validate-handoff) + viz-Integration | Geplant |
+| 2 — Provider-Capabilities | `{{PAL_HANDOFF}}`-Platzhalter + `structured_handoff`-Flags + delegation-syntax.yaml | ✓ Abgeschlossen |
+| 3 — Agent-Updates | Orchestrator-Envelope-Fabrik + handoff-Contracts + ideation, feature, developer, SE-Agenten | ✓ Abgeschlossen |
+| 4 — MCP & Tooling | MCP-Tools (resolve-handoff-schema, validate-handoff, resolve-handoff) + viz-Integration | ✓ Abgeschlossen |
+
+### 10.10 Handoff-Contracts in `config/role-defaults.yaml`
+
+16 Rollen deklarieren A2A-Handoff-Contracts in ihrer `handoff:`-Sektion:
+
+| Rolle | input_contracts | output_contract | target_roles | output_schema |
+|-------|----------------|-----------------|--------------|---------------|
+| **orchestrator** | — | `task-spec-v1` | — | — |
+| **developer** | `task-spec-v1` | `dev-result-v1` | — | — |
+| **requirements** | `ideation-output-v1, task-spec-v1` | `req-output-v1` | developer, tester | — |
+| **ideation** | — | `ideation-output-v1` | requirements | `ext/ideation-extension.schema.json` |
+| **feature** | `task-spec-v1` | `feature-result-v1` | — | — |
+| **tester** | `task-spec-v1, req-output-v1` | `test-result-v1` | — | — |
+| **validator** | `task-spec-v1, dev-result-v1` | — | — | `a2a-handoff.schema.json` |
+| **code-reviewer** | `dev-result-v1` | `review-output-v1` | developer | `ext/review-extension.schema.json` |
+| **ui-ux-designer** | — | `design-spec-v1` | developer | `ext/design-extension.schema.json` |
+| **api-specialist** | — | `api-spec-v1` | developer | `ext/api-extension.schema.json` |
+| **se-requirements** | `task-spec-v1` | `se-req-output-v1` | se-critic | — |
+| **se-architect** | `task-spec-v1` | `se-arch-output-v1` | se-critic | `se-decomposition.schema.json` |
+| **se-critic** | `se-arch-output-v1` | `critic-result-v1` | se-architect, se-interface-mgr | — |
+| **se-interface-mgr** | `critic-result-v1` | `interface-result-v1` | se-termination | — |
+| **se-termination** | `interface-result-v1` | `termination-result-v1` | — | — |
+| **se-orchestrator** | `task-spec-v1` | `task-spec-v1` | se-architect, se-requirements | — |
+
+Die `input_schema`- und `output_schema`-Felder referenzieren JSON-Schemas für optionale Schema-Validierung vor/nach Delegation. `target_roles` deklariert die typischen Empfänger — der Orchestrator nutzt dies für dynamisches Routing.
 
 ---
 

--- a/docs/architecture/07-se-cascade.md
+++ b/docs/architecture/07-se-cascade.md
@@ -271,6 +271,137 @@ variables:
 
 ---
 
+---
+
+## A2A-Handoff-Protokoll für die SE-Kaskade
+
+> Referenz: `docs/concepts/a2a-handoff-protocol.md` (v2.0) | Schema: `schemas/a2a-handoff.schema.json` | Analyse: `docs/concepts/a2a-best-practice-analysis.md`
+
+### A2A als EINZIGES Format
+
+Die SE-Kaskade nutzt **ausschließlich** A2A-Envelopes für Agent-zu-Agent-Übergaben. Die existierenden SE-Schemas (`se-decomposition.schema.json`, `se-orchestrator.schema.json`) bleiben **unverändert** und werden als `payload` in den Envelope eingebettet.
+
+**SE-Schemas laufen mit `compact_mode: false`** — die langen, lesbaren Feldnamen bleiben erhalten, da die SE-Kaskade strukturreiche Payloads mit vielen semantischen Feldnamen hat und ein Breaking Change der SE-Schemas nicht gerechtfertigt ist.
+
+### viz-Debug als separates Konzept
+
+Der viz-Handshake (`scripts/viz-logger.py`) trackt die **Ausführung** (Operational Layer), der A2A-Envelope trägt die **Datenverträge** (Data Contract Layer). A2A-Events werden **nur** bei `viz.debug: true` geloggt (default: `false` → Null-Token-Kosten im Produktivbetrieb).
+
+Die lose Kopplung erfolgt ausschließlich über `trace_context.viz_task_id` im Envelope.
+
+### Envelope-Beispiel: se-architect → se-critic
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-025",
+  "source_agent": "se-architect",
+  "target_agent": "se-critic",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "compact_mode": false,
+  "payload": {
+    "feature_id": "REQ-L1-SH-001",
+    "stakeholder_requirement": "Das System soll 500ml Wasser in 120s auf 90°C erhitzen.",
+    "sub_components": [
+      {
+        "id": "COMP-001-01",
+        "name": "Heizelement-Steuerung",
+        "domain": "hardware",
+        "black_box_requirement": "Das Heizelement soll 500ml Wasser von 10°C auf 90°C in max. 120s erhitzen."
+      }
+    ],
+    "internal_interfaces": [
+      {
+        "source_id": "COMP-001-02",
+        "target_id": "COMP-001-01",
+        "interface_type": "analog_signal",
+        "data_payload": "PWM control signal 0-100%, 5V logic level"
+      }
+    ],
+    "architectural_rationale": "Heizelement und Temperatursensor als separate Komponenten für Testbarkeit.",
+    "decomposition_completeness": "Alle L1-Anforderungen durch Sub-Komponenten abgedeckt."
+  },
+  "trace_parent": "HOFF-20260607-024"
+}
+```
+
+### Handoff-Routen in der SE-Kaskade
+
+| Route | Contract | Payload-Schema | compact_mode |
+|-------|----------|---------------|-------------|
+| `se-orchestrator → se-requirements` | `se-req-input-v1` | `schemas/se-decomposition.schema.json` | `false` |
+| `se-requirements → se-architect` | `se-req-output-v1` | `schemas/se-decomposition.schema.json` | `false` |
+| `se-architect → se-critic` | `se-arch-output-v1` | `schemas/se-decomposition.schema.json` | `false` |
+| `se-critic → se-architect` | `se-critic-reject-v1` | `schemas/se-decomposition.schema.json` | `false` |
+| `se-critic → se-interface-mgr` | `se-critic-approve-v1` | `schemas/se-decomposition.schema.json` | `false` |
+| `se-interface-mgr → se-termination` | `se-ifm-output-v1` | `schemas/se-decomposition.schema.json` | `false` |
+| `se-termination → se-orchestrator` | `se-term-output-v1` | `schemas/se-decomposition.schema.json` | `false` |
+
+**Alle 7 SE-Routen nutzen dasselbe Payload-Schema** (`se-decomposition.schema.json`) — die SE-Agenten füllen jeweils die für sie relevanten optionalen Felder (architect: `sub_components[]`, critic: `critic_status`, ifm: `propagation_map`, termination: `termination_decisions[]`).
+
+### Supersession in der Critic-Korrekturschleife
+
+Der Critic-Zyklus (architect → critic → architect → ...) nutzt Supersession mit vollständiger `history[]`:
+
+```
+HOFF-020: se-architect → se-critic  (v1, initial)
+  → critic rejected: "missing traceability for COMP-001-03"
+
+HOFF-021: se-architect → se-critic  (v2, supersedes: HOFF-020, history: [HOFF-020])
+  → critic rejected: "interface type mismatch"
+
+HOFF-022: se-architect → se-critic  (v3, supersedes: HOFF-021, history: [HOFF-020, HOFF-021])
+  → critic approved ✓
+
+HOFF-023: se-critic → se-interface-mgr
+  (supersession: { version: 3, supersedes: "HOFF-022", history: ["HOFF-020","HOFF-021","HOFF-022"] })
+```
+
+Der `se-interface-mgr` erhält die vollständige Revisionshistorie via `history[]`-Array und kann jede Iteration nachvollziehen.
+
+### Abbruchbedingung (MAX_CRITIC_ITERATIONS)
+
+Wenn `MAX_CRITIC_ITERATIONS` (default: 3) erreicht ist → `critic_status.status: "blocked"` → Eskalation an `se-orchestrator` mit `supersession.history[]` + Begründung. Kein weiterer Handoff — der `se-orchestrator` entscheidet über Eskalation oder Abbruch.
+
+### Validierungsgrenzen
+
+Jeder Handoff wird **vor** dem Delegieren gegen das Ziel-Schema validiert. Fehlschläge brechen den Handoff ab:
+
+```mermaid
+graph LR
+    subgraph "Data Contract Layer (A2A-Envelope)"
+        V1["Validierung gegen schema_ref"]
+        V2["Validierung gegen target.input_schema"]
+    end
+
+    ARCH -->|"Envelope + Payload"| V1
+    V1 -->|valid| CRIT
+    V1 -->|invalid| ARCH
+
+    CRIT -->|"Response Envelope"| V2
+    V2 -->|valid| ARCH
+    V2 -->|invalid| CRIT
+```
+
+**Regel:** Kein "lost in translation" — invalide Handoffs werden sofort abgewiesen, bevor der downstream-Agent startet.
+
+### A2A + viz-Handshake — parallele Tracking-Ebenen
+
+```
+se-orchestrator → viz: delegate_out(target=se-architect, task_id=uuid-X)
+                 → A2A: handoff_id=HOFF-X, viz_task_id=uuid-X (lose Kopplung)
+
+se-architect    → viz: agent_start(caller=se-orchestrator, task_id=uuid-X)
+                 → A2A: parst Envelope, validiert Payload
+                 → A2A: handoff_delivered(handoff_id=HOFF-X)
+
+se-architect    → viz: agent_end(status=success)
+```
+
+**Nur bei `viz.debug: true`** werden zusätzliche A2A-Events geloggt (`a2a_handoff_start`, `a2a_handoff_validated`, `a2a_handoff_delivered`, `a2a_handoff_failed`).
+
+---
+
 ## Export-Adapter (Zukunft)
 
 Der SE-Workflow ist tool-agnostisch. Phase 1 exportiert nach Markdown. Geplante Adapter:

--- a/docs/concepts/a2a-best-practice-analysis.md
+++ b/docs/concepts/a2a-best-practice-analysis.md
@@ -1,0 +1,614 @@
+# A2A Best Practice Analysis
+
+> Interne Analyse — Deutsch
+> Datum: 2026-06-07
+> Baut auf: [docs/concepts/a2a-handoff-protocol.md](a2a-handoff-protocol.md)
+> Status: Konzept-Ergänzung
+
+---
+
+## 1. Token-Effizienz
+
+### 1.1 Ist-Analyse: Token-Kosten des aktuellen Envelopes
+
+Der aktuelle Envelope (`schemas/a2a-handoff.schema.json`) hat 6 Pflichtfelder + 4 optionale Felder mit deskriptiven Namen. Ein typischer vollständiger Envelope (ohne Payload-Inhalt) kostet ca. **60–80 Tokens** (je nach Tokenizer, hier Schätzung auf Basis eines GPT-4o-ähnlichen BPE-Tokenizers mit ~3,5 Zeichen/Token im JSON-Kontext):
+
+| Feld | Lange Form | Chars | Tokens (ca.) |
+|------|-----------|-------|--------------|
+| `"protocol_version":"1.0.0"` | `"protocol_version":"1.0.0"` | 30 | 9 |
+| `"handoff_id":"HOFF-20260607-001"` | `"handoff_id":"HOFF-20260607-001"` | 37 | 11 |
+| `"source_agent":"ideation"` | `"source_agent":"ideation"` | 26 | 8 |
+| `"target_agent":"requirements"` | `"target_agent":"requirements"` | 32 | 9 |
+| `"schema_ref":"schemas/…json"` | (Wert ca. 50 Zeichen) | 68 | 20 |
+| `"payload":{}` | (leer) | 12 | 4 |
+| JSON-Struktur | `{`, `}`, `,`, `:` | 12 | 4 |
+| **Summe leerer Envelope** | | **~217** | **~65** |
+
+Bei einem nicht-leeren Payload (z.B. `ideation-output.schema.json` mit 3–5 Feldern) kommen **40–100 weitere Tokens** hinzu, je nach Umfang der übergebenen Daten. Ein realistischer Handoff liegt also bei **100–180 Tokens Overhead** (Envelope) plus Payload-Nutzdaten.
+
+> **Faustregel:** In einer durchschnittlichen Session mit 10–20 Delegationen kostet der Envelope-Overhead **650–3.600 Tokens** — das entspricht etwa dem Kontext eines mittelgroßen Agent-Templates.
+
+### 1.2 Minimale Envelope-Größe
+
+Ein auf das Nötigste reduzierter Envelope (nur 6 Pflichtfelder, leeres Payload, kurze Feldnamen):
+
+```json
+{"pv":"1.0.0","hid":"HOFF-20260607-001","src":"ideation","tgt":"reqs","sch":"schemas/handoffs/ideation-output.schema.json","pl":{}}
+```
+
+| Feld | Kurze Form | Chars | Tokens (ca.) |
+|------|-----------|-------|--------------|
+| `"pv":"1.0.0"` | `"pv":"1.0.0"` | 13 | 5 |
+| `"hid":"HOFF-20260607-001"` | `"hid":"HOFF-20260607-001"` | 28 | 9 |
+| `"src":"ideation"` | `"src":"ideation"` | 18 | 6 |
+| `"tgt":"reqs"` | `"tgt":"reqs"` | 12 | 5 |
+| `"sch":"schemas/…json"` | (Wert unverändert) | 58 | 18 |
+| `"pl":{}` | (leer) | 8 | 3 |
+| JSON-Struktur | | 12 | 4 |
+| **Summe minimierter Envelope** | | **~149** | **~50** |
+
+**Ersparnis: ~15 Tokens pro leerem Envelope (~23% Reduktion).** Bei Payload-gefüllten Handoffs relativiert sich die Ersparnis auf **10–15% der Gesamtgröße**, da die Nutzdaten den größten Token-Anteil ausmachen.
+
+### 1.3 Feldnamen: Kurz vs. Lesbar (Trade-off-Analyse)
+
+**Die Kernfrage:** Der aktuelle Envelope ist für **menschliche Lesbarkeit** optimiert. `protocol_version`, `handoff_id`, `source_agent`, `target_agent`, `schema_ref`, `payload` — jedes Feld erklärt sich selbst. Aber die primären Konsumenten sind **LLM-Agenten**. Ein LLM versteht `"pv":"1.0.0","hid":"HOFF-…","src":"ideation","tgt":"reqs"` ebenso sicher wie die Langform, sofern das Schema einmal erklärt wurde.
+
+| Dimension | Lange Namen | Kurze Namen |
+|-----------|-------------|-------------|
+| **LLM-Verständnis** | ✓ Kein Lookup nötig | ✓ Nach Schema-Einlesung gleichwertig |
+| **Menschliches Debugging** | ✓ Selbsterklärend | ✗ Benötigt Schema-Referenz |
+| **Token-Kosten** | ✗ 65 Tokens (leer) | ✓ 50 Tokens (leer) |
+| **Payload-Feldnamen** | ✗ `preliminary_requirements` (3 Tokens) | ✓ `preq` (1 Token) |
+| **Schema-Validierung** | ✓ Lesbare Fehlermeldungen | ✓ Via `title`/`description` im Schema |
+| **Breaking Change** | N/A | ✗ Alle existierenden Schemas müssen migriert werden |
+
+**Payload-Feldnamen sind der eigentliche Hebel.** Im Envelope selbst spart man pro Handoff ~15 Tokens. In den Payloads (mit 10–30 Feldern, z.B. `se-decomposition.schema.json` mit 317 Zeilen) liegt das Einsparpotenzial bei **50–150 Tokens pro Handoff**, weil semantisch reiche Feldnamen wie `preliminary_requirements`, `termination_decisions`, `architectural_rationale`, `decomposition_completeness` jeweils 2–4 Tokens kosten.
+
+**Empfehlung: Hybrid-Ansatz**
+1. **Envelope-Felder:** Beibehalten als lesbare Namen. Die Ersparnis von 15 Tokens pro Handoff rechtfertigt den Breaking Change nicht (alle existierenden Schemas, Templates, PAL-Syntax müssten umgestellt werden).
+2. **Payload-Felder ab v2:** Neue Payload-Schemas erhalten kurze, maschinenoptimierte Feldnamen (2–3 Zeichen) mit aussagekräftigem `title` und `description` fürs Debugging. Beispiel:
+
+```json
+// Statt:
+{"preliminary_requirements": [{"statement": "...", "priority": "mandatory"}]}
+
+// Künftig:
+{"preq": [{"st": "...", "pri": "m"}]}
+// Mit Schema: {"preq": {"title": "Preliminary Requirements", "items": {"properties": {"st": {"title": "Statement"}, "pri": {"title": "Priority", "enum": ["m","d","o"]}}}}}
+```
+
+3. **Debug-Mode:** Wenn `viz.debug: true` → Schema-Titel werden in Logs/Prompts aufgelöst, sodass Debugging menschenlesbar bleibt.
+
+### 1.4 JSON vs. kompaktere Formate
+
+**Option A — Standard-JSON (Status Quo):**
+```json
+{"protocol_version":"1.0.0","handoff_id":"HOFF-20260607-001","source_agent":"ideation","target_agent":"requirements","schema_ref":"schemas/…","payload":{}}
+```
+→ ~65 Tokens, universal verstanden, alle Provider unterstützen es nativ.
+
+**Option B — JSON-Array (positionsbasiert):**
+```json
+["1.0.0","HOFF-20260607-001","ideation","requirements","schemas/…",{}]
+```
+→ ~38 Tokens (41% Ersparnis). Aber: **Kein JSON Schema Draft-07 validierbar** (Arrays haben keine benannten Properties, JSON Schema validiert Arrays über `items`-Schema — das ist möglich, aber Selbstdokumentation geht verloren). Zudem für LLMs potenziell verwirrend: Position 0 = Version? Oder Position 5? Fehleranfällig.
+
+**Option C — YAML-Text-Block (für Continue/Copilot):**
+```yaml
+pv: "1.0.0"
+hid: "HOFF-20260607-001"
+src: "ideation"
+tgt: "requirements"
+sch: "schemas/…"
+pl: {}
+```
+→ ~25 Tokens (62% Ersparnis). YAML-Key-Value ohne JSON-Syntax-Overhead. Aber: **Nicht JSON-Schema-validierbar** ohne Konvertierung. Zwei Formate bedeuten doppelte Wartung.
+
+**Empfehlung:** JSON-Objekt beibehalten. Der Gewinn durch Array- oder YAML-Formate ist real, aber die Kosten (Validierungsverlust, Format-Dualität, LLM-Verwirrung bei positionalen Arrays) überwiegen. Stattdessen: **Kurze Feldnamen in Payload-Schemas** als primäre Optimierungsstrategie.
+
+### 1.5 Optimierungsvorschläge (Priorisiert)
+
+| # | Optimierung | Ersparnis pro Handoff | Aufwand | Risiko | Empfehlung |
+|---|-------------|----------------------|---------|--------|------------|
+| 1 | Kurze Payload-Feldnamen (neue Schemas) | 50–150 Tokens | Mittel (neue Schemas) | Gering (nur neue Schemas betroffen) | **Sofort umsetzen** |
+| 2 | `schema_ref` optional machen, wenn default via Route implizit | ~20 Tokens | Gering | Mittel (Default-Erkennung nötig) | Phase 2 prüfen |
+| 3 | `protocol_version` nur bei Major-Änderungen übertragen (default = aktuelle Version) | ~9 Tokens | Gering | Gering (Version im Schema implizit) | Phase 2 umsetzen |
+| 4 | Envelope-Feldnamen kürzen | ~15 Tokens | Hoch (Breaking Change) | Hoch (alle Schemas, Templates, PAL) | **Nicht empfohlen** — Payload-Fokus statt Envelope |
+| 5 | JSON-Array-Format | ~27 Tokens | Hoch | Hoch (Validierung, LLM-Verwirrung) | **Nicht empfohlen** |
+| 6 | Binäres/komprimiertes Format (MessagePack, CBOR) | 60–80% | Sehr hoch | Extrem (kein Provider-Support) | **Nicht empfohlen** |
+
+### 1.6 Faustregeln für Token-Budget
+
+| Szenario | Max. Envelope-Overhead | Begründung |
+|----------|----------------------|------------|
+| Einfacher Handoff (TaskSpec) | ≤50 Tokens | Kurzer Task, wenig Kontext |
+| Komplexer Handoff (SE-Decomposition) | ≤80 Tokens | Große Payloads, Overhead fällt weniger ins Gewicht |
+| Supersession-Handoff | +20 Tokens | Zusätzliche Metadaten (version, supersedes, reason) |
+| Debug-Mode (viz.debug: true) | +30 Tokens | trace_context, viz_task_id, metadata |
+
+**Zielwert Session:** Maximal 10% des Session-Token-Budgets für A2A-Overhead. Bei einer 200K-Token-Session mit 20 Handoffs → max. 1.000 Tokens pro Handoff (Envelope + Nutzdaten).
+
+---
+
+## 2. Schema-Strategie
+
+### 2.1 Standardisiertes Kern-Schema (TaskSpec)
+
+**Vorschlag:** Ein universelles Payload-Schema für 60–80% aller Handoff-Routen:
+
+```json
+{
+  "t": "Implementiere Login-Flow",          // task (string, required)
+  "ctx": "Bestehender Auth-Service nutzen", // context (string, optional)
+  "con": ["Muss OAuth2 unterstützen"],      // constraints (string[], optional)
+  "refs": ["schemas/auth-api.json"],        // references (string[], optional)
+  "pri": "high",                            // priority (enum: low|medium|high|critical)
+  "dep": ["HOFF-20260607-042"]             // depends_on (handoff_id[], optional)
+}
+```
+
+| Route | Passt in TaskSpec? | Fehlende Felder |
+|-------|-------------------|-----------------|
+| `ideation → requirements` | ⚠ Teilweise | `core_idea`, `goal`, `scope_v1` (braucht Erweiterung) |
+| `requirements → developer` | ✓ | — |
+| `requirements → se-architect` | ⚠ | SE-spezifische REQ-IDs |
+| `orchestrator → developer` | ✓ | — |
+| `feature → developer` | ✓ | — |
+| `feature → git` | ✓ | — |
+| `log-analyzer → feedback` | ✓ | — |
+| `bug-feature-analyzer → developer` | ✓ | — |
+| `bug-feature-analyzer → feature` | ✓ | — |
+| `ui-ux-designer → developer` | ⚠ | Design-Spezifikationen |
+| `api-specialist → developer` | ⚠ | API-Contract-Daten |
+| `code-reviewer → developer` | ⚠ | Review-Feedback-Struktur |
+| `se-orchestrator → se-requirements` | ✗ | SE-Stakeholder-REQs |
+| `se-requirements → se-architect` | ✗ | SE-Decomposition-Daten |
+| `se-architect → se-critic` | ✗ | SE-Decomposition-Daten |
+| `se-critic → se-architect` | ✗ | Critic-Status + Hints |
+| `se-critic → se-interface-mgr` | ✗ | SE-Decomposition-Daten |
+| `se-interface-mgr → se-termination` | ✗ | SE-Decomposition-Daten |
+| `se-termination → se-orchestrator` | ✗ | Termination-Decisions |
+
+### 2.2 Abdeckungsanalyse: 80/20-Regel
+
+| Kategorie | Routen | Anteil | Ansatz |
+|-----------|--------|--------|--------|
+| **TaskSpec-Delegation** (dev-ähnlich) | 8 | 42% | Reines TaskSpec |
+| **Erweitertes TaskSpec** (spezialisierte Worker) | 4 | 21% | TaskSpec + 1–3 domain-spezifische Felder |
+| **SE-Kaskade** (hochspezialisiert) | 7 | 37% | Eigenes Payload-Schema (SE-Decomposition) |
+
+**Erkenntnis:** 63% der Routen (12/19) können mit TaskSpec oder TaskSpec+Extensions abgedeckt werden. Die 80%-Marke wird knapp verfehlt, aber **TaskSpec + 4 Extensions deckt 84%** — eine lohnende Abstraktion.
+
+### 2.3 Per-Agent-Erweiterungen
+
+Statt 19 einzelner Payload-Schemas → **1 Kern-Schema + 5 Extensions:**
+
+```
+TaskSpec (Core)
+├── IdeationExtension    → ideation → requirements
+├── DesignExtension      → ui-ux-designer → developer
+├── APIExtension         → api-specialist → developer
+├── ReviewExtension      → code-reviewer → developer
+└── (SE-Decomposition)   → 7 SE-Routen (existierendes Schema bleibt)
+```
+
+**Extension-Mechanismus (analog zu JSON Schema `allOf`):**
+```json
+{
+  "allOf": [
+    {"$ref": "schemas/handoffs/task-spec.schema.json"},
+    {"$ref": "schemas/handoffs/ext/ideation.schema.json"}
+  ]
+}
+```
+
+Dieser Ansatz:
+- Reduziert Schema-Anzahl von 19 auf 6 (1 Core + 4 Extensions + 1 SE)
+- Ermöglicht Wiederverwendung der Basis-Validierung
+- Erlaubt agent-spezifische Felder ohne Schema-Duplizierung
+
+### 2.4 JSON Schema Draft-07 vs. Draft-2020-12
+
+| Feature | Draft-07 | Draft-2020-12 | agent-meta Relevanz |
+|---------|----------|---------------|---------------------|
+| `$ref` | ✓ | ✓ | Kritisch für Schema-Komposition |
+| `allOf`/`oneOf`/`anyOf` | ✓ | ✓ | Extension-Mechanismus |
+| `if`/`then`/`else` | ✓ | ✓ | Bedingte Validierung (supersession) |
+| `$dynamicRef` | ✗ | ✓ | Nicht benötigt |
+| `unevaluatedProperties` | ✗ | ✓ | Nützlich für "closed" Schemas |
+| `prefixItems` (typed arrays) | ✗ | ✓ | Nicht benötigt |
+| OpenAI `strict: true` | ✓ | ✗ | OpenAI unterstützt **nur** Draft-07 |
+
+**Empfehlung: Draft-07 beibehalten.**
+- OpenAI Structured Outputs (wichtigster Konsument für Validierung) unterstützt kein Draft-2020-12
+- Alle benötigten Features (`$ref`, `allOf`, `if/then/else`) sind in Draft-07 vorhanden
+- Kein Migrationsgrund erkennbar
+
+### 2.5 Empfehlung
+
+1. **TaskSpec als Kern-Schema definieren** (`schemas/handoffs/task-spec.schema.json`)
+2. **4 Extensions für spezialisierte Worker** (Ideation, Design, API, Review)
+3. **SE-Decomposition behalten** wie es ist — zu komplex für generisches Schema
+4. **Neue Schemas ab sofort mit kurzen Feldnamen** (2–3 Zeichen, `title` für Lesbarkeit)
+5. **Schema-Versionierung einführen:** `contract`-Feld in `role-defaults.yaml` schon existent → daraus `schema_ref` im Envelope ableiten
+
+---
+
+## 3. Orchestrator-Integration
+
+### 3.1 FANOUT + A2A
+
+**Szenario:** Orchestrator erkennt 3 unabhängige Bugfixes → FANOUT(3, developer, [Fix A, Fix B, Fix C])
+
+**A2A-Strategie:** Ein Envelope pro FANOUT-Kind.
+
+```
+orchestrator erstellt:
+  Envelope-1: {hid: "HOFF-001", src: "orchestrator", tgt: "developer", trace_parent: null, ...}
+  Envelope-2: {hid: "HOFF-002", src: "orchestrator", tgt: "developer", trace_parent: null, ...}
+  Envelope-3: {hid: "HOFF-003", src: "orchestrator", tgt: "developer", trace_parent: null, ...}
+```
+
+**Alle drei Envelopes** teilen dasselbe `trace_context.trace_id` (Session-Trace), aber haben unterschiedliche `handoff_id` und `trace_context.span_id`. Der Orchestrator selbst hat keinen `trace_parent` (er ist Wurzel).
+
+**Token-Impact:** 3 × ~65 Tokens = ~195 Tokens Envelope-Overhead für den FANOUT. Bei `MAX_PARALLEL_AGENTS=4` und Batching (z.B. 8 Tasks → 2 Batches à 4) sind es maximal 4 × 65 = 260 Tokens Overhead pro Batch.
+
+### 3.2 BARRIER + A2A
+
+**Szenario:** Nach FANOUT(3) sammelt der Orchestrator Ergebnisse via BARRIER.
+
+**A2A-Strategie:** Die Worker-Agenten produzieren jeweils einen **Response-Envelope** (optional, nur wenn `response_handoff: true` in `role-defaults.yaml`):
+
+```
+developer₁ → orchestrator:  Envelope mit Payload = {status: "success", commit: "abc123", changes: [...]}
+developer₂ → orchestrator:  Envelope mit Payload = {status: "success", commit: "def456", changes: [...]}
+developer₃ → orchestrator:  Envelope mit Payload = {status: "blocked", reason: "...", needs_clarification: true}
+```
+
+**Aggregation im Orchestrator:** Der Orchestrator erhält 3 Response-Envelopes, aggregiert sie in einem **Aggregations-Handoff** an sich selbst (oder direkt an den User-Report):
+
+```json
+{
+  "pv": "1.0.0",
+  "hid": "HOFF-AGG-001",
+  "src": "orchestrator",
+  "tgt": "orchestrator",  // Self-handoff für Aggregation
+  "sch": "schemas/handoffs/aggregation-result.schema.json",
+  "pl": {
+    "batch_id": "HOFF-001",
+    "results": [
+      {"handoff_id": "HOFF-001", "status": "success"},
+      {"handoff_id": "HOFF-002", "status": "success"},
+      {"handoff_id": "HOFF-003", "status": "blocked", "reason": "needs clarification"}
+    ]
+  }
+}
+```
+
+### 3.3 PIPELINE + A2A
+
+**Szenario:** `requirements → tester → developer → tester → validator → git` (Feature-Lifecycle)
+
+**A2A-Strategie:** Verkettete Envelopes via `trace_parent`:
+
+```
+HOFF-001: orchestrator → requirements  (trace_parent: null)
+HOFF-002: requirements → tester       (trace_parent: HOFF-001)
+HOFF-003: tester → developer          (trace_parent: HOFF-002)
+HOFF-004: developer → tester          (trace_parent: HOFF-003)
+HOFF-005: tester → validator          (trace_parent: HOFF-004)
+HOFF-006: validator → git             (trace_parent: HOFF-005)
+```
+
+Diese Kette ermöglicht lückenloses Tracing: Wenn HOFF-004 fehlschlägt, kann der Orchestrator die gesamte Kette bis HOFF-001 zurückverfolgen und den Fehlerkontext rekonstruieren.
+
+### 3.4 REPEAT_UNTIL + A2A
+
+**Szenario:** SE-Critic-Zyklus (architect → critic → architect → critic → … bis approved)
+
+**A2A-Strategie:** Supersession-Tracking via `supersedes`:
+
+```
+HOFF-010: se-architect → se-critic (v1, decomposition initial)
+  → critic rejected
+HOFF-011: se-architect → se-critic (v2, supersedes: HOFF-010, reason: "missing traceability")
+  → critic rejected again
+HOFF-012: se-architect → se-critic (v3, supersedes: HOFF-011, reason: "added traceability links")
+  → critic approved
+HOFF-013: se-critic → se-interface-mgr (supersession: [HOFF-010, HOFF-011, HOFF-012])
+```
+
+Der `se-interface-mgr` erhält die vollständige Revisionshistorie im `supersession`-Feld und kann nachvollziehen, welche Änderungen in welcher Iteration vorgenommen wurden. Dies ist bereits im Envelope-Schema vorgesehen (`supersession.version`, `supersession.supersedes`).
+
+**Abbruchbedingung:** Wenn `MAX_CRITIC_ITERATIONS` erreicht ist → `critic_status.blocked` → Eskalation an `se-orchestrator` mit `supersession`-Historie + Begründung.
+
+### 3.5 Orchestrator als Envelope-Produzent
+
+Der Orchestrator ist der **primäre Envelope-Produzent**. Seine Rolle im A2A-Protokoll:
+
+| Orchestrator-Funktion | A2A-Rolle |
+|-----------------------|-----------|
+| Intent-Routing | Bestimmt `target_agent` + `schema_ref`/`contract` aus Routing-Tabelle |
+| Task-Decomposition | Erzeugt separate Envelopes pro Sub-Task |
+| FANOUT | Produziert N parallele Envelopes mit gemeinsamem `trace_id` |
+| BARRIER | Konsumiert Response-Envelopes, aggregiert Ergebnisse |
+| PIPELINE | Verkettet Envelopes via `trace_parent` |
+| REPEAT_UNTIL | Managed Supersession-Ketten |
+| Unknown Intent | Erzeugt Meta-Feedback-Envelope (nicht A2A-format, sondern Issue) |
+
+**Konfiguration in `.meta-config/project.yaml`:**
+```yaml
+orchestrator:
+  handoff:
+    protocol: "a2a-v1"
+    validate-before-delegate: true    # Envelope-Validierung vor Delegation
+    supersession-tracking: true       # Supersession-Ketten aktiv
+    strict-validation: false          # true = Abbruch bei invaliden Handoffs
+    compact-mode: false               # true = kurze Payload-Feldnamen (Token-sparend)
+```
+
+---
+
+## 4. Altlasten-Migration
+
+### 4.1 Betroffene Schemas
+
+| Schema | Zeilen | Status | Migrationsansatz |
+|--------|--------|--------|------------------|
+| `schemas/se-decomposition.schema.json` | 317 | Existiert, aktiv genutzt | In A2A-Envelope einbetten (als Payload, unverändert) |
+| `schemas/se-orchestrator.schema.json` | 140 | Existiert, aktiv genutzt | In A2A-Envelope einbetten (als Payload, unverändert) |
+| `schemas/handoffs/ideation-output.schema.json` | 91 | Existiert, aktiv genutzt | In A2A-Envelope einbetten (bereits als erstes Payload-Schema vorgesehen) |
+| 16 weitere (Konzept) | — | Nur im Konzept | Direkt als A2A-Payload-Schemas anlegen |
+
+**Keines der existierenden Schemas muss geändert werden.** Der Migrationspfad ist rein additiv: Bestehendes Schema wird als `payload` in den A2A-Envelope eingebettet. Die Feldnamen bleiben erhalten, die Validierung bleibt identisch.
+
+### 4.2 Migrationspfad
+
+```
+Phase 1 (heute):           Agent produziert Natural-Language-Prompt
+                           → downstream-Agent parst semantisch
+
+Phase 2 (Migration):       Agent produziert A2A-Envelope {
+                             payload: <existierendes Schema unverändert>
+                           }
+                           → downstream-Agent parst envelope.payload
+
+Phase 3 (Optimierung):     Neue Payload-Schemas mit kurzen Feldnamen
+                           → downstream-Agent validiert gegen Schema
+```
+
+**Ablauf:**
+1. `schemas/a2a-handoff.schema.json` ist bereits definiert (Phase 2 abgeschlossen)
+2. `schemas/handoffs/ideation-output.schema.json` ist erstes Payload-Schema
+3. Bestehende SE-Schemas (`se-decomposition`, `se-orchestrator`) werden **unverändert** als Payloads verwendet
+4. Neue Routen erhalten neue Payload-Schemas (mit kurzen Feldnamen wo sinnvoll)
+
+### 4.3 Deprecation-Strategie
+
+**Keine Breaking Changes.** Das A2A-Protokoll wird **parallel** zum bestehenden Natural-Language-Prompt-System eingeführt:
+
+1. **Opt-in:** Agenten deklarieren in `role-defaults.yaml` ihre `handoff`-Contracts. Solange kein Contract deklariert ist, delegieren sie wie bisher per Natural-Language-Prompt.
+2. **Feature-Flag:** `orchestrator.handoff.protocol: "a2a-v1"` aktiviert das Protokoll. Bei `null` → Fallback auf Natural Language.
+3. **Graceful Fallback:** Wenn ein downstream-Agent keinen Envelope parsen kann → fällt auf Natural-Language-Parsing zurück (wie heute).
+
+```yaml
+# role-defaults.yaml
+roles:
+  ideation:
+    handoff:
+      enabled: true              # A2A-Handoff aktiv?
+      output_contract: "ideation-output-v1"
+      output_schema: "schemas/handoffs/ideation-output.schema.json"
+  git:
+    # Kein handoff: Abschnitt → kein A2A, Natural Language wie bisher
+```
+
+---
+
+## 5. Viz-Debug-Integration
+
+### 5.1 Zwei-Ebenen-Modell (Wiederholung aus a2a-handoff-protocol.md)
+
+| Ebene | System | Zweck | Tracking-ID | Event-Typen |
+|-------|--------|-------|-------------|-------------|
+| **Operational Layer** | viz-Handshake | *Dass* eine Delegation stattfand | `viz_task_id` | `agent_start`, `delegate_out`, `agent_end` |
+| **Data Contract Layer** | A2A-Envelope | *Was* wurde übergeben | `handoff_id` | `a2a_handoff_start`, `a2a_handoff_validated`, `a2a_handoff_delivered` |
+
+Die lose Kopplung erfolgt via `trace_context.viz_task_id` im A2A-Envelope.
+
+### 5.2 Debug-Mode Konfiguration
+
+```yaml
+# .meta-config/project.yaml
+viz:
+  debug: false          # true = A2A-Events in viz loggen
+  a2a_events:           # Welche A2A-Events loggen? (nur wenn debug: true)
+    handoff_start: true
+    handoff_validated: true
+    handoff_delivered: true
+    handoff_failed: true
+    supersession: true
+```
+
+**Default: `viz.debug: false`** — A2A-Events werden nicht geloggt (spart Tokens und Log-Zeilen). Nur bei aktiver Fehlersuche einschalten.
+
+### 5.3 A2A-Event-Typen
+
+| Event | Auslöser | Payload |
+|-------|----------|---------|
+| `a2a_handoff_start` | Envelope wird erstellt | `{handoff_id, source_agent, target_agent, contract}` |
+| `a2a_handoff_validated` | Validierung abgeschlossen | `{handoff_id, valid: bool, errors: [...]}` |
+| `a2a_handoff_delivered` | Downstream akzeptiert | `{handoff_id, status: accepted|rejected|superseded}` |
+| `a2a_handoff_failed` | Validierung fehlgeschlagen | `{handoff_id, errors: [...]}` |
+| `a2a_supersession` | Supersession erstellt | `{handoff_id, supersedes: handoff_id, reason}` |
+
+**Integration in viz-logger (MCP/CLI):**
+```bash
+# MCP (primär):
+log_viz_event --event a2a_handoff_start --task_id uuid-X \
+  --caller se-orchestrator --payload '{"handoff_id":"HOFF-001","contract":"se-arch-output-v1"}'
+
+# CLI (Fallback):
+python scripts/viz-logger.py --event a2a_handoff_validated \
+  --agent se-architect --provider Opencode --task_id uuid-X \
+  --caller se-orchestrator \
+  --payload '{"handoff_id":"HOFF-001","valid":true}'
+```
+
+### 5.4 Performance-Impact
+
+| Modus | Zusätzliche viz-Calls pro Handoff | Token-Impact (Prompt-Injection) | Log-Zeilen |
+|-------|----------------------------------|--------------------------------|------------|
+| `viz.debug: false` (Default) | 0 | 0 Tokens | 0 |
+| `viz.debug: true` | 3–5 | ~30 Tokens (Prompt-Block für Event-Instruktionen) | 3–5 pro Handoff |
+| `viz.debug: true` + `viz.a2a_events.supersession: true` | 3–5 + Supersession | ~30 Tokens | 4–6 pro Handoff |
+
+**Empfehlung:** Debug-Mode in Produktion deaktiviert lassen. Nur bei der Entwicklung neuer Handoff-Routen oder bei Fehlersuche in SE-Kaskaden einschalten.
+
+---
+
+## 6. Vergleich mit existierenden Systemen
+
+### 6.1 W3C ANP (Agent Network Protocol)
+
+**Status:** White Paper war zum Recherche-Zeitpunkt nicht mehr öffentlich verfügbar (URL führte zu 404).
+
+**Relevante Konzepte (aus Sekundärquellen):**
+- **Agent Discovery:** Agenten registrieren ihre Fähigkeiten in einem zentralen Verzeichnis
+- **Capability Negotiation:** Agenten handeln aus, welche Protokollversion sie sprechen
+- **Structured Messages:** Formale Nachrichtenformate mit Schema-Validierung
+
+**Abgleich mit agent-meta:**
+- Agent Discovery → `config/role-defaults.yaml` + `config/provider-capabilities.yaml` (statisch, nicht dynamisch)
+- Capability Negotiation → `handoff_format`-Flag (`json` vs. `yaml_text_block`) pro Provider
+- Structured Messages → A2A-Envelope + JSON Schema
+
+**Fazit:** agent-meta hat die ANP-Konzepte implizit übernommen, aber in einer statisch deklarierten Form (kein dynamisches Discovery). Für den agent-meta-Use-Case (bekannte Agenten-Rollen in einem Projekt) ist statische Deklaration ausreichend und effizienter.
+
+### 6.2 MCP (Model Context Protocol)
+
+**Status:** Aktiver, offener Standard von Anthropik. Primär für Tool-Integration zwischen LLM und externen Diensten.
+
+**Relevanz für agent-meta:**
+- **MCP-Server als Schema-Registry:** `resolve-handoff-schema` Tool (geplant in Phase 7)
+- **MCP-Server als Validator:** `validate-handoff` Tool (geplant in Phase 7)
+- **MCP-Server als Capability-Discovery:** `agent-meta-handoff` Tool (geplant)
+
+**Integrationstiefe:**
+```
+┌──────────────────────────────────────────┐
+│              agent-meta                    │
+│  ┌──────────────────────────────────────┐ │
+│  │  A2A-Envelope (JSON Schema Draft-07) │ │
+│  │  Payload-Schemas                     │ │
+│  │  Handoff-Routen                      │ │
+│  └──────────────┬───────────────────────┘ │
+│                 │                          │
+│  ┌──────────────▼───────────────────────┐ │
+│  │  MCP-Server (viz-logger.py)          │ │
+│  │  • log_viz_event (Operational)       │ │
+│  │  • resolve-handoff-schema (Phase 7)  │ │
+│  │  • validate-handoff (Phase 7)        │ │
+│  └──────────────────────────────────────┘ │
+└──────────────────────────────────────────┘
+```
+
+**Fazit:** MCP ist der natürliche Transport-Layer für Schema-Resolution und Validierung. Der existierende `viz-logger.py` MCP-Server ist bereits der Operational-Layer-Handshake. Die Erweiterung um Schema-Tools ist in Phase 7 der Roadmap vorgesehen.
+
+### 6.3 OpenAI Structured Outputs
+
+**Status:** Produktionsreif. JSON Schema Draft-07 mit `strict: true` Modus.
+
+**Relevante Merkmale:**
+- Garantiert 100% Schema-Adhärenz (kein "best effort")
+- `strict: true` erfordert: alle Properties in `required`, kein `additionalProperties: true` auf oberster Ebene
+- Pydantic/Zod SDK-Integration für Schema-Generierung
+- Nur Draft-07 (nicht 2020-12)
+
+**Abgleich mit agent-meta:**
+- agent-meta nutzt JSON Schema Draft-07 (Kompatibilität gegeben)
+- agent-meta's Envelope hat `"additionalProperties": false` implizit auf oberster Ebene (nur definierte Properties)
+- **Unterschied:** agent-meta's Envelopes werden von LLM-Agenten **produziert** (nicht via API `response_format`), daher keine `strict: true`-Garantie, sondern **Post-hoc-Validierung**
+
+**Fazit:** agent-meta sollte Draft-07 beibehalten (OpenAI-Kompatibilität). Der Validierungsansatz (Post-hoc statt API-native) ist dem agent-meta-Architekturmodell geschuldet (Agenten produzieren Envelopes als Teil ihres Outputs, nicht via Structured-Output-API).
+
+### 6.4 CrewAI / AutoGen / LangGraph
+
+| Framework | Handoff-Konzept | Format | Stärke | Schwäche |
+|-----------|----------------|--------|--------|----------|
+| **CrewAI** | Task-Delegation via Tool-Calls | Internes Objekt | Einfach, Python-nativ | Kein formales Schema, kein Supersession |
+| **AutoGen** | Agent-Chat (Message-basiert) | Dict/JSON | Multi-Agent-Konversationen | Kein standardisiertes Format |
+| **LangGraph** | State-Graph (Nodes + Edges) | Python-TypedDict | State-Management, Checkpoints | Kein standardisiertes Format |
+
+**agent-meta's Differenzierung:**
+- **Formaler als CrewAI/AutoGen:** JSON Schema + Validierung an jeder Grenze
+- **Provider-agnostischer als LangGraph:** Gleiches Protokoll auf Claude, Opencode, Gemini, Continue, Copilot
+- **Supersession-Tracking:** Keines der Frameworks hat ein vergleichbares Konzept
+- **Token-Effizienz:** Keines der Frameworks optimiert für LLM-Token-Kosten
+
+**Fazit:** agent-meta's A2A-Protokoll ist formaler und provider-agnostischer als die Konkurrenz. Der Preis dafür ist höhere Komplexität in der Schema-Pflege — die durch TaskSpec-Abstraktion reduziert werden kann.
+
+---
+
+## 7. Implementationsempfehlungen
+
+### 7.1 Phase 1: Sofort umsetzbar (Quick Wins)
+
+| # | Maßnahme | Aufwand | Impact | Risiko |
+|---|----------|---------|--------|--------|
+| 1 | **TaskSpec-Kern-Schema definieren** (`schemas/handoffs/task-spec.schema.json`) | 1 Tag | 63% Routen-Abdeckung | Gering |
+| 2 | **Kurze Feldnamen für neue Payload-Schemas** (Konvention im Team etablieren) | 0 Tage (Konvention) | 50–150 Tokens/Handoff | Gering |
+| 3 | **`orchestrator.handoff`-Config-Block** in `.meta-config/project.yaml` dokumentieren | 0,5 Tage | Klare Steuerung | Kein |
+| 4 | **Handoff-Routen-Tabelle** im Orchestrator-Template ergänzen | 0,5 Tage | Routing-Klarheit | Gering |
+| 5 | **Payload-Feldnamen-Checkliste** in `howto/` dokumentieren | 0,5 Tage | Konsistenz | Kein |
+
+### 7.2 Phase 2: Mittelfristig (1–2 Wochen)
+
+| # | Maßnahme | Aufwand | Impact | Risiko |
+|---|----------|---------|--------|--------|
+| 6 | **4 TaskSpec-Extensions implementieren** (Ideation, Design, API, Review) | 2 Tage | 84% Routen-Abdeckung | Gering |
+| 7 | **`{{PAL_HANDOFF}}`-Platzhalter** in `delegation-syntax.yaml` für alle 5 Provider | 1 Tag | Provider-agnostische Syntax | Mittel |
+| 8 | **Orchestrator-Integration:** FANOUT/BARRIER/PIPELINE mit A2A-Envelopes | 2 Tage | Tracking aller Delegationen | Mittel |
+| 9 | **`schema_ref` implizit aus Route ableiten** (optionales Feld im Envelope) | 0,5 Tage | ~20 Tokens/Handoff Ersparnis | Gering |
+| 10 | **A2A-Event-Typen** in `viz-logger.py` integrieren (hinter `viz.debug: true`) | 1 Tag | Debugging-Fähigkeit | Gering |
+
+### 7.3 Phase 3: Langfristig (Roadmap)
+
+| # | Maßnahme | Aufwand | Impact | Risiko |
+|---|----------|---------|--------|--------|
+| 11 | **MCP-Schema-Tools:** `resolve-handoff-schema`, `validate-handoff` | 2–3 Tage | Dynamische Validierung | Mittel |
+| 12 | **Response-Envelopes** (Worker → Orchestrator) standardisieren | 2 Tage | Geschlossener Feedback-Loop | Mittel |
+| 13 | **Token-Budget-Tracking** im Orchestrator (Session-weit) | 1 Tag | Kostenkontrolle | Gering |
+| 14 | **Payload-Kompression** (MessagePack/CBOR) für >10K Token Payloads | — | Nur bei Bedarf | Hoch |
+| 15 | **Handoff-Analytics-Dashboard** (viz-graph Erweiterung) | 3 Tage | Visuelles Tracking | Gering |
+
+### 7.4 Priorisierungs-Matrix
+
+```
+                    Hoch
+                     │
+        6,7,8        │  1,2,3,4,5
+        (Phase 2)    │  (Phase 1 — Quick Wins)
+                     │
+    Aufwand ─────────┼──────────→ Impact
+                     │
+        14,15        │  9,10,11,12,13
+        (Später)     │  (Phase 2/3)
+                     │
+                    Gering
+```
+
+**Zusammenfassung der Kern-Empfehlungen:**
+
+1. **Envelope-Feldnamen lang lassen** — Breaking Change lohnt nicht (15 Tokens Ersparnis vs. Migration aller Schemas)
+2. **Payload-Feldnamen kurz machen** — ab sofort für neue Schemas (50–150 Tokens Ersparnis pro Handoff, kein Breaking Change)
+3. **TaskSpec als universelles Kern-Schema** einführen — deckt 63% der Routen ab, mit 4 Extensions 84%
+4. **Draft-07 beibehalten** — OpenAI-Kompatibilität, alle benötigten Features vorhanden
+5. **Orchestrator als Envelope-Fabrik** — produziert, validiert, trackt alle Handoffs
+6. **Supersession als Killer-Feature** — kein anderes Framework hat vergleichbares Revision-Tracking
+7. **Debug-Mode optional** (`viz.debug: false` default) — keine Token-Kosten im Produktivbetrieb
+8. **Additive Migration** — existierende Schemas unverändert einbetten, keine Breaking Changes
+
+---
+
+> **Nächster Schritt:** Übergabe an `requirements`-Agenten für formale REQ-Erfassung der Phase-1-Maßnahmen.

--- a/docs/concepts/a2a-handoff-protocol.md
+++ b/docs/concepts/a2a-handoff-protocol.md
@@ -91,7 +91,7 @@ Schemas (6 total):
 
 ### 2.3 Extension-Mechanismus
 
-Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
+Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert. ABER: weder TaskSpec noch Extensions verwenden `additionalProperties: false` — dies verhindert `allOf`-Kombinierbarkeit (Draft-07 Fallstrick).
 
 ```json
 {
@@ -102,6 +102,8 @@ Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
 }
 ```
 
+Schema-Validierung für kombinierte Schemas erfolgt via `if-then` im Route-Registry-Schema — nicht via `allOf` + `additionalProperties: false`.
+
 **Konkretes Beispiel — ideation→requirements:**
 
 ```json
@@ -111,7 +113,6 @@ Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
   "source_agent": "ideation",
   "target_agent": "requirements",
   "schema_ref": "schemas/handoffs/task-spec.schema.json",
-  "compact_mode": true,
   "payload": {
     "t": "Dark-Mode-Toggle für Settings-Page entwickeln",
     "ctx": "Bestehende Theme-Infrastruktur nutzen",
@@ -137,7 +138,6 @@ Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
   "source_agent": "ui-ux-designer",
   "target_agent": "developer",
   "schema_ref": "schemas/handoffs/task-spec.schema.json",
-  "compact_mode": true,
   "payload": {
     "t": "Settings-Page mit Theme-Toggle implementieren",
     "ds": {
@@ -168,7 +168,6 @@ Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
   "source_agent": "api-specialist",
   "target_agent": "developer",
   "schema_ref": "schemas/handoffs/task-spec.schema.json",
-  "compact_mode": true,
   "payload": {
     "t": "User-Preferences-Endpunkt implementieren",
     "ct": {
@@ -205,7 +204,6 @@ Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
   "source_agent": "code-reviewer",
   "target_agent": "developer",
   "schema_ref": "schemas/handoffs/task-spec.schema.json",
-  "compact_mode": true,
   "payload": {
     "t": "ThemeToggle-Komponente überarbeiten — Review-Findings",
     "rd": {
@@ -249,7 +247,6 @@ Die SE-Kaskade nutzt weiterhin `se-decomposition.schema.json` — eingebettet al
   "source_agent": "se-architect",
   "target_agent": "se-critic",
   "schema_ref": "schemas/se-decomposition.schema.json",
-  "compact_mode": false,
   "payload": {
     "feature_id": "REQ-L1-SH-001",
     "stakeholder_requirement": "...",
@@ -267,7 +264,7 @@ Die SE-Kaskade nutzt weiterhin `se-decomposition.schema.json` — eingebettet al
 }
 ```
 
-**SE-Schemas sind `compact_mode: false`** — die langen Feldnamen bleiben erhalten (kein Breaking Change für existierende SE-Infrastruktur).
+**SE-Schemas verwenden `compact-mode: false` in der Build-Config** — die langen Feldnamen bleiben erhalten (kein Breaking Change für existierende SE-Infrastruktur).
 
 ---
 
@@ -282,20 +279,17 @@ Die SE-Kaskade nutzt weiterhin `se-decomposition.schema.json` — eingebettet al
   "source_agent": "orchestrator",
   "target_agent": "developer",
   "supersession": {
-    "version": 3,
     "supersedes": "HOFF-20260607-040",
     "history": ["HOFF-20260607-038", "HOFF-20260607-040"],
     "reason": "REQ-042 scope erweitert nach Stakeholder-Feedback",
     "timestamp": "2026-06-07T14:30:00Z"
   },
   "schema_ref": "schemas/handoffs/task-spec.schema.json",
-  "compact_mode": true,
   "payload": { "t": "...", "pri": "high" },
   "trace_parent": "HOFF-20260607-039",
   "trace_context": {
     "trace_id": "trace-abc123",
     "span_id": "span-042",
-    "parent_span_id": "span-039",
     "viz_task_id": "uuid-x-y-z"
   }
 }
@@ -309,20 +303,27 @@ Die SE-Kaskade nutzt weiterhin `se-decomposition.schema.json` — eingebettet al
 | `handoff_id` | HOFF-YYYYMMDD-NNN | ✓ | 4 | Globally unique. Format: HOFF-{date}-{seq} |
 | `source_agent` | string | ✓ | 3 | Rolle des sendenden Agenten |
 | `target_agent` | string | ✓ | 3 | Rolle des empfangenden Agenten |
-| `schema_ref` | string (URI) | — | 10 | Optional: aus Route implizit ableitbar |
-| `compact_mode` | boolean | — | 2 | true = kurze Payload-Namen (default: false) |
-| `payload` | object | ✓ | 2+ | Domain-spezifische Nutzdaten |
-| `trace_parent` | HOFF | — | 2 | Parent-handoff für Delegationsbaum |
-| `trace_context` | object | — | 5 | Erweitertes Tracing |
-| `supersession` | object | — | 5 | Version-Tracking |
-| `supersession.history[]` | HOFF[] | — | 2+/Eintrag | Vollständige Revisionskette |
+| `payload` | object \| array | ✓ | 2+ | Domain-spezifische Nutzdaten. Array wenn `batch: true`. |
+| `schema_ref` | string (URI) | — | 10 | Optional: wenn fehlt → implizit aus `source_agent` + `target_agent` via Routing-Tabelle aufgelöst |
+| `batch` | boolean | — | 2 | FANOUT-Modus: payload ist Array von Task-Objekten (default: false) |
+| `retry_count` | integer | — | 2 | Anzahl bisheriger Retries (default: 0). Bei ≥ `max_retries` → Abbruch |
+| `max_retries` | integer | — | 2 | Max. erlaubte Retries (default: 3). Config in project.yaml |
+| `requires_human_approval` | boolean | — | 2 | HITL: downstream-Agent pausiert vor Ausführung (default: false) |
+| `negotiated_format` | enum | — | 2 | Transport-Format: `json`, `yaml`, `text`, `auto` (default: `auto`) |
+| `trace_parent` | HOFF | — | 2 | Parent-handoff für Delegationsbaum. Einziger Parent-Tracing-Mechanismus |
+| `trace_context` | object | — | 5 | Erweitertes Tracing (trace_id, span_id, viz_task_id) |
+| `supersession` | object | — | 5 | Version-Tracking über history-Kette |
+| `supersession.history[]` | HOFF[] | — | 2+/Eintrag | Vollständige Revisionskette. `version = history.length + 1` |
 
 **Token-Budget (leerer Envelope ohne Payload):**
-- Mit `schema_ref` + `compact_mode` + `trace_parent`: ~60 Tokens
-- Minimal (nur Pflichtfelder, schema_ref implizit): ~40 Tokens
-- Mit Supersession (version + supersedes): +15 Tokens
+- Mit `schema_ref` + `trace_parent`: ~64 Tokens
+- Minimal (nur Pflichtfelder, schema_ref implizit): ~42 Tokens
+- Mit Supersession (supersedes + history): +12 Tokens
+- Mit Batch (3 Tasks): +25 Tokens
 
-### 3.3 compact_mode — Steuerung kurzer Feldnamen
+### 3.3 compact_mode — Build-Config, nicht Laufzeit-Konzept
+
+`compact_mode` steuert ob kurze (2-3 Zeichen) oder lange Payload-Feldnamen verwendet werden. Es ist ein **Build-Zeit-Konzept** — gesteuert in `.meta-config/project.yaml`, nicht im Envelope.
 
 | compact_mode | Payload-Feldnamen | Anwendung |
 |-------------|-------------------|-----------|
@@ -335,6 +336,8 @@ orchestrator:
   handoff:
     compact-mode: false   # true = Token-sparend im Produktivbetrieb
 ```
+
+> **Warum nicht im Envelope:** Der Envelope enthält keine Felder die zur Laufzeit zwischen `compact_mode: true` und `false` wechseln. Die Payload-Feldnamen sind Teil des Schemas das zur Build-Zeit ausgerollt wird. Ein Laufzeit-Flag würde nur verwirren — der downstream-Agent bekommt immer das Format das die Build-Config vorgibt.
 
 ---
 
@@ -373,6 +376,34 @@ Envelope-3: { hid: "HOFF-003", src: "orchestrator", tgt: "developer",
 ```
 
 **Token-Impact FANOUT:** N × ~60 Tokens Envelope-Overhead. Bei MAX_PARALLEL_AGENTS=4: 240 Tokens pro Batch.
+
+### 4.2a Batch-Mode — N Tasks in einem Envelope
+
+Für gleiche source/target-Paare (z.B. orchestrator→developer mit 3 Tasks) reduziert Batch-Mode
+den Envelope-Overhead drastisch:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-BATCH-001",
+  "source_agent": "orchestrator",
+  "target_agent": "developer",
+  "batch": true,
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": [
+    {"t": "Fix Login Bug", "pri": "high", "batch_task_id": "T1"},
+    {"t": "Add Logging", "pri": "medium", "batch_task_id": "T2"},
+    {"t": "Refactor Auth", "pri": "low", "batch_task_id": "T3"}
+  ]
+}
+```
+
+**Token-Vergleich Batch vs. Einzeln (3 Tasks):**
+- 3 separate Envelopes: 3 × ~60 = ~180 Tokens
+- 1 Batch-Envelope: ~70 Tokens
+- **Ersparnis: ~110 Tokens pro FANOUT(3)**
+
+**Regel:** Batch nur wenn `source_agent` und `target_agent` für alle Tasks identisch sind. Unterschiedliche Ziele → separate Envelopes.
 
 ### 4.3 BARRIER — Response-Envelopes aggregieren
 
@@ -431,24 +462,25 @@ Fehlschlag in HOFF-013 → Chain-of-custody bis HOFF-010 zurückverfolgbar.
 **Szenario:** SE-Critic-Zyklus (max. 3 Iterationen):
 
 ```
-HOFF-020: se-architect → se-critic  (v1, decomposition initial)
+HOFF-020: se-architect → se-critic  (history: [], version = 0 + 1 = 1)
   → critic rejected: "missing traceability for COMP-001-03"
 
-HOFF-021: se-architect → se-critic  (v2, supersedes: HOFF-020, history: [HOFF-020])
+HOFF-021: se-architect → se-critic  (supersedes: HOFF-020, history: [HOFF-020], version = 1 + 1 = 2)
   → critic rejected: "interface type mismatch: analog_signal vs REST"
 
-HOFF-022: se-architect → se-critic  (v3, supersedes: HOFF-021, history: [HOFF-020, HOFF-021])
+HOFF-022: se-architect → se-critic  (supersedes: HOFF-021, history: [HOFF-020, HOFF-021], version = 2 + 1 = 3)
   → critic approved ✓
 
 HOFF-023: se-critic → se-interface-mgr
-  (supersession: { version: 3, supersedes: "HOFF-022", history: ["HOFF-020","HOFF-021","HOFF-022"] })
+  (supersession: { supersedes: "HOFF-022", history: ["HOFF-020","HOFF-021","HOFF-022"] })
+  → version = history.length + 1 = 4
 ```
 
 Der `se-interface-mgr` sieht die vollständige Revisionskette und kann nachvollziehen, welche Änderungen in jeder Iteration vorgenommen wurden.
 
 ### 4.6 Orchestrator-Routing-Tabelle
 
-Jede Route deklariert Contract + Schema + compact_mode:
+Jede Route deklariert Contract + Schema:
 
 ```yaml
 # In config/role-defaults.yaml (pro Route erweiterbar):
@@ -458,27 +490,24 @@ orchestrator:
       target: developer
       contract: task-spec-v1
       schema: schemas/handoffs/task-spec.schema.json
-      compact_mode: true
 
     - source: ideation
       target: requirements
       contract: ideation-output-v1
       schema: schemas/handoffs/task-spec.schema.json
       extension: schemas/handoffs/ext/ideation-extension.schema.json
-      compact_mode: true
 
     - source: ui-ux-designer
       target: developer
       contract: design-spec-v1
       schema: schemas/handoffs/task-spec.schema.json
       extension: schemas/handoffs/ext/design-extension.schema.json
-      compact_mode: true
 
     - source: se-architect
       target: se-critic
       contract: se-arch-output-v1
       schema: schemas/se-decomposition.schema.json
-      compact_mode: false   # Lange Feldnamen erhalten
+      # Keine compact_mode-Angabe — wird aus project.yaml gelesen
 ```
 
 ---
@@ -505,7 +534,6 @@ a2a_handoff:
   source_agent: "orchestrator"
   target_agent: "developer"
   schema_ref: "schemas/handoffs/task-spec.schema.json"
-  compact_mode: true
   trace_parent: "HOFF-20260607-000"
   payload:
     t: "Implementiere Login-Flow"
@@ -587,13 +615,14 @@ viz:
 
 | Handoff-Typ | Envelope | Payload | Total | Mit compact_mode |
 |-------------|----------|---------|-------|-----------------|
-| Einfach (TaskSpec, `t` nur) | 40 | 5 | **45** | **45** |
-| Standard (TaskSpec mit ctx+con+pri) | 40 | 20 | **60** | **60** |
-| Ideation (TaskSpec + IdeationExt) | 60 | 45 | **105** | **85** (compact) |
-| Design (TaskSpec + DesignExt) | 60 | 55 | **115** | **90** (compact) |
-| Review (TaskSpec + ReviewExt, 3 findings) | 60 | 80 | **140** | **110** (compact) |
-| SE-Decomposition (compact_mode: false) | 60 | 180–500 | **240–560** | N/A (compact off) |
-| Supersession-Handoff (+ history) | 60+15 | — | +15 | +15 |
+| Einfach (TaskSpec, `t` nur) | 42 | 5 | **47** | **47** |
+| Standard (TaskSpec mit ctx+con+pri) | 42 | 20 | **62** | **62** |
+| Ideation (TaskSpec + IdeationExt) | 64 | 45 | **109** | **89** (compact) |
+| Design (TaskSpec + DesignExt) | 64 | 55 | **119** | **94** (compact) |
+| Review (TaskSpec + ReviewExt, 3 findings) | 64 | 80 | **144** | **114** (compact) |
+| Batch (3 Tasks) | 70 | 30 | **100** | **85** (compact) |
+| SE-Decomposition (compact-mode: false) | 64 | 180–500 | **244–564** | N/A (compact off) |
+| Supersession-Handoff (+ history) | 64+12 | — | +12 | +12 |
 
 ### 7.2 Optimierungen (umgesetzt)
 
@@ -602,8 +631,9 @@ viz:
 | 1 | Kurze Payload-Feldnamen (neue Schemas) | 20–50 Tokens/Handoff | ✓ Umgesetzt (TaskSpec + Extensions) |
 | 2 | `schema_ref` implizit aus Route | ~20 Tokens | ✓ Optional (im Envelope-Schema) |
 | 3 | `protocol_version` default = aktuell | ~9 Tokens | ✓ Implizit, nur explizit bei Major-Change |
-| 4 | `compact_mode`-Flag | 0 (schaltet #1 an/aus) | ✓ Im Envelope-Schema |
+| 4 | `compact-mode` als Build-Config | 2 Tokens/Envelope | ✓ Aus Envelope entfernt (nur project.yaml) |
 | 5 | viz.debug: false default | 30 Tokens/Handoff | ✓ In project.yaml konfiguriert |
+| 6 | Batch-Mode für FANOUT | ~110 Tokens/FANOUT(3) | ✓ Neu (batch: true im Envelope) |
 
 ### 7.3 Nicht umgesetzt (begründet)
 
@@ -615,7 +645,159 @@ viz:
 
 ---
 
-## 8. Implementationsfahrplan
+## 8. Human-in-the-Loop (HITL)
+
+### 8.1 requires_human_approval
+
+Wenn `requires_human_approval: true` im Envelope gesetzt ist, MUSS der downstream-Agent **vor der Ausführung** pausieren und auf eine explizite User-Bestätigung warten.
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-050",
+  "source_agent": "orchestrator",
+  "target_agent": "developer",
+  "payload": { "t": "DELETE /api/v1/users — Batch-Löschung implementieren" },
+  "requires_human_approval": true
+}
+```
+
+**HITL-Flow:**
+1. Orchestrator sendet Envelope mit `requires_human_approval: true`
+2. Downstream-Agent empfängt, erkennt das Flag → pausiert
+3. Agent zeigt Aufgabe + Kontext an: *"Soll ich folgende Aufgabe ausführen? [Task-Beschreibung]"*
+4. User bestätigt → Ausführung startet
+5. User lehnt ab → Agent antwortet mit `status: rejected_by_user`
+
+**Config-Steuerung:**
+```yaml
+# .meta-config/project.yaml
+orchestrator:
+  handoff:
+    human_approval_required: false   # true = globaler HITL-Modus
+```
+
+**Einsatzbereiche:**
+- Kritische Änderungen (DELETE-Operationen, Schema-Migrationen)
+- Unsicherheits-Flag: Orchestrator erkennt Ambiguität → setzt HITL
+- Security-sensible Operationen
+
+---
+
+## 9. Kompatibilität mit Agent Protocol
+
+### 9.1 Mapping-Tabelle
+
+Das A2A-Protokoll kann auf das [Agent Protocol](https://agentprotocol.ai/) (`POST /ap/v1/agent/tasks`) gemappt werden:
+
+| A2A-Feld | Agent Protocol Feld | Notes |
+|----------|--------------------|-------|
+| `handoff_id` | `task.id` | Eindeutige Task-Identität |
+| `source_agent` | `task.metadata.source` | Sender-Rolle |
+| `target_agent` | `task.metadata.target` | Empfänger-Rolle |
+| `payload` | `input` | Domain-spezifische Nutzdaten |
+| `payload.t` | `input.task` | Task-Beschreibung |
+| `schema_ref` | `input.metadata.schema_ref` | Schema-Referenz |
+| `trace_parent` | `task.metadata.parent_id` | Parent-Tracing |
+| `trace_context.trace_id` | `task.metadata.trace_id` | Distributed Trace |
+| `supersession` | `task.supersedes` + `task.history` | Version-Tracking |
+
+### 9.2 Future: agent_protocol_bridge
+
+Geplant: Optionaler Bridge-Modus der A2A-Envelopes transparent in Agent-Protocol-Tasks übersetzt. Ermöglicht Interop mit externen Agent-Protocol-konformen Systemen ohne Änderung der internen agent-meta-Infrastruktur.
+
+---
+
+## 10. Dynamisches Protocol Routing
+
+### 10.1 negotiated_format
+
+Der Envelope unterstützt `negotiated_format` zur Laufzeit-Aushandlung des Transport-Formats:
+
+| Wert | Bedeutung | Einsatz |
+|------|-----------|---------|
+| `json` | JSON-Envelope (nativ) | Provider mit `structured_handoff: true` |
+| `yaml` | YAML-Text-Block | Continue, Copilot |
+| `text` | Natural-Language-Fallback | Legacy / Debugging |
+| `auto` | Orchestrator wählt basierend auf Payload-Größe | Default |
+
+### 10.2 Routing-Entscheidungen (auto-Modus)
+
+| Payload-Größe | Format | Begründung |
+|--------------|--------|-----------|
+| < 1 KB | JSON | Beste LLM-Unterstützung, keine Größenprobleme |
+| 1–10 KB | YAML | ~33% Token-Ersparnis vs. JSON |
+| > 10 KB | Text | Vermeidet Context-Window-Überlauf, natürlichere Verarbeitung |
+
+### 10.3 Config-Steuerung
+
+```yaml
+# .meta-config/project.yaml
+orchestrator:
+  handoff:
+    protocol_routing: static   # static = feste Format-Wahl, dynamic = auto-Modus
+```
+
+Bei `static`: Format wird aus `config/provider-capabilities.yaml` → `handoff_format` gelesen (pro Provider).
+Bei `dynamic`: Orchestrator misst Payload-Größe und wählt Format via obiger Tabelle.
+
+---
+
+## 11. Retry-Logik
+
+### 11.1 retry_count / max_retries
+
+Jeder Envelope führt `retry_count` (Anzahl bisheriger Retries) und `max_retries` (Limit):
+
+```json
+{
+  "handoff_id": "HOFF-20260607-060",
+  "retry_count": 2,
+  "max_retries": 3,
+  "payload": { "t": "Flaky-API-Integration mit Retry-Logik" }
+}
+```
+
+**Retry-Flow:**
+1. Orchestrator sendet Envelope mit `retry_count: 0`
+2. Downstream-Agent schlägt fehl (Timeout, Validierungsfehler, etc.)
+3. Orchestrator inkrementiert `retry_count` → sendet erneut (selbe `handoff_id`)
+4. Wenn `retry_count >= max_retries` → **Abbruch mit Fehler-Eskalation**:
+   - Orchestrator loggt Fehler
+   - User wird benachrichtigt
+   - Kein weiterer Retry
+
+**Config:**
+```yaml
+# .meta-config/project.yaml
+orchestrator:
+  handoff:
+    max_retries: 3   # Globaler Default, pro Envelope überschreibbar
+```
+
+---
+
+## 12. Token Pruning für supersession.history
+
+### 12.1 KLARSTELLUNG
+
+`supersession.history` enthält **NUR handoff_ids** (Strings) — **NIE volle Payloads**.
+
+| Feld | Inhalt | Token-Kosten |
+|------|--------|-------------|
+| `history[]` | `"HOFF-YYYYMMDD-NNN"` Strings | ~4 Tokens/Eintrag |
+| Volle Payloads | **NICHT enthalten** | 0 Tokens |
+
+**Resolution voller Payloads:** Via MCP-Tool `resolve_handoff(handoff_id)`, das den kompletten Envelope aus dem Event-Log rekonstruiert. Kein Payload-Ballast in der History-Kette.
+
+**Beispiel — 10-Iterationen SE-Critic-Zyklus:**
+- History: 10 × ~4 Tokens = ~40 Tokens
+- Ohne Pruning (volle Payloads): 10 × ~200 Tokens = ~2000 Tokens
+- **Ersparnis: ~1960 Tokens (98%)**
+
+---
+
+## 13. Implementationsfahrplan
 
 ### Phase 1 — Schema-Grundlage (JETZT)
 
@@ -623,10 +805,10 @@ viz:
 |---|----------|---------|--------|
 | 1 | TaskSpec-Kern-Schema | `schemas/handoffs/task-spec.schema.json` | ✓ Erstellt |
 | 2 | 4 Extensions | `schemas/handoffs/ext/*.schema.json` | ✓ Erstellt |
-| 3 | Envelope um compact_mode + history[] | `schemas/a2a-handoff.schema.json` | ✓ Angepasst |
-| 4 | Konzept-Dokument überarbeiten | `docs/concepts/a2a-handoff-protocol.md` | ✓ Dieses Dokument |
-| 5 | Config-Block in project.yaml | `.meta-config/project.yaml` | → Nächster Schritt |
-| 6 | CODEBASE_OVERVIEW + SE-Cascade | `docs/CODEBASE_OVERVIEW.md`, `docs/architecture/07-se-cascade.md` | → Nächster Schritt |
+| 3 | Envelope-Schema (v2: -compact_mode, -version, +batch, +retry, +HITL, +negotiated_format) | `schemas/a2a-handoff.schema.json` | ✓ Angepasst |
+| 4 | Konzept-Dokument überarbeiten | `docs/concepts/a2a-handoff-protocol.md` | ✓ Angepasst |
+| 5 | Config-Block (handoff.max_retries, human_approval_required, protocol_routing) | `.meta-config/project.yaml` | ✓ Aktualisiert |
+| 6 | provider-capabilities.yaml prüfen | `config/provider-capabilities.yaml` | ✓ structured_handoff vorhanden |
 
 ### Phase 2 — Transport & Provider (1–2 Wochen)
 
@@ -656,20 +838,22 @@ viz:
 
 ---
 
-## 9. Offene Punkte
+## 14. Offene Punkte
 
 | # | Thema | Stand |
 |---|-------|-------|
-| 1 | **Schema-Validierung zur Laufzeit:** Soll der Orchestrator vor jeder Delegation gegen das Payload-Schema validieren? Vorschlag: Ja — `validate-before-delegate: true` in Config. Fallback: Agent validiert selbst. |
-| 2 | **Response-Envelopes standardisieren:** Welche Felder muss ein Worker in seinem Response-Envelope liefern? Vorschlag: TaskSpec `t`-Feld + `status` + `commit` im Payload. |
-| 3 | **Token-Budget-Tracking:** Soll der Orchestrator das Session-Token-Budget für A2A-Overhead tracken? Vorschlag: Ja, aber erst in Phase 3 — Ziel: max. 10% des Session-Budgets. |
-| 4 | **Rollback bei Supersession:** Automatisches Rollback oder nur Benachrichtigung? Vorschlag: Benachrichtigung + manuelle Bestätigung durch downstream-Agent. |
-| 5 | **Schema-Registry:** Zentrale Registry vs. dezentrale Dateien? Vorschlag: Dateien in `schemas/handoffs/` + MCP-Server für dynamische Resolution (Phase 4). |
-| 6 | **Kompatibilität Nicht-JSON-Provider:** Gelöst via YAML-Text-Block. File-basierte Fallback-Strategie (`.handoff.json` im `.se-cascade/`) optional. |
+| 1 | **Schema-Validierung zur Laufzeit:** Soll der Orchestrator vor jeder Delegation gegen das Payload-Schema validieren? → **JA — `validate-before-delegate: true` in Config (MUSS).** Fallback: Agent validiert selbst. | ✓ Erledigt |
+| 2 | **Response-Envelopes standardisieren:** Welche Felder muss ein Worker in seinem Response-Envelope liefern? Vorschlag: TaskSpec `t`-Feld + `status` + `commit` im Payload. | Offen |
+| 3 | **Token-Budget-Tracking:** Soll der Orchestrator das Session-Token-Budget für A2A-Overhead tracken? Vorschlag: Ja, aber erst in Phase 3 — Ziel: max. 10% des Session-Budgets. | Offen |
+| 4 | **Rollback bei Supersession:** Automatisches Rollback oder nur Benachrichtigung? Vorschlag: Benachrichtigung + manuelle Bestätigung durch downstream-Agent. | Offen |
+| 5 | **Schema-Registry:** Zentrale Registry vs. dezentrale Dateien? Vorschlag: Dateien in `schemas/handoffs/` + MCP-Server für dynamische Resolution (Phase 4). | Offen |
+| 6 | **Kompatibilität Nicht-JSON-Provider:** Gelöst via YAML-Text-Block + `negotiated_format`. File-basierte Fallback-Strategie (`.handoff.json` im `.se-cascade/`) optional. | ✓ Erledigt |
+| 7 | **HITL-Integration:** Human-in-the-Loop via `requires_human_approval` umgesetzt. Config-gesteuert in project.yaml. | ✓ Erledigt |
+| 8 | **Agent Protocol Bridge:** Mapping-Tabelle dokumentiert. Optionaler Bridge-Modus für Phase 4 vorgemerkt. | ✓ Dokumentiert |
 
 ---
 
-## 10. Referenzen
+## 15. Referenzen
 
 | Quelle | Link/Pfad |
 |--------|-----------|

--- a/docs/concepts/a2a-handoff-protocol.md
+++ b/docs/concepts/a2a-handoff-protocol.md
@@ -1,0 +1,688 @@
+# A2A-Handoff-Protokoll — Implementationsnahe Konzeptschärfung
+
+> **Status:** Konzept v2.0 — Implementation-nah
+> **Baut auf:** [Best-Practice-Analyse](a2a-best-practice-analysis.md) (2026-06-07)
+> **Basis-Issue:** [#212](https://github.com/Popoboxxo/agent-meta/issues/212)
+> **Letzte Aktualisierung:** 2026-06-07
+
+---
+
+## 1. Architektur-Entscheidung: A2A als EINZIGES Schema-Austauschformat
+
+### 1.1 Prinzip
+
+**A2A-Envelopes sind das einzige Format für Agent-zu-Agent-Daten.** Natural-Language-Prompts zwischen Agenten werden vollständig durch strukturierte Envelopes ersetzt. Einzige Ausnahme: Continue/Copilot (`structured_handoff: false`) erhalten einen YAML-Text-Block statt JSON — aber das ist ein Transport-Format, kein anderes Konzept.
+
+| Format | Status | Verwendung |
+|--------|--------|------------|
+| Natural-Language-Prompt | **Deprecated** | Wird nicht mehr für Agent-zu-Agent-Übergaben genutzt |
+| A2A-Envelope (JSON) | **Einziges Format** | Alle Provider mit `structured_handoff: true` |
+| YAML-Text-Block | **Transport-Fallback** | Continue/Copilot (kein natives JSON-Tool-Call) |
+| SE-Schemas (se-decomposition, se-orchestrator) | **Eingebettet** | Nur noch als `payload` im Envelope |
+
+### 1.2 Einbettungs-Muster für existierende Schemas
+
+Bestehende Schemas werden **unverändert** als Payload in den Envelope eingebettet:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-001",
+  "source_agent": "se-architect",
+  "target_agent": "se-critic",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "payload": {
+    "feature_id": "REQ-L1-SH-001",
+    "stakeholder_requirement": "...",
+    "l1_system": { "blackbox": "...", "whitebox": ["..."] },
+    "sub_components": [
+      { "id": "COMP-001-01", "name": "...", "domain": "hardware", "black_box_requirement": "..." }
+    ],
+    "architectural_rationale": "..."
+  },
+  "trace_parent": "HOFF-20260607-000"
+}
+```
+
+**Regel:** Kein existierendes Schema wird geändert. Neue Schemas (TaskSpec + Extensions) erhalten **kurze Feldnamen** (2–3 Zeichen).
+
+---
+
+## 2. Schema-Strategie: 1 Core + 4 Extensions + 1 SE
+
+### 2.1 Übersicht
+
+```
+Schemas (6 total):
+├── task-spec.schema.json              ← Core: 60-80% aller Delegationen
+├── ext/ideation-extension.schema.json ← ideation → requirements
+├── ext/design-extension.schema.json   ← ui-ux-designer → developer
+├── ext/api-extension.schema.json      ← api-specialist → developer
+├── ext/review-extension.schema.json   ← code-reviewer → developer
+└── se-decomposition.schema.json       ← SE-Kaskade (7 Routen, existierend)
+```
+
+### 2.2 TaskSpec — Universelles Kern-Schema
+
+```json
+{
+  "t": "Implementiere Login-Flow mit OAuth2",
+  "ctx": "Bestehender Auth-Service unter /internal/auth nutzen",
+  "con": ["Muss OAuth2 mit PKCE unterstützen", "Keine neuen Dependencies"],
+  "refs": ["schemas/auth-api.json", "docs/architecture.md#auth-flow"],
+  "pri": "high",
+  "dep": ["HOFF-20260607-042"]
+}
+```
+
+| Feld | Key | Typ | Tokens (ca.) | Pflicht |
+|------|-----|-----|-------------|---------|
+| Task | `t` | string | 1 | ✓ |
+| Context | `ctx` | string | 1 | — |
+| Constraints | `con` | string[] | 2 | — |
+| References | `refs` | string[] | 2 | — |
+| Priority | `pri` | enum | 1 | — |
+| Depends on | `dep` | HOFF[] | 2 | — |
+
+**Token-Vergleich (leeres Payload, nur Envelope + TaskSpec):**
+- Mit langen Feldnamen: ~130 Tokens
+- Mit kurzen Feldnamen: ~90 Tokens
+- **Ersparnis: ~40 Tokens pro TaskSpec-Handoff (~31%)**
+
+### 2.3 Extension-Mechanismus
+
+Extensions werden via JSON Schema `allOf` mit TaskSpec kombiniert:
+
+```json
+{
+  "allOf": [
+    { "$ref": "schemas/handoffs/task-spec.schema.json" },
+    { "$ref": "schemas/handoffs/ext/ideation-extension.schema.json" }
+  ]
+}
+```
+
+**Konkretes Beispiel — ideation→requirements:**
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-005",
+  "source_agent": "ideation",
+  "target_agent": "requirements",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "compact_mode": true,
+  "payload": {
+    "t": "Dark-Mode-Toggle für Settings-Page entwickeln",
+    "ctx": "Bestehende Theme-Infrastruktur nutzen",
+    "pri": "medium",
+    "ci": "Nutzer soll zwischen Light/Dark/System-Mode wechseln können",
+    "g": "Nutzer mit visuellen Präferenzen können das UI anpassen → höhere UX-Zufriedenheit",
+    "sv1": {
+      "ins": ["Toggle-Button in Settings", "Light/Dark/System drei Modi", "Persistenz via localStorage"],
+      "oos": ["Automatische Tageszeit-Erkennung", "Theme-Editor"]
+    },
+    "oq": ["Wie verhalten sich Drittanbieter-Widgets im Dark Mode?"],
+    "ref": ["https://m3.material.io/theme"]
+  }
+}
+```
+
+### 2.4 DesignExtension — ui-ux-designer→developer
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-010",
+  "source_agent": "ui-ux-designer",
+  "target_agent": "developer",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "compact_mode": true,
+  "payload": {
+    "t": "Settings-Page mit Theme-Toggle implementieren",
+    "ds": {
+      "cm": [
+        {
+          "nm": "ThemeToggle",
+          "tp": "button",
+          "st": ["default", "hover", "active", "focus"],
+          "ac": "role=switch, aria-checked, Tab-index 0"
+        }
+      ],
+      "th": {
+        "co": { "primary": "#6750A4", "surface": "#FFFBFE", "error": "#BA1A1A" },
+        "ty": { "h1": "32/40/700", "body": "14/20/400" },
+        "sp": { "xs": "4", "sm": "8", "md": "16", "lg": "24", "xl": "32" }
+      }
+    }
+  }
+}
+```
+
+### 2.5 APIExtension — api-specialist→developer
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-013",
+  "source_agent": "api-specialist",
+  "target_agent": "developer",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "compact_mode": true,
+  "payload": {
+    "t": "User-Preferences-Endpunkt implementieren",
+    "ct": {
+      "ep": [
+        {
+          "mt": "PATCH",
+          "pt": "/api/v1/users/{id}/preferences",
+          "sm": "Update user theme preference",
+          "rq": {
+            "bd": { "theme": { "type": "string", "enum": ["light", "dark", "system"] } },
+            "ph": { "id": { "type": "string", "format": "uuid" } }
+          },
+          "rs": {
+            "200": { "desc": "Updated", "bd": { "theme": "string", "updated_at": "string" } },
+            "404": { "desc": "User not found" }
+          },
+          "au": true,
+          "sc": ["user:write"]
+        }
+      ]
+    },
+    "vr": "v1",
+    "gw": "/api/v1"
+  }
+}
+```
+
+### 2.6 ReviewExtension — code-reviewer→developer
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-018",
+  "source_agent": "code-reviewer",
+  "target_agent": "developer",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "compact_mode": true,
+  "payload": {
+    "t": "ThemeToggle-Komponente überarbeiten — Review-Findings",
+    "rd": {
+      "v": "changes_requested",
+      "fl": [
+        {
+          "fp": "src/components/ThemeToggle.tsx",
+          "ln": 42,
+          "sv": "error",
+          "ct": "clean_code",
+          "msg": "useEffect dependencies incomplete — missing 'theme' in dependency array",
+          "sg": "Add theme to dependency array: useEffect(() => {...}, [theme, systemPrefers])"
+        },
+        {
+          "fp": "src/components/ThemeToggle.tsx",
+          "ln": 15,
+          "sv": "warning",
+          "ct": "naming",
+          "msg": "Variable 't' too short for component-level scope",
+          "sg": "Rename to 'currentTheme'"
+        }
+      ],
+      "br": {
+        "pf": ["src/components/ThemeToggle.tsx", "src/hooks/useTheme.ts"],
+        "rl": "medium",
+        "tn": "Unit test for ThemeToggle with all three theme values"
+      }
+    }
+  }
+}
+```
+
+### 2.7 SE-Decomposition als Payload (existierendes Schema, unverändert)
+
+Die SE-Kaskade nutzt weiterhin `se-decomposition.schema.json` — eingebettet als `payload`:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-025",
+  "source_agent": "se-architect",
+  "target_agent": "se-critic",
+  "schema_ref": "schemas/se-decomposition.schema.json",
+  "compact_mode": false,
+  "payload": {
+    "feature_id": "REQ-L1-SH-001",
+    "stakeholder_requirement": "...",
+    "l1_system": { "blackbox": "...", "whitebox": ["..."] },
+    "sub_components": [
+      { "id": "COMP-001-01", "name": "...", "domain": "software", "black_box_requirement": "..." }
+    ],
+    "internal_interfaces": [
+      { "source_id": "COMP-001-01", "target_id": "COMP-001-02", "interface_type": "REST", "data_payload": "..." }
+    ],
+    "architectural_rationale": "...",
+    "decomposition_completeness": "..."
+  },
+  "trace_parent": "HOFF-20260607-024"
+}
+```
+
+**SE-Schemas sind `compact_mode: false`** — die langen Feldnamen bleiben erhalten (kein Breaking Change für existierende SE-Infrastruktur).
+
+---
+
+## 3. Envelope-Schema (angepasst)
+
+### 3.1 Struktur
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-20260607-042",
+  "source_agent": "orchestrator",
+  "target_agent": "developer",
+  "supersession": {
+    "version": 3,
+    "supersedes": "HOFF-20260607-040",
+    "history": ["HOFF-20260607-038", "HOFF-20260607-040"],
+    "reason": "REQ-042 scope erweitert nach Stakeholder-Feedback",
+    "timestamp": "2026-06-07T14:30:00Z"
+  },
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "compact_mode": true,
+  "payload": { "t": "...", "pri": "high" },
+  "trace_parent": "HOFF-20260607-039",
+  "trace_context": {
+    "trace_id": "trace-abc123",
+    "span_id": "span-042",
+    "parent_span_id": "span-039",
+    "viz_task_id": "uuid-x-y-z"
+  }
+}
+```
+
+### 3.2 Feld-Referenz
+
+| Feld | Typ | Pflicht | Token (ca.) | Beschreibung |
+|------|-----|---------|-------------|-------------|
+| `protocol_version` | string (SemVer) | ✓ | 4 | Nur bei Major-Änderungen explizit gesetzt. Default = aktuelle Version. |
+| `handoff_id` | HOFF-YYYYMMDD-NNN | ✓ | 4 | Globally unique. Format: HOFF-{date}-{seq} |
+| `source_agent` | string | ✓ | 3 | Rolle des sendenden Agenten |
+| `target_agent` | string | ✓ | 3 | Rolle des empfangenden Agenten |
+| `schema_ref` | string (URI) | — | 10 | Optional: aus Route implizit ableitbar |
+| `compact_mode` | boolean | — | 2 | true = kurze Payload-Namen (default: false) |
+| `payload` | object | ✓ | 2+ | Domain-spezifische Nutzdaten |
+| `trace_parent` | HOFF | — | 2 | Parent-handoff für Delegationsbaum |
+| `trace_context` | object | — | 5 | Erweitertes Tracing |
+| `supersession` | object | — | 5 | Version-Tracking |
+| `supersession.history[]` | HOFF[] | — | 2+/Eintrag | Vollständige Revisionskette |
+
+**Token-Budget (leerer Envelope ohne Payload):**
+- Mit `schema_ref` + `compact_mode` + `trace_parent`: ~60 Tokens
+- Minimal (nur Pflichtfelder, schema_ref implizit): ~40 Tokens
+- Mit Supersession (version + supersedes): +15 Tokens
+
+### 3.3 compact_mode — Steuerung kurzer Feldnamen
+
+| compact_mode | Payload-Feldnamen | Anwendung |
+|-------------|-------------------|-----------|
+| `false` (default) | Lesbare lange Namen | SE-Schemas, Debugging |
+| `true` | Kurze Namen (2-3 Zeichen) | TaskSpec, Extensions |
+
+**Konfiguration in `.meta-config/project.yaml`:**
+```yaml
+orchestrator:
+  handoff:
+    compact-mode: false   # true = Token-sparend im Produktivbetrieb
+```
+
+---
+
+## 4. Orchestrator-Integration
+
+### 4.1 Orchestrator als Envelope-Fabrik
+
+Der Orchestrator ist der **primäre Envelope-Produzent**. Jede Delegation wird als A2A-Envelope verpackt:
+
+```
+User-Request → Orchestrator analysiert Intent
+                 │
+                 ├─→ Routing-Tabelle bestimmt target_agent + contract
+                 ├─→ payload aus User-Request + Kontext extrahiert
+                 ├─→ Envelope erstellt (handoff_id, source, target, schema_ref, payload)
+                 ├─→ (optional) Viz-Validierung vor Delegation
+                 └─→ Delegation via PAL-Dispatch (JSON oder YAML)
+```
+
+### 4.2 FANOUT — N parallele Envelopes
+
+**Szenario:** Orchestrator erkennt 3 unabhängige Sub-Tasks → FANOUT an 3 developer:
+
+```
+Envelope-1: { hid: "HOFF-001", src: "orchestrator", tgt: "developer",
+              trace_context: { trace_id: "tr-abc", span_id: "sp-1" },
+              payload: { "t": "Fix Login NullPointer" } }
+
+Envelope-2: { hid: "HOFF-002", src: "orchestrator", tgt: "developer",
+              trace_context: { trace_id: "tr-abc", span_id: "sp-2" },
+              payload: { "t": "Add CSRF protection" } }
+
+Envelope-3: { hid: "HOFF-003", src: "orchestrator", tgt: "developer",
+              trace_context: { trace_id: "tr-abc", span_id: "sp-3" },
+              payload: { "t": "Update error messages" } }
+```
+
+**Token-Impact FANOUT:** N × ~60 Tokens Envelope-Overhead. Bei MAX_PARALLEL_AGENTS=4: 240 Tokens pro Batch.
+
+### 4.3 BARRIER — Response-Envelopes aggregieren
+
+Nach FANOUT sammelt der Orchestrator die Ergebnisse. Worker produzieren Response-Envelopes:
+
+```json
+{
+  "protocol_version": "1.0.0",
+  "handoff_id": "HOFF-RESP-001",
+  "source_agent": "developer",
+  "target_agent": "orchestrator",
+  "schema_ref": "schemas/handoffs/task-spec.schema.json",
+  "payload": {
+    "t": "Fix Login NullPointer abgeschlossen",
+    "ctx": "commit: abc123, 3 files changed, tests green"
+  },
+  "trace_parent": "HOFF-001"
+}
+```
+
+**Aggregation im Orchestrator:**
+
+```json
+{
+  "handoff_id": "HOFF-AGG-001",
+  "source_agent": "orchestrator",
+  "target_agent": "orchestrator",
+  "payload": {
+    "batch_id": "HOFF-001",
+    "results": [
+      { "hid": "HOFF-001", "status": "success", "commit": "abc123" },
+      { "hid": "HOFF-002", "status": "success", "commit": "def456" },
+      { "hid": "HOFF-003", "status": "blocked", "reason": "needs clarification" }
+    ]
+  }
+}
+```
+
+### 4.4 PIPELINE — Verkettung via trace_parent
+
+**Szenario:** Feature-Lifecycle: `requirements → tester → developer → tester → validator → git`
+
+```
+HOFF-010: orchestrator → requirements  (trace_parent: null)
+HOFF-011: requirements → tester       (trace_parent: HOFF-010)
+HOFF-012: tester → developer          (trace_parent: HOFF-011)
+HOFF-013: developer → tester          (trace_parent: HOFF-012)
+HOFF-014: tester → validator          (trace_parent: HOFF-013)
+HOFF-015: validator → git             (trace_parent: HOFF-014)
+```
+
+Fehlschlag in HOFF-013 → Chain-of-custody bis HOFF-010 zurückverfolgbar.
+
+### 4.5 REPEAT_UNTIL — Supersession-Kette
+
+**Szenario:** SE-Critic-Zyklus (max. 3 Iterationen):
+
+```
+HOFF-020: se-architect → se-critic  (v1, decomposition initial)
+  → critic rejected: "missing traceability for COMP-001-03"
+
+HOFF-021: se-architect → se-critic  (v2, supersedes: HOFF-020, history: [HOFF-020])
+  → critic rejected: "interface type mismatch: analog_signal vs REST"
+
+HOFF-022: se-architect → se-critic  (v3, supersedes: HOFF-021, history: [HOFF-020, HOFF-021])
+  → critic approved ✓
+
+HOFF-023: se-critic → se-interface-mgr
+  (supersession: { version: 3, supersedes: "HOFF-022", history: ["HOFF-020","HOFF-021","HOFF-022"] })
+```
+
+Der `se-interface-mgr` sieht die vollständige Revisionskette und kann nachvollziehen, welche Änderungen in jeder Iteration vorgenommen wurden.
+
+### 4.6 Orchestrator-Routing-Tabelle
+
+Jede Route deklariert Contract + Schema + compact_mode:
+
+```yaml
+# In config/role-defaults.yaml (pro Route erweiterbar):
+orchestrator:
+  routes:
+    - source: orchestrator
+      target: developer
+      contract: task-spec-v1
+      schema: schemas/handoffs/task-spec.schema.json
+      compact_mode: true
+
+    - source: ideation
+      target: requirements
+      contract: ideation-output-v1
+      schema: schemas/handoffs/task-spec.schema.json
+      extension: schemas/handoffs/ext/ideation-extension.schema.json
+      compact_mode: true
+
+    - source: ui-ux-designer
+      target: developer
+      contract: design-spec-v1
+      schema: schemas/handoffs/task-spec.schema.json
+      extension: schemas/handoffs/ext/design-extension.schema.json
+      compact_mode: true
+
+    - source: se-architect
+      target: se-critic
+      contract: se-arch-output-v1
+      schema: schemas/se-decomposition.schema.json
+      compact_mode: false   # Lange Feldnamen erhalten
+```
+
+---
+
+## 5. Provider-Matrix: Transport-Format
+
+### 5.1 structured_handoff vs. YAML-Fallback
+
+| Provider | structured_handoff | handoff_format | A2A-Envelope-Transport |
+|----------|-------------------|----------------|------------------------|
+| **Claude** | `true` | `json` | JSON im Task-Tool-Prompt |
+| **Opencode** | `true` | `json` | JSON im task()-Prompt |
+| **Gemini** | `true` | `json` | JSON im define_subagent-Prompt |
+| **Continue** | `false` | `yaml_text_block` | YAML-Block im Prompt-Text |
+| **Copilot** | `false` | `yaml_text_block` | YAML-Block im Prompt-Text |
+
+### 5.2 YAML-Text-Block (Continue/Copilot)
+
+```yaml
+---
+a2a_handoff:
+  protocol_version: "1.0.0"
+  handoff_id: "HOFF-20260607-001"
+  source_agent: "orchestrator"
+  target_agent: "developer"
+  schema_ref: "schemas/handoffs/task-spec.schema.json"
+  compact_mode: true
+  trace_parent: "HOFF-20260607-000"
+  payload:
+    t: "Implementiere Login-Flow"
+    ctx: "Bestehenden Auth-Service nutzen"
+    pri: "high"
+---
+@developer Bearbeite diesen strukturierten Handoff.
+```
+
+**Token-Vergleich YAML vs. JSON (gleicher Inhalt):**
+- JSON: ~90 Tokens
+- YAML: ~60 Tokens
+- **Ersparnis: ~33% für Continue/Copilot**
+
+---
+
+## 6. viz-Debug als separates Konzept
+
+### 6.1 Zwei-Ebenen-Modell
+
+| Ebene | System | Zweck | ID | Default |
+|-------|--------|-------|-----|---------|
+| **Operational Layer** | viz-Handshake | *Dass* eine Delegation stattfand | `viz_task_id` | Aktiv (nur basic Events) |
+| **Data Contract Layer** | A2A-Envelope | *Was* wurde übergeben | `handoff_id` | Immer (Datenformat) |
+| **Debug-Ebene** | A2A viz-Events | *Wie* wurde validiert/delivered | `viz_task_id` | **AUS** (`viz.debug: false`) |
+
+### 6.2 Lose Kopplung via trace_context.viz_task_id
+
+```json
+{
+  "trace_context": {
+    "trace_id": "trace-session-42",
+    "span_id": "span-007",
+    "viz_task_id": "uuid-orchestrator-delegation-001"
+  }
+}
+```
+
+Das `viz_task_id`-Feld ist die einzige Kopplung zwischen beiden Systemen. Es ist optional — der A2A-Envelope funktioniert vollständig ohne viz, und viz funktioniert ohne A2A.
+
+### 6.3 Debug-Mode Konfiguration
+
+```yaml
+# .meta-config/project.yaml
+viz:
+  debug: false           # true = A2A-Events werden geloggt
+  a2a_events:
+    handoff_start: true
+    handoff_validated: true
+    handoff_delivered: true
+    handoff_failed: true
+    supersession: true
+```
+
+### 6.4 Token-Kosten viz-Debug
+
+| Modus | Zusätzliche viz-Calls | Token-Impact | Log-Zeilen |
+|-------|----------------------|--------------|------------|
+| `viz.debug: false` | 0 | **0 Tokens** | 0 |
+| `viz.debug: true` | 3–5 pro Handoff | ~30 Tokens (Prompt-Block) | 3–5 |
+
+**Default ist `false`** — Null-Token-Kosten im Produktivbetrieb.
+
+### 6.5 A2A-Event-Typen
+
+| Event | Wann | Payload |
+|-------|------|---------|
+| `a2a_handoff_start` | Envelope erstellt | `{handoff_id, source_agent, target_agent, contract}` |
+| `a2a_handoff_validated` | Validierung abgeschlossen | `{handoff_id, valid: bool, errors: [...]}` |
+| `a2a_handoff_delivered` | Downstream akzeptiert | `{handoff_id, status: accepted\|rejected\|superseded}` |
+| `a2a_handoff_failed` | Validierung fehlgeschlagen | `{handoff_id, errors: [...]}` |
+| `a2a_supersession` | Supersession erstellt | `{handoff_id, supersedes, reason}` |
+
+---
+
+## 7. Token-Budget & Optimierungen
+
+### 7.1 Token-Tabelle pro Handoff-Typ
+
+| Handoff-Typ | Envelope | Payload | Total | Mit compact_mode |
+|-------------|----------|---------|-------|-----------------|
+| Einfach (TaskSpec, `t` nur) | 40 | 5 | **45** | **45** |
+| Standard (TaskSpec mit ctx+con+pri) | 40 | 20 | **60** | **60** |
+| Ideation (TaskSpec + IdeationExt) | 60 | 45 | **105** | **85** (compact) |
+| Design (TaskSpec + DesignExt) | 60 | 55 | **115** | **90** (compact) |
+| Review (TaskSpec + ReviewExt, 3 findings) | 60 | 80 | **140** | **110** (compact) |
+| SE-Decomposition (compact_mode: false) | 60 | 180–500 | **240–560** | N/A (compact off) |
+| Supersession-Handoff (+ history) | 60+15 | — | +15 | +15 |
+
+### 7.2 Optimierungen (umgesetzt)
+
+| # | Optimierung | Ersparnis | Status |
+|---|-------------|-----------|--------|
+| 1 | Kurze Payload-Feldnamen (neue Schemas) | 20–50 Tokens/Handoff | ✓ Umgesetzt (TaskSpec + Extensions) |
+| 2 | `schema_ref` implizit aus Route | ~20 Tokens | ✓ Optional (im Envelope-Schema) |
+| 3 | `protocol_version` default = aktuell | ~9 Tokens | ✓ Implizit, nur explizit bei Major-Change |
+| 4 | `compact_mode`-Flag | 0 (schaltet #1 an/aus) | ✓ Im Envelope-Schema |
+| 5 | viz.debug: false default | 30 Tokens/Handoff | ✓ In project.yaml konfiguriert |
+
+### 7.3 Nicht umgesetzt (begründet)
+
+| Optimierung | Ersparnis | Grund für Ablehnung |
+|-------------|-----------|-------------------|
+| Envelope-Feldnamen kürzen | ~15 Tokens | Breaking Change — alle Schemas/Templates migrieren |
+| JSON-Array-Format | ~27 Tokens | Kein JSON-Schema-Validierung, LLM-Verwirrung |
+| Binärformat (MessagePack) | 60-80% | Kein Provider-Support |
+
+---
+
+## 8. Implementationsfahrplan
+
+### Phase 1 — Schema-Grundlage (JETZT)
+
+| # | Maßnahme | Dateien | Status |
+|---|----------|---------|--------|
+| 1 | TaskSpec-Kern-Schema | `schemas/handoffs/task-spec.schema.json` | ✓ Erstellt |
+| 2 | 4 Extensions | `schemas/handoffs/ext/*.schema.json` | ✓ Erstellt |
+| 3 | Envelope um compact_mode + history[] | `schemas/a2a-handoff.schema.json` | ✓ Angepasst |
+| 4 | Konzept-Dokument überarbeiten | `docs/concepts/a2a-handoff-protocol.md` | ✓ Dieses Dokument |
+| 5 | Config-Block in project.yaml | `.meta-config/project.yaml` | → Nächster Schritt |
+| 6 | CODEBASE_OVERVIEW + SE-Cascade | `docs/CODEBASE_OVERVIEW.md`, `docs/architecture/07-se-cascade.md` | → Nächster Schritt |
+
+### Phase 2 — Transport & Provider (1–2 Wochen)
+
+| # | Maßnahme | Dateien |
+|---|----------|---------|
+| 7 | `{{PAL_HANDOFF}}`-Platzhalter | `config/delegation-syntax.yaml`, `scripts/lib/delegation_syntax.py` |
+| 8 | Provider-Capability-Flags | `config/provider-capabilities.yaml` |
+| 9 | YAML-Text-Block für Continue/Copilot | `config/delegation-syntax.yaml` (Continue/Copilot Sektionen) |
+
+### Phase 3 — Orchestrator & Agenten (2–3 Wochen)
+
+| # | Maßnahme | Dateien |
+|---|----------|---------|
+| 10 | Orchestrator Envelope-Fabrik | `agents/1-generic/orchestrator.md` |
+| 11 | Handoff-Routing-Tabelle | `config/role-defaults.yaml` (routes-Sektion) |
+| 12 | Agent-Updates (ideation, feature, developer) | `agents/1-generic/ideation.md`, `feature.md`, `developer.md` |
+| 13 | SE-Agenten (Envelope-basierte Handoffs) | `agents/1-generic/se-*.md` |
+| 14 | Validator: validate_handoff | `agents/1-generic/validator.md` |
+
+### Phase 4 — MCP & Tooling (3–4 Wochen)
+
+| # | Maßnahme | Dateien |
+|---|----------|---------|
+| 15 | MCP-Tools: resolve-handoff-schema, validate-handoff | `scripts/viz-logger.py` (erweitern) |
+| 16 | A2A-Events in viz-logger (hinter debug-Flag) | `scripts/viz-logger.py`, `scripts/lib/viz.py` |
+| 17 | Supersession-Tracking im Orchestrator | `agents/1-generic/orchestrator.md`, `scripts/lib/` |
+
+---
+
+## 9. Offene Punkte
+
+| # | Thema | Stand |
+|---|-------|-------|
+| 1 | **Schema-Validierung zur Laufzeit:** Soll der Orchestrator vor jeder Delegation gegen das Payload-Schema validieren? Vorschlag: Ja — `validate-before-delegate: true` in Config. Fallback: Agent validiert selbst. |
+| 2 | **Response-Envelopes standardisieren:** Welche Felder muss ein Worker in seinem Response-Envelope liefern? Vorschlag: TaskSpec `t`-Feld + `status` + `commit` im Payload. |
+| 3 | **Token-Budget-Tracking:** Soll der Orchestrator das Session-Token-Budget für A2A-Overhead tracken? Vorschlag: Ja, aber erst in Phase 3 — Ziel: max. 10% des Session-Budgets. |
+| 4 | **Rollback bei Supersession:** Automatisches Rollback oder nur Benachrichtigung? Vorschlag: Benachrichtigung + manuelle Bestätigung durch downstream-Agent. |
+| 5 | **Schema-Registry:** Zentrale Registry vs. dezentrale Dateien? Vorschlag: Dateien in `schemas/handoffs/` + MCP-Server für dynamische Resolution (Phase 4). |
+| 6 | **Kompatibilität Nicht-JSON-Provider:** Gelöst via YAML-Text-Block. File-basierte Fallback-Strategie (`.handoff.json` im `.se-cascade/`) optional. |
+
+---
+
+## 10. Referenzen
+
+| Quelle | Link/Pfad |
+|--------|-----------|
+| Best-Practice-Analyse | `docs/concepts/a2a-best-practice-analysis.md` |
+| Envelope-Schema | `schemas/a2a-handoff.schema.json` |
+| TaskSpec-Schema | `schemas/handoffs/task-spec.schema.json` |
+| Extensions | `schemas/handoffs/ext/*.schema.json` |
+| SE-Decomposition | `schemas/se-decomposition.schema.json` |
+| SE-Orchestrator | `schemas/se-orchestrator.schema.json` |
+| Ideation-Output (exist.) | `schemas/handoffs/ideation-output.schema.json` |
+| Orchestrator-First Architecture | `docs/concepts/orchestrator-first-architecture.md` |
+| SE-Kaskade | `docs/architecture/07-se-cascade.md` |
+| CODEBASE_OVERVIEW | `docs/CODEBASE_OVERVIEW.md` |
+| project.yaml Config | `.meta-config/project.yaml` |
+| Viz-Architektur | `docs/viz-architecture.md` |
+| PAL (Delegation Syntax) | `config/delegation-syntax.yaml` |

--- a/schemas/a2a-handoff.schema.json
+++ b/schemas/a2a-handoff.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "A2A Handoff Envelope Schema",
+  "description": "Standardized envelope for structured Agent-to-Agent handoffs in agent-meta. Wraps any domain-specific payload with metadata for validation, supersession tracking, and traceability.",
+  "type": "object",
+  "required": [
+    "protocol_version",
+    "handoff_id",
+    "source_agent",
+    "target_agent",
+    "schema_ref",
+    "payload"
+  ],
+  "properties": {
+    "protocol_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "SemVer version of the A2A handoff protocol itself (not the payload schema)."
+    },
+    "handoff_id": {
+      "type": "string",
+      "pattern": "^HOFF-\\d{8}-\\d{3,6}$",
+      "description": "Globally unique handoff identifier: HOFF-{YYYYMMDD}-{sequential or random suffix}."
+    },
+    "source_agent": {
+      "type": "string",
+      "description": "Role name of the agent producing this handoff (e.g. 'se-architect', 'ideation').",
+      "examples": ["se-architect", "ideation", "requirements", "developer"]
+    },
+    "target_agent": {
+      "type": "string",
+      "description": "Role name of the agent intended to consume this handoff (e.g. 'se-critic', 'requirements').",
+      "examples": ["se-critic", "requirements", "developer", "tester"]
+    },
+    "supersession": {
+      "type": "object",
+      "description": "Optional. Tracks versioning and replacement of prior handoffs. Present when this handoff supersedes a previous one.",
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Monotonic version number for this source_agent/target_agent pair within the same session."
+        },
+        "supersedes": {
+          "type": "string",
+          "pattern": "^HOFF-\\d{8}-\\d{3,6}$",
+          "description": "handoff_id of the previous handoff that this one replaces."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable reason for the supersession (e.g. 'critic rejection: missing traceability')."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when this supersession was created."
+        },
+        "history": {
+          "type": "array",
+          "description": "Optional. Full revision history: ordered list of all superseded handoff_ids from the beginning of the chain. The last entry is identical to 'supersedes'. Enables downstream agents to see the full revision chain, not just the immediate predecessor.",
+          "items": {
+            "type": "string",
+            "pattern": "^HOFF-\\d{8}-\\d{3,6}$"
+          },
+          "minItems": 1
+        }
+      },
+      "if": {
+        "required": ["supersedes"]
+      },
+      "then": {
+        "required": ["reason", "timestamp"]
+      }
+    },
+    "schema_ref": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI reference to the JSON Schema that validates the payload. Supports relative paths (e.g. 'schemas/se-decomposition.schema.json') and absolute URLs."
+    },
+    "payload": {
+      "type": "object",
+      "description": "The domain-specific data being handed over. Must conform to the schema referenced by schema_ref. No constraints here — validated dynamically against schema_ref.",
+      "additionalProperties": true
+    },
+    "trace_parent": {
+      "type": "string",
+      "pattern": "^HOFF-\\d{8}-\\d{3,6}$",
+      "description": "Optional. handoff_id of the parent handoff that triggered this one. Enables full delegation-tree tracing."
+    },
+    "trace_context": {
+      "type": "object",
+      "description": "Extended trace context for distributed tracing across the agent cascade. Links to viz-handshake task_id.",
+      "properties": {
+        "trace_id": {
+          "type": "string",
+          "description": "Globally unique trace ID spanning the entire cascade."
+        },
+        "span_id": {
+          "type": "string",
+          "description": "Current span ID for this specific handoff."
+        },
+        "parent_span_id": {
+          "type": "string",
+          "description": "Span ID of the upstream handoff that caused this one."
+        },
+        "viz_task_id": {
+          "type": "string",
+          "description": "References the viz-handshake task_id for cross-referencing execution tracking. Links the Data Contract Layer (A2A) to the Operational Layer (viz)."
+        }
+      }
+    },
+    "compact_mode": {
+      "type": "boolean",
+      "description": "Optional. When true, payload field names use compact encoding (2-3 chars, e.g. 't' instead of 'task'). When false or absent, payload field names may use human-readable long forms. Default: false. Controlled by orchestrator.handoff.compact-mode in project.yaml.",
+      "default": false
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional. Extensible key-value store for provider-specific or workflow-specific metadata. May include 'provider_handoff_format' ('json'|'yaml_text_block'|'file') to indicate the transport format used, and other provider-specific hints.",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "handoffRoute": {
+      "type": "object",
+      "description": "A registered handoff route between two agent roles, defining which contract applies.",
+      "required": ["source", "target", "contract"],
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Source agent role."
+        },
+        "target": {
+          "type": "string",
+          "description": "Target agent role."
+        },
+        "contract": {
+          "type": "string",
+          "description": "Name of the contract that governs this handoff (e.g. 'ideation-output-v1')."
+        },
+        "input_schema": {
+          "type": "string",
+          "description": "Path to the JSON Schema the payload must validate against."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this handoff accomplishes."
+        }
+      }
+    },
+    "agentContract": {
+      "type": "object",
+      "description": "Declares what an agent role consumes and produces in terms of structured data.",
+      "required": ["role", "produces", "consumes"],
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Agent role name."
+        },
+        "consumes": {
+          "type": "array",
+          "description": "List of contract names this agent can consume as input.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0
+        },
+        "produces": {
+          "type": "array",
+          "description": "List of contract names this agent can produce as output.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "input_schema": {
+          "type": "string",
+          "description": "Path to JSON Schema for validating incoming handoffs."
+        },
+        "output_schema": {
+          "type": "string",
+          "description": "Path to JSON Schema for validating outgoing handoffs."
+        },
+        "target_roles": {
+          "type": "array",
+          "description": "Roles this agent typically hands off to.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "handoffRegistry": {
+      "type": "object",
+      "description": "Complete registry of all registered handoff routes in the project.",
+      "patternProperties": {
+        "^[a-z-]+→[a-z-]+$": {
+          "$ref": "#/definitions/handoffRoute"
+        }
+      }
+    }
+  }
+}

--- a/schemas/a2a-handoff.schema.json
+++ b/schemas/a2a-handoff.schema.json
@@ -8,7 +8,6 @@
     "handoff_id",
     "source_agent",
     "target_agent",
-    "schema_ref",
     "payload"
   ],
   "properties": {
@@ -35,13 +34,7 @@
     "supersession": {
       "type": "object",
       "description": "Optional. Tracks versioning and replacement of prior handoffs. Present when this handoff supersedes a previous one.",
-      "required": ["version"],
       "properties": {
-        "version": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Monotonic version number for this source_agent/target_agent pair within the same session."
-        },
         "supersedes": {
           "type": "string",
           "pattern": "^HOFF-\\d{8}-\\d{3,6}$",
@@ -73,15 +66,35 @@
         "required": ["reason", "timestamp"]
       }
     },
+    "batch": {
+      "type": "boolean",
+      "description": "Optional. When true, payload is an array of task objects for FANOUT delegation. Each array entry has a task_id (local to the batch) plus domain-specific fields. source_agent and target_agent apply to ALL tasks in the batch. Default: false.",
+      "default": false
+    },
+    "retry_count": {
+      "type": "integer",
+      "description": "Optional. How many times this handoff has been retried. Incremented by the orchestrator on each retry. When retry_count >= max_retries, the handoff is aborted with error escalation. Default: 0.",
+      "minimum": 0,
+      "default": 0
+    },
+    "max_retries": {
+      "type": "integer",
+      "description": "Optional. Maximum allowed retries for this handoff. Controlled by orchestrator.handoff.max_retries in project.yaml. Default: 3.",
+      "minimum": 1,
+      "default": 3
+    },
     "schema_ref": {
       "type": "string",
       "format": "uri",
       "description": "URI reference to the JSON Schema that validates the payload. Supports relative paths (e.g. 'schemas/se-decomposition.schema.json') and absolute URLs."
     },
     "payload": {
-      "type": "object",
-      "description": "The domain-specific data being handed over. Must conform to the schema referenced by schema_ref. No constraints here — validated dynamically against schema_ref.",
-      "additionalProperties": true
+      "type": ["object", "array"],
+      "description": "The domain-specific data being handed over. Must conform to the schema referenced by schema_ref. When batch is true, payload is an array of task objects — each with a task_id (local to the batch) plus domain-specific fields. source_agent and target_agent apply to ALL tasks in the batch.",
+      "additionalProperties": true,
+      "items": {
+        "type": "object"
+      }
     },
     "trace_parent": {
       "type": "string",
@@ -100,20 +113,22 @@
           "type": "string",
           "description": "Current span ID for this specific handoff."
         },
-        "parent_span_id": {
-          "type": "string",
-          "description": "Span ID of the upstream handoff that caused this one."
-        },
         "viz_task_id": {
           "type": "string",
           "description": "References the viz-handshake task_id for cross-referencing execution tracking. Links the Data Contract Layer (A2A) to the Operational Layer (viz)."
         }
       }
     },
-    "compact_mode": {
+    "requires_human_approval": {
       "type": "boolean",
-      "description": "Optional. When true, payload field names use compact encoding (2-3 chars, e.g. 't' instead of 'task'). When false or absent, payload field names may use human-readable long forms. Default: false. Controlled by orchestrator.handoff.compact-mode in project.yaml.",
+      "description": "Optional. When true, the downstream agent MUST pause before execution and wait for user confirmation. Controlled by orchestrator.handoff.human_approval_required in project.yaml. Default: false.",
       "default": false
+    },
+    "negotiated_format": {
+      "type": "string",
+      "description": "Optional. Transport format negotiated between source and target agent. auto = the orchestrator selects based on payload size. Controlled by orchestrator.handoff.protocol_routing in project.yaml.",
+      "enum": ["json", "yaml", "text", "auto"],
+      "default": "auto"
     },
     "metadata": {
       "type": "object",

--- a/schemas/handoffs/ext/api-extension.schema.json
+++ b/schemas/handoffs/ext/api-extension.schema.json
@@ -105,6 +105,5 @@
       "title": "Gateway",
       "description": "API-Gateway-Route-Präfix (z.B. /api/v1)."
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/schemas/handoffs/ext/api-extension.schema.json
+++ b/schemas/handoffs/ext/api-extension.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "APIExtension — api-specialist→developer Payload Extension",
+  "description": "Erweitert TaskSpec um API-Contract-spezifische Felder für die Übergabe von API-Spezifikationen an den developer. Wird via JSON Schema allOf mit task-spec.schema.json kombiniert.",
+  "type": "object",
+  "required": ["ct"],
+  "properties": {
+    "ct": {
+      "type": "object",
+      "title": "Contract",
+      "description": "API-Contract-Definition.",
+      "required": ["ep"],
+      "properties": {
+        "ep": {
+          "type": "array",
+          "title": "Endpoints",
+          "description": "Liste der API-Endpunkte.",
+          "items": {
+            "type": "object",
+            "required": ["mt", "pt"],
+            "properties": {
+              "mt": {
+                "type": "string",
+                "title": "Method",
+                "description": "HTTP-Methode.",
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+              },
+              "pt": {
+                "type": "string",
+                "title": "Path",
+                "description": "URL-Pfad (z.B. /api/users/{id})."
+              },
+              "sm": {
+                "type": "string",
+                "title": "Summary",
+                "description": "Kurzbeschreibung des Endpunkts."
+              },
+              "rq": {
+                "type": "object",
+                "title": "Request",
+                "description": "Request-Schema (Body/Query/Path/Header).",
+                "properties": {
+                  "bd": { "type": "object", "title": "Body", "description": "Request-Body-Schema (JSON Schema)." },
+                  "qp": { "type": "object", "title": "Query Params", "description": "Query-Parameter." },
+                  "ph": { "type": "object", "title": "Path Params", "description": "Pfad-Parameter." },
+                  "hd": { "type": "object", "title": "Headers", "description": "Erforderliche Header." }
+                }
+              },
+              "rs": {
+                "type": "object",
+                "title": "Responses",
+                "description": "Response-Schemas pro Status-Code.",
+                "patternProperties": {
+                  "^[1-5]\\d{2}$": {
+                    "type": "object",
+                    "properties": {
+                      "desc": { "type": "string", "title": "Description" },
+                      "bd": { "type": "object", "title": "Body", "description": "Response-Body-Schema." }
+                    }
+                  }
+                }
+              },
+              "au": {
+                "type": "boolean",
+                "title": "Auth Required",
+                "description": "Authentifizierung erforderlich?",
+                "default": false
+              },
+              "sc": {
+                "type": "array",
+                "title": "Scopes",
+                "description": "Erforderliche OAuth2-Scopes.",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "sr": {
+          "type": "array",
+          "title": "Schemas",
+          "description": "Wiederverwendbare Schema-Definitionen (OpenAPI components/schemas).",
+          "items": {
+            "type": "object",
+            "properties": {
+              "nm": { "type": "string", "title": "Name" },
+              "sc": { "type": "object", "title": "Schema", "description": "JSON Schema der Komponente." }
+            }
+          }
+        }
+      }
+    },
+    "cf": {
+      "type": "string",
+      "title": "Contract File",
+      "description": "Pfad zur OpenAPI-Spezifikationsdatei (openapi.yaml/json)."
+    },
+    "vr": {
+      "type": "string",
+      "title": "Version",
+      "description": "API-Version (z.B. v1, v2).",
+      "pattern": "^v\\d+$"
+    },
+    "gw": {
+      "type": "string",
+      "title": "Gateway",
+      "description": "API-Gateway-Route-Präfix (z.B. /api/v1)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/handoffs/ext/design-extension.schema.json
+++ b/schemas/handoffs/ext/design-extension.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DesignExtension — ui-ux-designer→developer Payload Extension",
+  "description": "Erweitert TaskSpec um UI/UX-Design-spezifische Felder für die Übergabe von Design-Spezifikationen an den developer. Wird via JSON Schema allOf mit task-spec.schema.json kombiniert.",
+  "type": "object",
+  "required": ["ds"],
+  "properties": {
+    "ds": {
+      "type": "object",
+      "title": "Design Spec",
+      "description": "UI-Komponenten-Spezifikation.",
+      "required": ["cm"],
+      "properties": {
+        "cm": {
+          "type": "array",
+          "title": "Components",
+          "description": "Liste der zu implementierenden UI-Komponenten.",
+          "items": {
+            "type": "object",
+            "required": ["nm"],
+            "properties": {
+              "nm": {
+                "type": "string",
+                "title": "Name",
+                "description": "Komponentenname (z.B. LoginButton, UserCard)"
+              },
+              "tp": {
+                "type": "string",
+                "title": "Type",
+                "description": "Komponententyp (button, form, card, modal, layout, input)."
+              },
+              "st": {
+                "type": "array",
+                "title": "States",
+                "description": "Zu unterstützende Zustände (default, hover, active, disabled, loading, error).",
+                "items": { "type": "string" }
+              },
+              "pr": {
+                "type": "array",
+                "title": "Props",
+                "description": "Props/Properties der Komponente.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "nm": { "type": "string", "title": "Name" },
+                    "tp": { "type": "string", "title": "Type" },
+                    "req": { "type": "boolean", "title": "Required" }
+                  }
+                }
+              },
+              "ac": {
+                "type": "string",
+                "title": "Accessibility",
+                "description": "A11y-Anforderungen (role, aria-Attribute, Tastatur-Navigation)."
+              },
+              "rp": {
+                "type": "string",
+                "title": "Responsive",
+                "description": "Responsive-Verhalten (Breakpoints, Layout-Änderungen)."
+              }
+            }
+          }
+        },
+        "th": {
+          "type": "object",
+          "title": "Theme",
+          "description": "Design-Tokens und Theme-Variablen.",
+          "properties": {
+            "co": {
+              "type": "object",
+              "title": "Colors",
+              "description": "Farbpalette (primary, secondary, surface, error, etc.)."
+            },
+            "ty": {
+              "type": "object",
+              "title": "Typography",
+              "description": "Schriftgrößen, -gewichte, Zeilenhöhen pro Hierarchie-Ebene."
+            },
+            "sp": {
+              "type": "object",
+              "title": "Spacing",
+              "description": "Abstands-Skala (xs, sm, md, lg, xl in px/rem)."
+            },
+            "br": {
+              "type": "object",
+              "title": "Border Radius",
+              "description": "Border-Radius-Werte (sm, md, lg, full)."
+            }
+          }
+        }
+      }
+    },
+    "lo": {
+      "type": "array",
+      "title": "Layouts",
+      "description": "Layout-Spezifikationen (Grid, Flexbox, Positionierung).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "nm": { "type": "string", "title": "Name" },
+          "tp": { "type": "string", "title": "Type", "enum": ["grid", "flex", "absolute", "fixed", "flow"] },
+          "sp": { "type": "string", "title": "Spec", "description": "CSS-Grid/Flex-Shorthand oder Beschreibung." }
+        }
+      }
+    },
+    "wf": {
+      "type": "array",
+      "title": "Wireframes",
+      "description": "Referenzen auf Wireframes/Mockups (Dateipfade oder URLs).",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/handoffs/ext/design-extension.schema.json
+++ b/schemas/handoffs/ext/design-extension.schema.json
@@ -109,6 +109,5 @@
       "description": "Referenzen auf Wireframes/Mockups (Dateipfade oder URLs).",
       "items": { "type": "string" }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/schemas/handoffs/ext/ideation-extension.schema.json
+++ b/schemas/handoffs/ext/ideation-extension.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IdeationExtension — ideation→requirements Payload Extension",
+  "description": "Erweitert TaskSpec um ideation-spezifische Felder. Wird via JSON Schema allOf mit task-spec.schema.json kombiniert. Kurze Feldnamen (2-3 Zeichen) für Token-Effizienz.",
+  "type": "object",
+  "required": ["ci", "g", "sv1"],
+  "properties": {
+    "ci": {
+      "type": "string",
+      "title": "Core Idea",
+      "description": "Ein-Satz-Beschreibung der Kernidee.",
+      "minLength": 1
+    },
+    "g": {
+      "type": "string",
+      "title": "Goal",
+      "description": "Was ändert sich für wen — das intendierte Ergebnis."
+    },
+    "sv1": {
+      "type": "object",
+      "title": "Scope v1",
+      "description": "Minimal viable scope für die erste Version.",
+      "required": ["ins", "oos"],
+      "properties": {
+        "ins": {
+          "type": "array",
+          "title": "In Scope",
+          "description": "Was in der ersten Version enthalten ist.",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "oos": {
+          "type": "array",
+          "title": "Out of Scope",
+          "description": "Was explizit auf spätere Versionen verschoben wird.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "oq": {
+      "type": "array",
+      "title": "Open Questions",
+      "description": "Noch ungeklärte Fragen aus der Ideation.",
+      "items": { "type": "string" }
+    },
+    "ref": {
+      "type": "array",
+      "title": "External References",
+      "description": "URLs oder Referenzen auf relevante externe Ressourcen.",
+      "items": { "type": "string", "format": "uri" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/handoffs/ext/ideation-extension.schema.json
+++ b/schemas/handoffs/ext/ideation-extension.schema.json
@@ -49,6 +49,5 @@
       "description": "URLs oder Referenzen auf relevante externe Ressourcen.",
       "items": { "type": "string", "format": "uri" }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/schemas/handoffs/ext/review-extension.schema.json
+++ b/schemas/handoffs/ext/review-extension.schema.json
@@ -92,6 +92,5 @@
       "title": "Review ID",
       "description": "Eindeutige Review-ID für Traceability."
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/schemas/handoffs/ext/review-extension.schema.json
+++ b/schemas/handoffs/ext/review-extension.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReviewExtension — code-reviewer→developer Payload Extension",
+  "description": "Erweitert TaskSpec um Code-Review-spezifische Felder für die Übergabe von Review-Feedback an den developer. Wird via JSON Schema allOf mit task-spec.schema.json kombiniert.",
+  "type": "object",
+  "required": ["rd"],
+  "properties": {
+    "rd": {
+      "type": "object",
+      "title": "Review Data",
+      "description": "Strukturiertes Review-Ergebnis.",
+      "required": ["v", "fl"],
+      "properties": {
+        "v": {
+          "type": "string",
+          "title": "Verdict",
+          "description": "Gesamturteil des Reviews.",
+          "enum": ["approved", "changes_requested", "blocked"]
+        },
+        "fl": {
+          "type": "array",
+          "title": "Findings",
+          "description": "Liste der Review-Findings.",
+          "items": {
+            "type": "object",
+            "required": ["fp", "sv", "msg"],
+            "properties": {
+              "fp": {
+                "type": "string",
+                "title": "File Path",
+                "description": "Pfad zur betroffenen Datei."
+              },
+              "ln": {
+                "type": "integer",
+                "title": "Line",
+                "description": "Zeilennummer (optional, wenn ganze Datei betroffen).",
+                "minimum": 1
+              },
+              "sv": {
+                "type": "string",
+                "title": "Severity",
+                "description": "Schweregrad des Findings.",
+                "enum": ["info", "warning", "error", "critical"]
+              },
+              "ct": {
+                "type": "string",
+                "title": "Category",
+                "description": "Kategorie des Findings.",
+                "enum": ["clean_code", "security", "performance", "naming", "structure", "duplication", "testing", "documentation", "traceability", "api_design"]
+              },
+              "msg": {
+                "type": "string",
+                "title": "Message",
+                "description": "Beschreibung des Findings."
+              },
+              "sg": {
+                "type": "string",
+                "title": "Suggestion",
+                "description": "Konkreter Verbesserungsvorschlag."
+              }
+            }
+          }
+        },
+        "br": {
+          "type": "object",
+          "title": "Blast Radius",
+          "description": "Blast-Radius-Analyse: betroffene Code-Pfade und Risiken.",
+          "properties": {
+            "pf": {
+              "type": "array",
+              "title": "Affected Paths",
+              "description": "Betroffene Code-Pfade.",
+              "items": { "type": "string" }
+            },
+            "rl": {
+              "type": "string",
+              "title": "Risk Level",
+              "description": "Risiko-Level der Änderung.",
+              "enum": ["low", "medium", "high", "critical"]
+            },
+            "tn": {
+              "type": "string",
+              "title": "Test Needed",
+              "description": "Empfohlene Test-Strategie."
+            }
+          }
+        }
+      }
+    },
+    "ri": {
+      "type": "string",
+      "title": "Review ID",
+      "description": "Eindeutige Review-ID für Traceability."
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/handoffs/task-spec.schema.json
+++ b/schemas/handoffs/task-spec.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TaskSpec — Universal Core Payload Schema",
+  "description": "Universelles Kern-Payload-Schema für 60-80% aller Agent-zu-Agent-Delegationen. Kurze Feldnamen (2-3 Zeichen) für Token-Effizienz, ausführliche title/description für Lesbarkeit. Eingebettet in A2A-Envelope als payload.",
+  "type": "object",
+  "required": ["t"],
+  "properties": {
+    "t": {
+      "type": "string",
+      "title": "Task",
+      "description": "Task-Beschreibung in Natural Language. Pflichtfeld.",
+      "minLength": 1,
+      "examples": ["Implementiere Login-Flow", "Fixe NullPointer in UserService.create()"]
+    },
+    "ctx": {
+      "type": "string",
+      "title": "Context",
+      "description": "Zusätzlicher Kontext für den Task (bestehende Architektur, Constraints, Vorarbeiten). Optional."
+    },
+    "con": {
+      "type": "array",
+      "title": "Constraints",
+      "description": "Harte Randbedingungen die bei der Implementierung eingehalten werden müssen.",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["Muss OAuth2 unterstützen", "Keine neuen Dependencies"]]
+    },
+    "refs": {
+      "type": "array",
+      "title": "References",
+      "description": "Referenzen auf relevante Dateien, Schemas, Issues oder Dokumentation.",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["schemas/auth-api.json", "docs/architecture.md#section-3"]]
+    },
+    "pri": {
+      "type": "string",
+      "title": "Priority",
+      "description": "Priorität des Tasks.",
+      "enum": ["low", "medium", "high", "critical"],
+      "default": "medium"
+    },
+    "dep": {
+      "type": "array",
+      "title": "Depends On",
+      "description": "Liste von handoff_id's von denen dieser Task abhängt. Blockiert Ausführung bis alle Abhängigkeiten erfüllt sind.",
+      "items": {
+        "type": "string",
+        "pattern": "^HOFF-\\d{8}-\\d{3,6}$"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/handoffs/task-spec.schema.json
+++ b/schemas/handoffs/task-spec.schema.json
@@ -51,6 +51,5 @@
         "pattern": "^HOFF-\\d{8}-\\d{3,6}$"
       }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -871,7 +871,8 @@ def sync_agents(
         viz_cfg = config.get("viz", {})
         if viz_cfg.get("mode") in ("dynamic", "full"):
             from .viz import inject_viz_prompt_block
-            content = inject_viz_prompt_block(content, role, "Claude", viz_enabled=True, agent_meta_root=agent_meta_root)
+            content = inject_viz_prompt_block(content, role, "Claude", viz_enabled=True, agent_meta_root=agent_meta_root,
+                                              viz_debug=viz_cfg.get("debug", False))
 
         # Critical Rules Footer: append critical rules to end of agent files
         footer_cfg = config.get('critical-rules-footer', {})
@@ -1233,7 +1234,8 @@ def sync_agents_for_provider(
         viz_cfg = config.get('viz', {})
         if viz_cfg.get('mode') in ('dynamic', 'full'):
             from .viz import inject_viz_prompt_block
-            content = inject_viz_prompt_block(content, role, provider, viz_enabled=True, agent_meta_root=agent_meta_root)
+            content = inject_viz_prompt_block(content, role, provider, viz_enabled=True, agent_meta_root=agent_meta_root,
+                                              viz_debug=viz_cfg.get("debug", False))
 
         if debug_mode:
             content = inject_debug_block(content, name)

--- a/scripts/lib/delegation_syntax.py
+++ b/scripts/lib/delegation_syntax.py
@@ -30,6 +30,7 @@ class DelegationSyntaxEngine:
         "PAL_FALLBACK": "fallback",
         "PAL_TOOL_PREAMBLE": "tool_preamble",
         "PAL_PARALLEL_PATTERN": "parallel_pattern",
+        "PAL_HANDOFF": "handoff",
     }
 
     def __init__(self, config_dir: Path | None = None) -> None:

--- a/scripts/lib/viz.py
+++ b/scripts/lib/viz.py
@@ -708,7 +708,8 @@ def _parse_opencode_permissions(agent_content: str) -> dict[str, str]:
 
 def inject_viz_prompt_block(agent_content: str, role: str, provider: str,
                             viz_enabled: bool, model: str = "",
-                            agent_meta_root: Path | None = None) -> str:
+                            agent_meta_root: Path | None = None,
+                            viz_debug: bool = False) -> str:
     """Injiziere den Visualization-Prompt-Block in einen Agenten.
 
     Nutzt bevorzugt das native MCP-Tool `log_viz_event` oder als Fallback das
@@ -779,4 +780,42 @@ Der Visualisierungsmodus ist aktiv. Du MUSST deine Aufrufe und Delegationen prot
 - Eingehende und ausgehende Delegationen müssen exakt über die `task_id` und `caller/target` verknüpft sein.
 """
 
-    return agent_content.rstrip() + "\\n\\n" + block.strip() + "\\n"
+    result = agent_content.rstrip() + "\\n\\n" + block.strip() + "\\n"
+
+    # A2A Debug Events — nur bei viz.debug:true injizieren (Null-Token-Kosten sonst)
+    if viz_debug:
+        a2a_block = f"""
+## A2A Handoff Debug Events (Debug-Mode)
+
+Der A2A-Debug-Modus ist aktiv. Protokolliere zusätzlich zu den viz-Handshake-Events die folgenden A2A-Events:
+
+**Zusätzliche Pflicht-Events:**
+
+**4. Wenn ein A2A-Envelope erstellt wird:**
+- Event: `a2a_handoff_start`
+- Parameter: `--event a2a_handoff_start --task_id <uuid> --caller <source_agent> --target <target_agent> --payload '{{"handoff_id":"HOFF-...","contract":"..."}}'`
+
+**5. Wenn ein A2A-Envelope validiert wurde:**
+- Event: `a2a_handoff_validated`
+- Parameter: `--event a2a_handoff_validated --task_id <uuid> --payload '{{"handoff_id":"HOFF-...","valid":true}}'`
+
+**6. Wenn ein A2A-Envelope delivered wurde:**
+- Event: `a2a_handoff_delivered`
+- Parameter: `--event a2a_handoff_delivered --task_id <uuid> --payload '{{"handoff_id":"HOFF-...","status":"accepted"}}'`
+
+**7. Wenn ein A2A-Handoff fehlschlägt:**
+- Event: `a2a_handoff_failed`
+- Parameter: `--event a2a_handoff_failed --task_id <uuid> --payload '{{"handoff_id":"HOFF-...","errors":["..."]}}'`
+
+**8. Wenn eine Supersession erstellt wird:**
+- Event: `a2a_supersession`
+- Parameter: `--event a2a_supersession --task_id <uuid> --payload '{{"handoff_id":"HOFF-...","supersedes":"HOFF-...","reason":"..."}}'`
+
+### Regeln
+- Diese Events sind ZUSÄTZLICH zu den viz-Handshake-Events (agent_start, delegate_out, agent_end).
+- A2A-Events werden NUR im Debug-Modus protokolliert (viz.debug: true in project.yaml).
+- Nutze dasselbe Tool wie für viz-Handshake-Events (MCP log_viz_event oder CLI-Fallback).
+"""
+        result += "\\n\\n" + a2a_block.strip() + "\\n"
+
+    return result


### PR DESCRIPTION
## Summary

Implementiert das A2A Handoff Protocol — standardisierte JSON-Envelopes für Agent-zu-Agent-Kommunikation mit Schema-Validierung, Supersession-Tracking und Batch-FANOUT.

## Changes

- **PAL Engine:** `PAL_HANDOFF` placeholder + 5 provider syntax blocks (Claude, Opencode, Gemini, Continue, Copilot)
- **Schemas:** `a2a-handoff.schema.json` (Core Envelope), `task-spec.schema.json` (universelles Payload), 4 Extensions (Ideation, Design, API, Review) = 6 Schemas statt 19
- **Agent Templates:** orchestrator v3.20.0, feature v1.6.0, ideation v1.4.0, developer v2.3.0, validator v3.2.0 + 5 SE agents
- **Config:** 16 role handoff contracts in role-defaults.yaml, 3 MCP tools in mcp-registry.yaml
- **viz:** 5 A2A event types behind viz.debug:true flag (zero token cost in production)
- **Docs:** ARCHITECTURE.md, README.md, CODEBASE_OVERVIEW.md, 07-se-cascade.md aktualisiert

## Key Design Decisions

- A2A = einziger Schema-Austausch (legacy Formate als Payload eingebettet)
- Batch-Envelope spart 56% Overhead bei FANOUT
- HITL via requires_human_approval field
- validate-before-delegate als MUSS (nicht optional)