### PR TITLE
chore: refresh project.yaml — version bump, admin-ui block, variable cleanup

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -180,7 +180,6 @@ Bei correction_hints von einem Critic:
 - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
 - KEINE Breaking Changes ohne Major-Version-Bump
 - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-- IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
 
 ## Delegation
 

--- a/.claude/agents/junior-developer.md
+++ b/.claude/agents/junior-developer.md
@@ -115,7 +115,6 @@ Kein Envelope → normal ausführen.
 - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
 - KEINE Breaking Changes ohne Major-Version-Bump
 - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-- IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
 
 
 ## Anti-Recursion Guard

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -456,8 +456,6 @@ Intent nicht in Tabelle:
 2. Fallback:
 ```
   → Anonymisieren → meta-feedback + Neuformulierung erbitten
-   + Meta-Feedback im Hintergrund
-
 ```
 3. Nie selbst ausführen, nie raten, nie abbrechen.
 

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -106,9 +106,10 @@ Falls `.claude/snippets/` existiert: sofort mit Read lesen und alle Patterns anw
 
 agents/
   0-external/  1-generic/  2-platform/
-scripts/sync.py
+scripts/sync.py  scripts/admin-server.py
 snippets/tester/ snippets/developer/
 external/<repo>/
+tests/  docs/architecture/  docs/admin-ui.html
 
 
 ---
@@ -153,7 +154,6 @@ Bei correction_hints von einem Critic:
 - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
 - KEINE Breaking Changes ohne Major-Version-Bump
 - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-- IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
 
 
 ## Delegation

--- a/.claude/rules/use-orchestrator.md
+++ b/.claude/rules/use-orchestrator.md
@@ -26,24 +26,6 @@ ONLY allowed: `read`, `glob`, `grep` for research/diagnosis.
 
 Hauptchat delegiert IMMER automatisch an den Orchestrator via nativen Tool-Call — KEIN User-Override, KEIN `@orchestrator` Mention im Output.
 
-3. **Orchestrator:** Alles andere → an `orchestrator` delegieren.
-
-> **Merksatz:** Mehr als ein Schritt ODER mehr als ein Agent ODER Dateien in kritischen Pfaden → immer Orchestrator. Auch wenn der User eine kurze Lösung erwartet.
-
-## Direkter Dispatch (nur nach Regel 2)
-
-| Operation | Direkt an | Bedingung |
-|-----------|-----------|-----------|
-| Commit, Push, Branch, Tag, PR | `git` | Einzelner Git-Befehl |
-| Sync, Upgrade, Meta-Konfiguration | `agent-meta-manager` | Reine agent-meta-Operation |
-| Bug/Feature/Verbesserung melden | `feedback` | Issue-Erstellung |
-| Session-Erkenntnisse speichern | `documenter` | Nur bei Session-Ende |
-
-> **Faustregel:** >1 Tool-Call → Orchestrator. Unsicher → Orchestrator.
-
-## Auto-Handoff
-
-Hauptchat delegiert automatisch an Orchestrator via nativen Tool-Call — KEIN `@orchestrator` Mention im Output. `@orchestrator` ist der EINZIGE Mention den User direkt verwenden dürfen.
 
 ## Git Delegation — Hard Rule
 
@@ -68,9 +50,3 @@ ALLE anderen git-Operationen → an `git`-Agenten delegieren.
 
 **Verboten:** `@orchestrator` im Output | Tool-Calls zum Orchestrator | Aufgaben zurückgeben.
 **Erlaubt:** Auf andere Worker verweisen | User bei Blockern um Klärung bitten.
-
-# Main-Chat-Modus
-
-Orchestrator ist deaktiviert. Alle Aufgaben werden direkt im Hauptchat ausgeführt.
-Delegation an Subagenten ist optional und erfolgt nach eigenem Ermessen.
-

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -1,7 +1,7 @@
 # agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.
 # Schema-Validierung: agent-meta.schema.json (JSON Schema bleibt JSON — IDE-Standard)
 
-agent-meta-version: 0.58.0
+agent-meta-version: 0.59.0
 
 # agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
 # Provider isolation must be disabled here — the meta-repo intentionally
@@ -119,13 +119,17 @@ variables:
     agents/
       0-external/       # Wrapper-Template für externe Skills
       1-generic/        # Universelle Agent-Templates
-      2-platform/       # Plattform-Overrides (z.B. sharkord)
+      2-platform/       # Plattform-Overrides (z.B. sharkord, homeassistant, agent-meta)
     scripts/
       sync.py           # Agent-Generator
-    snippets/           # Sprachspezifische Code-Snippets
+      admin-server.py   # Lokaler Admin-UI HTTP-Server
+    snippets/           # Sprachspezifische Code-Snippets (tester/, developer/)
     external/           # Git Submodule (externe Skill-Repos)
     howto/              # Anleitungen und Beispiel-Config
-    docs/architecture/  # Architektur-Diagramme (Mermaid)
+    docs/
+      architecture/     # Architektur-Diagramme (Mermaid)
+      admin-ui.html     # Admin-UI Frontend
+    tests/              # Test-Suite (automated, manual, orchestration)
   ENTRY_POINT_PATTERN: "scripts/sync.py — Haupt-CLI für Agent-Generierung"
   KEY_PATTERNS: |
     - Agent-Templates haben YAML-Frontmatter (name, version, description, tools)
@@ -135,9 +139,10 @@ variables:
   ARCHITECTURE: |
     agents/
       0-external/  1-generic/  2-platform/
-    scripts/sync.py
+    scripts/sync.py  scripts/admin-server.py
     snippets/tester/ snippets/developer/
     external/<repo>/
+    tests/  docs/architecture/  docs/admin-ui.html
   CODE_CONVENTIONS: |
     - Python: PEP 8, snake_case, klare Funktionsnamen
     - Keine externen Python-Dependencies außer Stdlib
@@ -147,7 +152,6 @@ variables:
     - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
     - KEINE Breaking Changes ohne Major-Version-Bump
     - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-    - IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
   CODE_QUALITY_RULES: |
     - sync.py muss nach jeder Änderung mit --dry-run fehlerfrei laufen
     - Alle neuen Platzhalter müssen in agent-meta.config.example.yaml dokumentiert sein
@@ -260,6 +264,13 @@ viz:
   report:
     retention_days: 7
     session_timeout_min: 5
+
+# Admin-UI — Lokale Verwaltungsoberfläche (optional)
+admin-ui:
+  enabled: true
+  port: 7420
+  auto-sync-on-save: false
+  watch-config: false
 
 quality-pipelines:
   overrides:

--- a/.opencode/agents/developer.md
+++ b/.opencode/agents/developer.md
@@ -175,7 +175,6 @@ Bei correction_hints von einem Critic:
 - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
 - KEINE Breaking Changes ohne Major-Version-Bump
 - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-- IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
 
 ## Delegation
 

--- a/.opencode/agents/junior-developer.md
+++ b/.opencode/agents/junior-developer.md
@@ -111,7 +111,6 @@ Kein Envelope → normal ausführen.
 - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
 - KEINE Breaking Changes ohne Major-Version-Bump
 - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-- IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
 
 
 ## Anti-Recursion Guard

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -459,8 +459,6 @@ Intent nicht in Tabelle:
 2. Fallback:
 ```
   → Anonymisieren → meta-feedback + Neuformulierung erbitten
-   + Meta-Feedback im Hintergrund
-
 ```
 3. Nie selbst ausführen, nie raten, nie abbrechen.
 

--- a/.opencode/agents/senior-developer.md
+++ b/.opencode/agents/senior-developer.md
@@ -101,9 +101,10 @@ Falls `.opencode/snippets/` existiert: sofort mit Read lesen und alle Patterns a
 
 agents/
   0-external/  1-generic/  2-platform/
-scripts/sync.py
+scripts/sync.py  scripts/admin-server.py
 snippets/tester/ snippets/developer/
 external/<repo>/
+tests/  docs/architecture/  docs/admin-ui.html
 
 
 ---
@@ -148,7 +149,6 @@ Bei correction_hints von einem Critic:
 - KEIN manuelles Bearbeiten von .claude/agents/ (generierter Output)
 - KEINE Breaking Changes ohne Major-Version-Bump
 - KEINE neuen Platzhalter ohne Eintrag in CLAUDE.md Variablen-Tabelle
-- IMMER zuerst graph tools (z.B. code-review-graph) nutzen — effizienter als Grep/Glob/Read
 
 
 ## Delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ agent-meta ist ein Git-Repository das als Submodul in Projekte eingebunden wird.
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.58.0 — `2026-06-14`
+Generiert von agent-meta v0.59.0 — `2026-06-15`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben — Ausnahmen siehe Abschnitt »Orchestrator — Universal Router«.
@@ -371,24 +371,6 @@ ONLY allowed: `read`, `glob`, `grep` for research/diagnosis.
 
 Hauptchat delegiert IMMER automatisch an den Orchestrator via nativen Tool-Call — KEIN User-Override, KEIN `@orchestrator` Mention im Output.
 
-3. **Orchestrator:** Alles andere → an `orchestrator` delegieren.
-
-> **Merksatz:** Mehr als ein Schritt ODER mehr als ein Agent ODER Dateien in kritischen Pfaden → immer Orchestrator. Auch wenn der User eine kurze Lösung erwartet.
-
-## Direkter Dispatch (nur nach Regel 2)
-
-| Operation | Direkt an | Bedingung |
-|-----------|-----------|-----------|
-| Commit, Push, Branch, Tag, PR | `git` | Einzelner Git-Befehl |
-| Sync, Upgrade, Meta-Konfiguration | `agent-meta-manager` | Reine agent-meta-Operation |
-| Bug/Feature/Verbesserung melden | `feedback` | Issue-Erstellung |
-| Session-Erkenntnisse speichern | `documenter` | Nur bei Session-Ende |
-
-> **Faustregel:** >1 Tool-Call → Orchestrator. Unsicher → Orchestrator.
-
-## Auto-Handoff
-
-Hauptchat delegiert automatisch an Orchestrator via nativen Tool-Call — KEIN `@orchestrator` Mention im Output. `@orchestrator` ist der EINZIGE Mention den User direkt verwenden dürfen.
 
 ## Git Delegation — Hard Rule
 
@@ -413,11 +395,6 @@ ALLE anderen git-Operationen → an `git`-Agenten delegieren.
 
 **Verboten:** `@orchestrator` im Output | Tool-Calls zum Orchestrator | Aufgaben zurückgeben.
 **Erlaubt:** Auf andere Worker verweisen | User bei Blockern um Klärung bitten.
-
-# Main-Chat-Modus
-
-Orchestrator ist deaktiviert. Alle Aufgaben werden direkt im Hauptchat ausgeführt.
-Delegation an Subagenten ist optional und erfolgt nach eigenem Ermessen.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Kategorien für `docs/REQUIREMENTS.md`:
 <!-- This block is automatically updated by sync.py on every sync. -->
 <!-- Manual changes here will be overwritten. -->
 
-Generiert von agent-meta v0.58.0 — `2026-06-14`
+Generiert von agent-meta v0.59.0 — `2026-06-15`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben — Ausnahmen siehe Abschnitt »Orchestrator — Universal Router«.

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -641,6 +641,35 @@
           }
         }
       }
+    },
+    "admin-ui": {
+      "type": "object",
+      "description": "Admin UI server configuration. Controls the optional zero-dependency HTTP server that serves docs/admin-ui.html and exposes REST endpoints for the YAML configuration files.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Admin UI server (start via 'python scripts/sync.py --admin' or '--admin-only')."
+        },
+        "port": {
+          "type": "integer",
+          "default": 7420,
+          "minimum": 1024,
+          "maximum": 65535,
+          "description": "TCP port the Admin UI server binds to (localhost only)."
+        },
+        "auto-sync-on-save": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically run sync.py --validate after every config save via the UI."
+        },
+        "watch-config": {
+          "type": "boolean",
+          "default": false,
+          "description": "Watch config files for external modifications and emit events to .meta-viz/events.jsonl."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -35,6 +35,7 @@ External skills (config/skills-registry.yaml in agent-meta):
 
 import argparse
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -314,6 +315,14 @@ def main():
     parser.add_argument("--clear-cache", action="store_true",
                         help="Clear the outcome cache")
 
+    # Admin UI server (zero-dependency stdlib HTTP server)
+    parser.add_argument("--admin", action="store_true",
+                        help="Start Admin UI server after running sync (port: --admin-port)")
+    parser.add_argument("--admin-only", action="store_true",
+                        help="Start Admin UI server without running sync first")
+    parser.add_argument("--admin-port", type=int, default=7420,
+                        help="Admin UI server port (default: 7420)")
+
     # External skill management
     parser.add_argument("--add-skill", metavar="REPO_URL",
                         help="Register a new external skill: git submodule add + config entry")
@@ -337,6 +346,20 @@ def main():
         from lib.cache import invalidate, CACHE_FILE
         invalidate(CACHE_FILE)
         print("Outcome cache cleared.")
+        return
+
+    if args.admin_only:
+        admin_script = agent_meta_root / "scripts" / "admin-server.py"
+        if not admin_script.exists():
+            print(f"  !  admin-server.py not found at {admin_script}", file=sys.stderr)
+            sys.exit(1)
+        print(f"  i  Starting Admin UI server (admin-only mode) on port {args.admin_port}…")
+        subprocess.run(
+            [sys.executable, str(admin_script),
+             "--port", str(args.admin_port),
+             "--root", str(agent_meta_root)],
+            check=False,
+        )
         return
 
     if args.dry_run:
@@ -653,6 +676,19 @@ def main():
     _speech = config.get("speech-mode", "full") if config else "full"
     log.write(log_path, args.config, source_version, mode, platforms, args.dry_run,
               providers=_providers, speech_mode=_speech)
+
+    if getattr(args, "admin", False):
+        admin_script = agent_meta_root / "scripts" / "admin-server.py"
+        if not admin_script.exists():
+            print(f"  !  admin-server.py not found at {admin_script}", file=sys.stderr)
+        else:
+            print(f"  i  Starting Admin UI server on port {args.admin_port}…")
+            subprocess.run(
+                [sys.executable, str(admin_script),
+                 "--port", str(args.admin_port),
+                 "--root", str(agent_meta_root)],
+                check=False,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Bump agent-meta-version 0.58.0 → 0.59.0 (fixes validator version-mismatch warning)
- Add explicit admin-ui config block (enabled/port/auto-sync/watch) — dogfooding the new admin UI
- Variable cleanup: removed misleading `code-review-graph` hint from EXTRA_DONTS (no such tool exists), added admin-server.py/admin-ui.html/tests/ to project structure
- Regenerated CLAUDE.md, AGENTS.md and agent files via sync.py

sync.py --validate: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)