### PR TITLE
fix: address PAL delegation engine gaps (Issue #289)

### DIFF
--- a/agents/1-generic/orchestrator.md
+++ b/agents/1-generic/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: template-orchestrator
-version: "3.28.0"
+version: "3.29.0"
 description: "Provider-agnostischer Task-Orchestrator: zerlegt, parallelisiert, delegiert."
 hint: "Einstiegspunkt für ALLE Entwicklungsaufgaben — zerlegt komplexe Tasks und dispatched parallel"
 tools:
@@ -396,6 +396,41 @@ Bei Output >200 Zeilen oder strukturiertem Report:
 
 **Wann:** Cascading Pipelines (≥3 Relay-Punkte), Analyse-Reports, große Changelogs.
 **Warum:** Referenz (~100 Tokens) statt Report (~5000 Tokens) — verhindert Context-Bloat und Telephone-Effekt.
+
+## Agent Return Format
+
+**Erwartetes Rückgabeformat** für alle Worker-Agenten nach einer Delegation:
+
+Jeder Subagent soll seine Antwort in einem der folgenden Formate zurückgeben — je nach Komplexität des Ergebnisses:
+
+**Standard (kompakt):**
+```
+STATUS: <done|partial|failed|escalate>
+RESULT: <1-2 Sätze was tatsächlich gemacht wurde>
+ARTIFACTS: <geänderte Dateien, optional>
+ERRORS: <Fehlermeldungen, leer wenn keiner>
+```
+
+**Erweitert (bei Eskalation oder Partial-Completion):**
+```
+STATUS: escalate | partial
+RESULT: <was wurde abgeschlossen>
+ESCALATE_REASON: <warum nicht vollständig — kurz>
+RECOMMENDED_TIER: <tier>
+PARTIAL_WORK: <was bereits erledigt ist>
+NEXT_STEPS: <konkrete nächste Schritte>
+```
+
+**Regeln:**
+- `STATUS: done` → Orchestrator fährt mit nächstem Schritt fort
+- `STATUS: partial` → Orchestrator zeigt dem User den Stand, fragt nach weiter/abbrechen
+- `STATUS: failed` → Orchestrator aktiviert Failure Recovery (→ »Delegation Failure Recovery«)
+- `STATUS: escalate` → Orchestrator dispatched sofort an `recommended_tier`, kein User-Gate
+- Kein freier Text ohne STATUS-Header — der Orchestrator muss den Status maschinenlesbar erkennen können
+
+**Schema-Referenz:** `schemas/a2a-handoff.schema.json` (Envelope), `schemas/handoffs/task-spec.schema.json` (Payload)
+
+---
 
 ## Quality Pipelines (Generated)
 

--- a/scripts/lib/delegation_syntax.py
+++ b/scripts/lib/delegation_syntax.py
@@ -10,6 +10,7 @@ Usage:
     processed = engine.apply(content, provider="Gemini")
 """
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -19,9 +20,59 @@ try:
 except ImportError:
     yaml = None  # type: ignore[assignment]
 
+# Known A2A schemas shipped with agent-meta (relative to repo root).
+# These paths are intentionally relative so they remain valid when the repo is
+# used as a Git submodule embedded inside another project.
+_SCHEMA_PATHS: dict[str, str] = {
+    "a2a-handoff": "schemas/a2a-handoff.schema.json",
+    "task-spec": "schemas/handoffs/task-spec.schema.json",
+}
+
+# Required fields in an A2A envelope (mirrors a2a-handoff.schema.json).
+# Maintained here as a fast stdlib-only check — no jsonschema dependency needed.
+_A2A_REQUIRED_FIELDS: tuple[str, ...] = (
+    "protocol_version",
+    "handoff_id",
+    "source_agent",
+    "target_agent",
+    "payload",
+)
+
 
 class DelegationSyntaxEngine:
-    """Substitutes abstract delegation placeholders with provider-specific syntax."""
+    """Substitutes abstract delegation placeholders with provider-specific syntax.
+
+    ## Placeholder taxonomy
+
+    This engine handles exclusively **build-time** PAL_* placeholders — they are
+    resolved during `sync.py` and replaced with provider-specific syntax strings
+    (e.g. native tool-call syntax, YAML text blocks).
+
+    **Runtime placeholders** such as ``<agent-name>`` and ``<task-description>``
+    are intentionally NOT handled here.  They are filled in by the LLM at runtime
+    when it constructs an actual delegation call.  Using ``{{double-braces}}``
+    for these tokens is explicitly avoided: the LLM interprets curly-brace syntax
+    as unresolved sync.py placeholders and refuses to delegate (Issue #277 root
+    cause).  The angle-bracket convention (``<agent-name>``) signals a
+    human-readable slot that the LLM is expected to fill with a concrete value.
+
+    See also: docs/conclusions/conclusions-2026-06-12.md for the historical
+    rationale behind this split.
+
+    ## A2A schema integration
+
+    The PAL_HANDOFF placeholder, once substituted, injects provider-specific
+    envelope syntax into templates.  The canonical schema for these envelopes is
+    ``schemas/a2a-handoff.schema.json`` (repo root).
+
+    Use :meth:`get_schema_ref` to obtain the relative path to a named schema and
+    :meth:`validate_envelope` for a lightweight required-fields check that works
+    without any third-party dependencies.  Full JSON Schema validation (if
+    ``jsonschema`` is installed) is available via :meth:`validate_envelope` as
+    well — it degrades gracefully when the library is absent.
+
+    See also: docs/concepts/a2a-handoff-protocol.md for architecture rationale.
+    """
 
     PLACEHOLDERS: dict[str, str] = {
         "PAL_DELEGATE": "delegate",
@@ -39,6 +90,10 @@ class DelegationSyntaxEngine:
         self.config_dir = config_dir
         self._syntax_registry: dict[str, Any] | None = None
         self._capabilities_registry: dict[str, Any] | None = None
+
+    # ------------------------------------------------------------------
+    # Internal registries
+    # ------------------------------------------------------------------
 
     @property
     def syntax_registry(self) -> dict[str, Any]:
@@ -75,6 +130,80 @@ class DelegationSyntaxEngine:
     def get_capabilities(self, provider: str) -> dict[str, Any]:
         """Return capabilities for a provider."""
         return self.capabilities_registry.get("capabilities", {}).get(provider, {})
+
+    # ------------------------------------------------------------------
+    # A2A schema helpers
+    # ------------------------------------------------------------------
+
+    def get_schema_ref(self, schema_name: str) -> str:
+        """Return the relative repo path for a named A2A schema.
+
+        Args:
+            schema_name: Key from the internal registry, e.g. ``"a2a-handoff"``
+                or ``"task-spec"``.
+
+        Returns:
+            Relative path string (e.g. ``"schemas/a2a-handoff.schema.json"``),
+            or an empty string when the name is unknown.
+        """
+        return _SCHEMA_PATHS.get(schema_name, "")
+
+    def validate_envelope(
+        self,
+        envelope: dict[str, Any],
+        schema_name: str = "a2a-handoff",
+        agent_meta_root: Path | None = None,
+    ) -> list[str]:
+        """Validate an A2A envelope dict and return a list of error strings.
+
+        Validation strategy (two tiers):
+
+        1. **Stdlib required-fields check** — always runs, no extra dependencies.
+           Verifies that all fields listed in ``_A2A_REQUIRED_FIELDS`` are present.
+
+        2. **Full JSON Schema validation** — runs only when ``jsonschema`` is
+           importable *and* the schema file can be resolved.  Gracefully skipped
+           when either condition is not met (e.g. lightweight CI environments).
+
+        Args:
+            envelope:        The envelope dict to validate.
+            schema_name:     Schema key (default ``"a2a-handoff"``).
+            agent_meta_root: Repo root path used to locate the schema file.
+                             Derived from ``config_dir`` when not provided.
+
+        Returns:
+            A list of human-readable error strings.  Empty list means valid.
+        """
+        errors: list[str] = []
+
+        # Tier 1: required-fields check (stdlib, always runs)
+        missing = [f for f in _A2A_REQUIRED_FIELDS if f not in envelope]
+        if missing:
+            errors.append(f"Missing required fields: {', '.join(missing)}")
+
+        # Tier 2: full JSON Schema validation (optional, graceful degradation)
+        schema_rel = self.get_schema_ref(schema_name)
+        if schema_rel:
+            if agent_meta_root is None:
+                agent_meta_root = self.config_dir.parent
+            schema_path = agent_meta_root / schema_rel
+            try:
+                import jsonschema  # type: ignore[import]
+                with open(schema_path, encoding="utf-8") as f:
+                    schema = json.load(f)
+                validator = jsonschema.Draft7Validator(schema)
+                for err in sorted(validator.iter_errors(envelope), key=str):
+                    errors.append(str(err.message))
+            except ImportError:
+                pass  # jsonschema not installed — tier-1 check is sufficient
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass  # schema file missing/corrupt — skip silently
+
+        return errors
+
+    # ------------------------------------------------------------------
+    # Template substitution
+    # ------------------------------------------------------------------
 
     def apply(self, content: str, provider: str, log=None) -> str:
         """Apply provider-specific syntax to abstract placeholders in content.
@@ -128,6 +257,10 @@ class DelegationSyntaxEngine:
         content = re.sub(r"PAL_PREFIX:\w+\s*\n", "", content)
 
         return content
+
+    # ------------------------------------------------------------------
+    # Provider capability checks
+    # ------------------------------------------------------------------
 
     def needs_bootstrap(self, provider: str) -> bool:
         """Check if provider needs session bootstrap."""


### PR DESCRIPTION
## Summary

- **P0** (`delegation_syntax.py`): Document build-time vs. runtime placeholder split. Clarifies why `<angle-bracket>` tokens replace `{{double-brace}}` slots — prevents LLM from refusing to delegate due to perceived unresolved sync.py placeholders (Issue #277 root cause). Adds class-level docstring section with historical rationale reference.

- **P1** (`delegation_syntax.py`): Add schema-awareness to `DelegationSyntaxEngine`. New methods: `get_schema_ref(schema_name)` returns relative path to `a2a-handoff` or `task-spec` schema; `validate_envelope(envelope)` performs stdlib required-fields check (tier 1) with optional `jsonschema` full validation (tier 2, graceful degradation when library absent).

- **P2** (`agents/1-generic/orchestrator.md`): Add **Agent Return Format** section defining the `STATUS/RESULT/ARTIFACTS/ERRORS` contract for all worker agents. Includes escalation fields (`ESCALATE_REASON`, `RECOMMENDED_TIER`, `PARTIAL_WORK`) and schema references. Version bump 3.28.0 → 3.29.0.

## Test plan

- [ ] `python scripts/sync.py --dry-run` passes (123 actions, 0 errors)
- [ ] `python -c "from scripts.lib.delegation_syntax import DelegationSyntaxEngine; e = DelegationSyntaxEngine(); assert e.get_schema_ref('a2a-handoff') == 'schemas/a2a-handoff.schema.json'"` passes
- [ ] `validate_envelope` returns empty list for valid envelope, error list for missing required fields
- [ ] No breaking changes to `apply()` signature or existing PAL substitution behaviour

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)