### PR TITLE
feat: admin dashboard — target-repo view + unified server entry-point

### DIFF
--- a/docs/admin-ui.html
+++ b/docs/admin-ui.html
@@ -727,6 +727,7 @@ class StateManager {
       redo: [],
       hierarchy: null,
       templates: [],
+      projectAdminAvailable: false,  // true when super_admin + .meta-config/project.yaml exists
     };
     this.listeners = new Map();
   }
@@ -1173,6 +1174,7 @@ function buildSidebar() {
       title: "Configs",
       items: [
         { route: "/config/project", label: "project.yaml", icon: "□" },
+        { route: "/config/project-target", label: "target project.yaml", icon: "□", superAdminProjectOnly: true },
         { route: "/config/role-defaults", label: "role-defaults", icon: "□", superOnly: true },
         { route: "/config/ai-providers", label: "ai-providers", icon: "□", superOnly: true },
         { route: "/config/skills-registry", label: "skills", icon: "□", superOnly: true },
@@ -1195,7 +1197,10 @@ function buildSidebar() {
   for (const group of groups) {
     nav.appendChild(el("div", { class: "nav-group-title" }, [group.title]));
     for (const item of group.items) {
-      const disabled = item.superOnly && state.state.mode !== "super_admin";
+      const disabled = (item.superOnly && state.state.mode !== "super_admin")
+                    || (item.superAdminProjectOnly && !state.state.projectAdminAvailable);
+      const hidden = item.superAdminProjectOnly && state.state.mode !== "super_admin";
+      if (hidden) continue;
       const node = el("div", {
         class: `nav-item ${disabled ? "disabled" : ""}`,
         dataset: { route: item.route },
@@ -1246,12 +1251,66 @@ async function viewDashboard() {
       el("h2", {}, ["Super admin"]),
       el("p", {}, ["You're running inside the agent-meta framework repository. All super-admin configs (role-defaults, ai-providers, skills-registry, mcp-registry, dod-presets, delegation-syntax, export) are editable."]),
     ]));
+    // Target repo section — only when .meta-config/project.yaml exists
+    if (state.state.projectAdminAvailable) {
+      wrap.appendChild(el("div", { class: "panel" }, [
+        el("h2", {}, ["Target repo"]),
+        el("p", {}, [
+          "This agent-meta repository also has its own ",
+          el("code", {}, [".meta-config/project.yaml"]),
+          " (it uses itself as a target). ",
+          el("a", { href: "#/config/project-target" }, ["Edit target project.yaml"]),
+          ".",
+        ]),
+      ]));
+    }
   } else {
     wrap.appendChild(el("div", { class: "panel" }, [
       el("h2", {}, ["Project admin"]),
       el("p", {}, ["You're running inside a target project. Only .meta-config/project.yaml is editable; super-admin configs are read-only / hidden."]),
     ]));
   }
+
+  // Sub-server status panel (Viz dashboard + MCP server)
+  try {
+    const sub = await api.get("/api/subserver-status").catch(() => null);
+    if (sub) {
+      const vizStatus = sub.viz.running
+        ? el("span", { style: "color:var(--accent-green)" }, ["running"])
+        : el("span", { style: "color:var(--text-muted)" }, ["stopped"]);
+      const mcpStatus = sub.mcp.running
+        ? el("span", { style: "color:var(--accent-green)" }, ["running"])
+        : el("span", { style: "color:var(--text-muted)" }, ["stopped"]);
+
+      const vizLine = sub.viz.running
+        ? [vizStatus, ` — port ${sub.viz.port} · PID ${sub.viz.pid} · `, el("a", { href: sub.viz.url, target: "_blank" }, [sub.viz.url])]
+        : [vizStatus, ` — port ${sub.viz.port}`];
+      const mcpLine = sub.mcp.running
+        ? [mcpStatus, ` — port ${sub.mcp.port} · PID ${sub.mcp.pid} · `, el("a", { href: sub.mcp.url, target: "_blank" }, [sub.mcp.url])]
+        : [mcpStatus, ` — port ${sub.mcp.port}`];
+
+      wrap.appendChild(el("div", { class: "panel" }, [
+        el("h2", {}, ["Sub-servers"]),
+        el("table", { class: "data", style: "margin-top:8px;" }, [
+          el("thead", {}, [el("tr", {}, ["Server", "Status / URL"].map(h => el("th", {}, [h])))]),
+          el("tbody", {}, [
+            el("tr", {}, [el("td", { class: "mono" }, ["Viz dashboard"]), el("td", {}, vizLine)]),
+            el("tr", {}, [el("td", { class: "mono" }, ["MCP SSE server"]), el("td", {}, mcpLine)]),
+          ]),
+        ]),
+        el("p", { class: "muted", style: "font-size:12px; margin-top:8px;" }, [
+          "Start/stop: ",
+          el("code", {}, ["python scripts/admin-server.py"]),
+          " (unified) or ",
+          el("code", {}, ["python scripts/viz-server.py start"]),
+          " (legacy). Use ",
+          el("code", {}, ["--no-viz"]),
+          " to run Admin UI only.",
+        ]),
+      ]));
+    }
+  } catch { /* sub-server status is best-effort */ }
+
   return wrap;
 }
 
@@ -2497,6 +2556,7 @@ async function init() {
     const mode = await api.get("/api/mode");
     state.state.mode = mode.mode;
     state.state.allowedKeys = mode.allowed_keys || [];
+    state.state.projectAdminAvailable = !!mode.project_admin_available;
     const badge = document.getElementById("mode-badge");
     badge.textContent = mode.mode;
     badge.classList.toggle("project", mode.mode === "project_admin");
@@ -2517,6 +2577,10 @@ async function init() {
   router.register("/sync",            viewSync);
   router.register("/live",            viewLive);
   router.register("/config/project",  configView("project", "project.yaml", schemaP));
+  // Target repo view — only visible in super_admin when .meta-config/project.yaml exists.
+  // Uses the same "project" config key because the server resolves it to the
+  // same file in super_admin mode.
+  router.register("/config/project-target", configView("project", "project.yaml (target repo)", schemaP));
   router.register("/config/role-defaults",     viewRoleDefaults);
   router.register("/config/ai-providers",      viewAIProviders);
   router.register("/config/skills-registry",   viewSkillsRegistry);

--- a/scripts/admin-server.py
+++ b/scripts/admin-server.py
@@ -15,10 +15,18 @@ Two modes:
     integrated as a submodule. Only ``.meta-config/project.yaml`` is exposed.
 
 Start:
-  python scripts/admin-server.py
+  python scripts/admin-server.py               (Admin UI + Viz dashboard + MCP server)
+  python scripts/admin-server.py --no-viz      (Admin UI only, lightweight mode)
   python scripts/admin-server.py --port 7420 --root .
-  python scripts/sync.py --admin            (after a normal sync)
-  python scripts/sync.py --admin-only       (skip sync)
+  python scripts/sync.py --admin               (after a normal sync)
+  python scripts/sync.py --admin-only          (skip sync)
+
+Unified entry-point:
+  In super_admin mode the server also starts the Viz dashboard (viz-report.py)
+  and the MCP SSE server (viz-logger.py) as supervised subprocesses unless
+  ``--no-viz`` is passed.  PID-files and logs are written to ``.meta-viz/``.
+  In project_admin (target-repo) mode the same subprocesses are started via
+  the submodule path (``.agent-meta/scripts/``).
 """
 
 from __future__ import annotations
@@ -52,6 +60,16 @@ DEFAULT_HOST = "127.0.0.1"
 MAX_BACKUPS = 5
 SSE_HEARTBEAT_SECONDS = 15
 
+# PID files and logs for supervised sub-servers (relative to project root).
+VIZ_PID_FILE   = ".meta-viz/.server-pid"
+VIZ_LOG_FILE   = ".meta-viz/server.log"
+MCP_PID_FILE   = ".meta-viz/.mcp-server-pid"
+MCP_LOG_FILE   = ".meta-viz/mcp-server.log"
+
+_DEFAULT_VIZ_PORT    = 8765
+_DEFAULT_VIZ_TIMEOUT = 300
+_DEFAULT_MCP_PORT    = 9090
+
 # Loopback addresses are the ONLY values the ``--host`` flag accepts. The admin
 # UI exposes write access to every editable config file; binding the server to
 # anything reachable from the network would be a privilege-escalation vector.
@@ -72,6 +90,233 @@ SUPER_ADMIN_FILES: dict[str, str] = {
 PROJECT_FILES: dict[str, str] = {
     "project": ".meta-config/project.yaml",
 }
+
+
+# --------------------------------------------------------------------------- #
+# Viz / MCP sub-server manager                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _load_viz_config(root: Path) -> dict:
+    """Load viz server ports/timeouts from ``.meta-config/project.yaml``."""
+    config_path = root / ".meta-config" / "project.yaml"
+    try:
+        sys.path.insert(0, str(root / "scripts"))
+        sys.path.insert(0, str(root / ".agent-meta" / "scripts"))
+        from lib.config import load_config  # type: ignore[import]
+        config = load_config(config_path)
+        viz_cfg = config.get("viz", {})
+        server_cfg = viz_cfg.get("server", {})
+        mcp_cfg = viz_cfg.get("mcp", {})
+        return {
+            "viz_port":    int(server_cfg.get("port", _DEFAULT_VIZ_PORT)),
+            "viz_timeout": int(server_cfg.get("timeout_sec", _DEFAULT_VIZ_TIMEOUT)),
+            "mcp_port":    int(mcp_cfg.get("port", _DEFAULT_MCP_PORT)),
+        }
+    except Exception:
+        return {
+            "viz_port":    _DEFAULT_VIZ_PORT,
+            "viz_timeout": _DEFAULT_VIZ_TIMEOUT,
+            "mcp_port":    _DEFAULT_MCP_PORT,
+        }
+
+
+def _is_pid_running(pid: Optional[int]) -> bool:
+    if not pid:
+        return False
+    try:
+        if sys.platform == "win32":
+            import ctypes
+            kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+            handle = kernel32.OpenProcess(1, False, pid)
+            if handle:
+                kernel32.CloseHandle(handle)
+                return True
+            return False
+        else:
+            os.kill(pid, 0)
+            return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def _read_pid(pid_file: Path) -> Optional[int]:
+    if pid_file.exists():
+        try:
+            return int(pid_file.read_text(encoding="utf-8").strip())
+        except (ValueError, OSError):
+            pass
+    return None
+
+
+class VizManager:
+    """Manages the Viz dashboard and MCP SSE server as supervised subprocesses.
+
+    Both sub-servers run in detached sessions (``start_new_session=True`` on
+    POSIX, ``CREATE_NEW_PROCESS_GROUP`` on Windows) so they survive a parent
+    process re-exec but are cleaned up when :meth:`stop_all` is called.
+
+    Resolution order for script paths (same pattern as SyncExecutor):
+      1. ``<root>/scripts/viz-report.py``              -- top-level checkout
+      2. ``<root>/.agent-meta/scripts/viz-report.py``  -- submodule layout
+    """
+
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve()
+        self._viz_report = self._resolve_script("viz-report.py")
+        self._viz_logger = self._resolve_script("viz-logger.py")
+
+    # ---------------------------------------------------------------------- #
+    # Internal helpers                                                       #
+    # ---------------------------------------------------------------------- #
+
+    def _resolve_script(self, name: str) -> Path:
+        primary  = self.root / "scripts" / name
+        fallback = self.root / ".agent-meta" / "scripts" / name
+        return primary if primary.exists() else fallback
+
+    def _start(
+        self,
+        args: list,
+        pid_file: Path,
+        log_file: Path,
+        label: str,
+    ) -> bool:
+        """Start a detached subprocess, record its PID, return True on success."""
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        if log_file.exists():
+            try:
+                log_file.unlink()
+            except PermissionError:
+                pass
+
+        if sys.platform == "win32":
+            si = subprocess.STARTUPINFO()
+            si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            si.wShowWindow = 0
+            proc = subprocess.Popen(
+                args,
+                stdout=open(log_file, "a", encoding="utf-8"),
+                stderr=subprocess.STDOUT,
+                startupinfo=si,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                cwd=str(self.root),
+            )
+        else:
+            proc = subprocess.Popen(
+                args,
+                stdout=open(log_file, "a", encoding="utf-8"),
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                cwd=str(self.root),
+            )
+
+        pid_file.write_text(str(proc.pid), encoding="utf-8")
+        time.sleep(1.5)
+
+        if _is_pid_running(proc.pid):
+            print(f"  +  {label} started (PID: {proc.pid})")
+            return True
+        else:
+            print(f"  !  {label} failed to start -- see {log_file}")
+            pid_file.unlink(missing_ok=True)
+            return False
+
+    def _stop(self, pid_file: Path, label: str) -> None:
+        pid = _read_pid(pid_file)
+        if not pid or not _is_pid_running(pid):
+            pid_file.unlink(missing_ok=True)
+            return
+        try:
+            if sys.platform == "win32":
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/F"],
+                    check=True, capture_output=True,
+                )
+            else:
+                os.kill(pid, 15)
+                time.sleep(1)
+                if _is_pid_running(pid):
+                    os.kill(pid, 9)
+            print(f"  -  {label} stopped (PID: {pid})")
+        except Exception as exc:
+            print(f"  !  Error stopping {label}: {exc}")
+        finally:
+            pid_file.unlink(missing_ok=True)
+
+    # ---------------------------------------------------------------------- #
+    # Public interface                                                       #
+    # ---------------------------------------------------------------------- #
+
+    def start_all(self) -> None:
+        """Start both the Viz dashboard and the MCP server."""
+        cfg = _load_viz_config(self.root)
+
+        # --- Viz dashboard ---
+        viz_pid = self.root / VIZ_PID_FILE
+        viz_log = self.root / VIZ_LOG_FILE
+        if not _is_pid_running(_read_pid(viz_pid)):
+            if self._viz_report.exists():
+                self._start(
+                    [
+                        sys.executable,
+                        str(self._viz_report),
+                        "--serve",
+                        "--port", str(cfg["viz_port"]),
+                        "--timeout", str(cfg["viz_timeout"]),
+                    ],
+                    viz_pid, viz_log,
+                    f"Viz dashboard (port {cfg['viz_port']})",
+                )
+            else:
+                print("  -  viz-report.py not found, skipping Viz dashboard")
+
+        # --- MCP server ---
+        mcp_pid = self.root / MCP_PID_FILE
+        mcp_log = self.root / MCP_LOG_FILE
+        if not _is_pid_running(_read_pid(mcp_pid)):
+            if self._viz_logger.exists():
+                self._start(
+                    [
+                        sys.executable, "-u",
+                        str(self._viz_logger),
+                        "--http", str(cfg["mcp_port"]),
+                    ],
+                    mcp_pid, mcp_log,
+                    f"MCP server (port {cfg['mcp_port']})",
+                )
+            else:
+                print("  -  viz-logger.py not found, skipping MCP server")
+
+    def stop_all(self) -> None:
+        """Terminate both sub-servers."""
+        self._stop(self.root / VIZ_PID_FILE, "Viz dashboard")
+        self._stop(self.root / MCP_PID_FILE, "MCP server")
+
+    def status(self) -> dict:
+        """Return a status dict for the ``/api/subserver-status`` endpoint."""
+        cfg = _load_viz_config(self.root)
+        viz_pid_val = _read_pid(self.root / VIZ_PID_FILE)
+        mcp_pid_val = _read_pid(self.root / MCP_PID_FILE)
+        viz_running = _is_pid_running(viz_pid_val)
+        mcp_running = _is_pid_running(mcp_pid_val)
+        return {
+            "viz": {
+                "running": viz_running,
+                "pid":     viz_pid_val,
+                "port":    cfg["viz_port"],
+                "url":     f"http://localhost:{cfg['viz_port']}/",
+                "log":     VIZ_LOG_FILE,
+            },
+            "mcp": {
+                "running": mcp_running,
+                "pid":     mcp_pid_val,
+                "port":    cfg["mcp_port"],
+                "url":     f"http://127.0.0.1:{cfg['mcp_port']}/sse",
+                "log":     MCP_LOG_FILE,
+            },
+        }
+
 
 # --------------------------------------------------------------------------- #
 # Exceptions                                                                  #
@@ -389,6 +634,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
 
     config_manager: ConfigManager
     sync_executor: SyncExecutor
+    viz_manager: "VizManager"
     mode: str
     root: Path
     version: str
@@ -549,11 +795,18 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             })
 
         if path == "/api/mode":
-            return self._send_json({
+            payload: dict = {
                 "mode": self.__class__.mode,
                 "root": str(self.__class__.root),
                 "allowed_keys": sorted(self.__class__.config_manager._allowed_keys().keys()),
-            })
+            }
+            # In super_admin mode the project.yaml of the meta-repo is also
+            # available as the "target repo" view.  Signal this to the UI so
+            # it can render the combined dashboard.
+            if self.__class__.mode == "super_admin":
+                project_yaml = self.__class__.root / ".meta-config" / "project.yaml"
+                payload["project_admin_available"] = project_yaml.exists()
+            return self._send_json(payload)
 
         if path.startswith("/api/config/"):
             key = path[len("/api/config/"):]
@@ -582,6 +835,9 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
 
         if path == "/api/events":
             return self._stream_events()
+
+        if path == "/api/subserver-status":
+            return self._send_json(self.__class__.viz_manager.status())
 
         raise FileNotFoundError(path)
 
@@ -873,6 +1129,7 @@ class AdminServer:
         host: str = DEFAULT_HOST,
         port: int = DEFAULT_PORT,
         enable_watcher: bool = False,
+        enable_viz: bool = True,
     ) -> None:
         if host not in ALLOWED_HOSTS:
             raise ValueError(
@@ -885,9 +1142,12 @@ class AdminServer:
         self.mode = detect_mode(self.root)
         self.watcher: Optional[ConfigWatcher] = None
         self.enable_watcher = enable_watcher
+        self.enable_viz = enable_viz
+        self.viz_manager = VizManager(self.root)
 
         AdminRequestHandler.config_manager = ConfigManager(self.root, self.mode)
         AdminRequestHandler.sync_executor = SyncExecutor(self.root)
+        AdminRequestHandler.viz_manager = self.viz_manager
         AdminRequestHandler.mode = self.mode
         AdminRequestHandler.root = self.root
         AdminRequestHandler.version = self._read_version()
@@ -912,6 +1172,10 @@ class AdminServer:
             self.watcher = ConfigWatcher(self.root)
             self.watcher.start()
 
+        # Start Viz dashboard + MCP server as supervised subprocesses.
+        if self.enable_viz:
+            self.viz_manager.start_all()
+
         print(f"  i  agent-meta Admin UI")
         print(f"  i  Mode:    {self.mode}")
         print(f"  i  Version: {AdminRequestHandler.version}")
@@ -919,6 +1183,8 @@ class AdminServer:
         print(f"  i  Root:    {self.root}")
         if self.enable_watcher:
             print(f"  i  Watcher: enabled (.meta-viz/events.jsonl)")
+        if not self.enable_viz:
+            print(f"  i  Viz/MCP: disabled (--no-viz)")
         print(f"  i  Press Ctrl+C to stop")
         print()
 
@@ -930,6 +1196,10 @@ class AdminServer:
             self.httpd.server_close()
             if self.watcher is not None:
                 self.watcher.stop()
+            # Sub-servers are intentionally left running — they are detached
+            # processes with their own PID-files. The user can stop them via
+            # ``python scripts/viz-server.py stop`` or a subsequent
+            # ``admin-server.py`` invocation with ``--stop-viz`` (future).
 
 
 # --------------------------------------------------------------------------- #
@@ -944,11 +1214,21 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=DEFAULT_PORT,
                         help=f"Server port (default: {DEFAULT_PORT})")
     parser.add_argument("--host", default=DEFAULT_HOST, choices=list(ALLOWED_HOSTS),
-                        help=f"Bind host — loopback only (default: {DEFAULT_HOST})")
+                        help=f"Bind host -- loopback only (default: {DEFAULT_HOST})")
     parser.add_argument("--root", default=".",
                         help="Project root directory (default: current directory)")
     parser.add_argument("--watch", action="store_true",
                         help="Enable filesystem watcher (polls config files every 2s)")
+    parser.add_argument(
+        "--no-viz",
+        dest="no_viz",
+        action="store_true",
+        help=(
+            "Skip starting the Viz dashboard and MCP server as subprocesses. "
+            "Useful for lightweight / CI environments where only the Admin UI "
+            "itself is needed."
+        ),
+    )
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
@@ -956,7 +1236,13 @@ def main() -> None:
         print(f"  !  root directory does not exist: {root}", file=sys.stderr)
         sys.exit(1)
 
-    server = AdminServer(root, host=args.host, port=args.port, enable_watcher=args.watch)
+    server = AdminServer(
+        root,
+        host=args.host,
+        port=args.port,
+        enable_watcher=args.watch,
+        enable_viz=not args.no_viz,
+    )
     server.start()
 
 

--- a/scripts/viz-server.py
+++ b/scripts/viz-server.py
@@ -1,31 +1,34 @@
 #!/usr/bin/env python3
 """
-viz-server.py — Start/Stop/Toggle/Status für den agent-meta Viz- und MCP-Server
-=================================================================================
+viz-server.py — Thin backward-compatibility wrapper for agent-meta Admin UI
+=============================================================================
 
-Usage:
-  python scripts/viz-server.py start      # Dashboard + MCP-Server starten
-  python scripts/viz-server.py stop       # Beide Server beenden
-  python scripts/viz-server.py status     # Status beider Server
-  python scripts/viz-server.py restart    # Beide neustarten
-  python scripts/viz-server.py toggle     # Umschalten
-  python scripts/viz-server.py open       # Dashboard im Browser öffnen
-  python scripts/viz-server.py mcp-only   # Nur MCP-Server starten (ohne Dashboard)
+This script forwards all commands to ``admin-server.py``, which is now the
+unified entry-point for Admin UI, Viz dashboard and MCP SSE server.
 
-Konfiguration (.meta-config/project.yaml):
+Usage (legacy — all commands still work):
+  python scripts/viz-server.py start      # Start all servers via admin-server.py
+  python scripts/viz-server.py stop       # Stop Viz dashboard + MCP server
+  python scripts/viz-server.py status     # Show status of all servers
+  python scripts/viz-server.py restart    # Restart all servers
+  python scripts/viz-server.py toggle     # Toggle start/stop
+  python scripts/viz-server.py open       # Open Viz dashboard in browser
+  python scripts/viz-server.py mcp-only   # Start MCP server only
 
-  viz:
-    server:
-      port: 8765          # Dashboard-Port
-      timeout_sec: 300    # Auto-Shutdown nach Inaktivität
-    mcp:
-      port: 9090          # MCP-SSE-Port (opencode verbindet sich hierher)
+Migration note:
+  The preferred way to start all servers is now:
+    python scripts/admin-server.py          (Admin UI + Viz + MCP)
+    python scripts/admin-server.py --no-viz (Admin UI only)
+
+  This wrapper is kept for backward compatibility with existing scripts,
+  documentation and muscle memory. It will not be removed.
 """
 
 import sys
 import os
 import subprocess
 import time
+import webbrowser
 from pathlib import Path
 
 if hasattr(sys.stdout, "reconfigure"):
@@ -36,253 +39,109 @@ if hasattr(sys.stderr, "reconfigure"):
 SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 
-# --- Dashboard server ---
-VIZ_REPORT = SCRIPT_DIR / "viz-report.py"
-VIZ_PID_FILE = PROJECT_ROOT / ".meta-viz/.server-pid"
-VIZ_LOG_FILE = PROJECT_ROOT / ".meta-viz/server.log"
-
-# --- MCP server ---
-VIZ_LOGGER = SCRIPT_DIR / "viz-logger.py"
-MCP_PID_FILE = PROJECT_ROOT / ".meta-viz/.mcp-server-pid"
-MCP_LOG_FILE = PROJECT_ROOT / ".meta-viz/mcp-server.log"
-
-# --- Defaults ---
-_DEFAULT_VIZ_PORT = 8765
-_DEFAULT_VIZ_TIMEOUT = 300
-_DEFAULT_MCP_PORT = 9090
-
-
-def _load_server_config() -> dict:
-    """Load viz config from project.yaml, returns dict with defaults."""
-    config_path = PROJECT_ROOT / ".meta-config" / "project.yaml"
-    try:
-        sys.path.insert(0, str(SCRIPT_DIR))
-        from lib.config import load_config
-        config = load_config(config_path)
-        viz_cfg = config.get("viz", {})
-        server_cfg = viz_cfg.get("server", {})
-        mcp_cfg = viz_cfg.get("mcp", {})
-        return {
-            "viz_port": int(server_cfg.get("port", _DEFAULT_VIZ_PORT)),
-            "viz_timeout": int(server_cfg.get("timeout_sec", _DEFAULT_VIZ_TIMEOUT)),
-            "mcp_port": int(mcp_cfg.get("port", _DEFAULT_MCP_PORT)),
-        }
-    except Exception:
-        return {
-            "viz_port": _DEFAULT_VIZ_PORT,
-            "viz_timeout": _DEFAULT_VIZ_TIMEOUT,
-            "mcp_port": _DEFAULT_MCP_PORT,
-        }
-
-
-def _is_process_running(pid: int) -> bool:
-    if not pid:
-        return False
-    try:
-        if sys.platform == "win32":
-            import ctypes
-            kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(1, False, pid)
-            if handle:
-                kernel32.CloseHandle(handle)
-                return True
-            return False
-        else:
-            os.kill(pid, 0)
-            return True
-    except (OSError, ProcessLookupError):
-        return False
-
-
-def _read_pid(pid_file: Path) -> int | None:
-    if pid_file.exists():
-        try:
-            return int(pid_file.read_text().strip())
-        except ValueError:
-            pass
-    return None
-
-
-def _start_process(args: list[str], pid_file: Path, log_file: Path, label: str) -> bool:
-    """Start a background process, write PID. Returns True on success."""
-    pid_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Rotate old log
-    if log_file.exists():
-        try:
-            log_file.unlink()
-        except PermissionError:
-            pass
-
-    if sys.platform == "win32":
-        si = subprocess.STARTUPINFO()
-        si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        si.wShowWindow = 0  # SW_HIDE
-        proc = subprocess.Popen(
-            args,
-            stdout=open(log_file, "a", encoding="utf-8"),
-            stderr=subprocess.STDOUT,
-            startupinfo=si,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-            cwd=str(PROJECT_ROOT),
-        )
-    else:
-        proc = subprocess.Popen(
-            args,
-            stdout=open(log_file, "a", encoding="utf-8"),
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            cwd=str(PROJECT_ROOT),
-        )
-
-    pid_file.write_text(str(proc.pid))
-    time.sleep(1.5)
-
-    if _is_process_running(proc.pid):
-        print(f"  + {label} gestartet. PID: {proc.pid}")
-        return True
-    else:
-        print(f"  ! {label} konnte nicht gestartet werden. Siehe {log_file}")
-        pid_file.unlink(missing_ok=True)
-        return False
-
-
-def _stop_process(pid_file: Path, label: str):
-    pid = _read_pid(pid_file)
-    if not pid:
-        print(f"  - {label}: läuft nicht.")
-        pid_file.unlink(missing_ok=True)
-        return
-
-    if not _is_process_running(pid):
-        print(f"  - {label}: Prozess {pid} nicht mehr aktiv.")
-        pid_file.unlink(missing_ok=True)
-        return
-
-    try:
-        if sys.platform == "win32":
-            subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=True, capture_output=True)
-        else:
-            os.kill(pid, 15)
-            time.sleep(1)
-            if _is_process_running(pid):
-                os.kill(pid, 9)
-        print(f"  - {label} beendet (PID: {pid}).")
-    except Exception as e:
-        print(f"  ! Fehler beim Beenden von {label}: {e}")
-    finally:
-        pid_file.unlink(missing_ok=True)
-
-
 # ---------------------------------------------------------------------------
-# Dashboard server
+# Locate the VizManager helpers from admin-server module
 # ---------------------------------------------------------------------------
+# We import the shared helpers directly from admin-server.py rather than
+# duplicating them — single source of truth for PID-file paths and process
+# management logic.
 
-def start_viz():
-    cfg = _load_server_config()
-    pid = _read_pid(VIZ_PID_FILE)
-    if pid and _is_process_running(pid):
-        print(f"  - Dashboard läuft bereits (PID: {pid}, Port: {cfg['viz_port']})")
-        return
-    _start_process(
-        [sys.executable, str(VIZ_REPORT), "--serve", "--port", str(cfg["viz_port"]), "--timeout", str(cfg["viz_timeout"])],
-        VIZ_PID_FILE, VIZ_LOG_FILE,
-        f"Dashboard (Port {cfg['viz_port']})",
+sys.path.insert(0, str(SCRIPT_DIR))
+try:
+    from admin_server import (  # type: ignore[import]
+        VizManager,
+        _load_viz_config,
+        _read_pid,
+        _is_pid_running,
+        VIZ_PID_FILE,
+        MCP_PID_FILE,
     )
+    _IMPORT_OK = True
+except ImportError:
+    _IMPORT_OK = False
 
 
-def stop_viz():
-    _stop_process(VIZ_PID_FILE, "Dashboard")
+def _get_viz_manager() -> "VizManager":
+    if not _IMPORT_OK:
+        print("  !  Could not import admin-server.py helpers. Is the file present?",
+              file=sys.stderr)
+        sys.exit(1)
+    return VizManager(PROJECT_ROOT)
 
 
-def viz_running() -> bool:
-    pid = _read_pid(VIZ_PID_FILE)
-    return bool(pid and _is_process_running(pid))
-
-
-# ---------------------------------------------------------------------------
-# MCP server
-# ---------------------------------------------------------------------------
-
-def start_mcp():
-    cfg = _load_server_config()
-    pid = _read_pid(MCP_PID_FILE)
-    if pid and _is_process_running(pid):
-        print(f"  - MCP-Server läuft bereits (PID: {pid}, Port: {cfg['mcp_port']})")
-        return
-    _start_process(
-        [sys.executable, "-u", str(VIZ_LOGGER), "--http", str(cfg["mcp_port"])],
-        MCP_PID_FILE, MCP_LOG_FILE,
-        f"MCP-Server (Port {cfg['mcp_port']})",
-    )
-
-
-def stop_mcp():
-    _stop_process(MCP_PID_FILE, "MCP-Server")
-
-
-def mcp_running() -> bool:
-    pid = _read_pid(MCP_PID_FILE)
-    return bool(pid and _is_process_running(pid))
-
-
-# ---------------------------------------------------------------------------
-# Commands
-# ---------------------------------------------------------------------------
-
-def cmd_start(mcp_only: bool = False):
-    cfg = _load_server_config()
-    if not mcp_only:
-        start_viz()
-    start_mcp()
+def cmd_start(mcp_only: bool = False) -> None:
+    mgr = _get_viz_manager()
+    cfg = _load_viz_config(PROJECT_ROOT)
+    if mcp_only:
+        # Only start MCP by using a temp VizManager that skips viz
+        mcp_pid = PROJECT_ROOT / MCP_PID_FILE
+        mcp_log = PROJECT_ROOT / ".meta-viz" / "mcp-server.log"
+        if not _is_pid_running(_read_pid(mcp_pid)):
+            mgr._start(
+                [sys.executable, "-u", str(mgr._viz_logger), "--http", str(cfg["mcp_port"])],
+                mcp_pid, mcp_log,
+                f"MCP server (port {cfg['mcp_port']})",
+            )
+        else:
+            print(f"  -  MCP server already running (PID: {_read_pid(mcp_pid)})")
+    else:
+        mgr.start_all()
     print()
     if not mcp_only:
-        print(f"  Dashboard: http://localhost:{cfg['viz_port']}/")
-    print(f"  MCP-SSE:   http://127.0.0.1:{cfg['mcp_port']}/sse")
-    print(f"  Logs:      {PROJECT_ROOT / '.meta-viz'}")
+        print(f"  Viz dashboard:  http://localhost:{cfg['viz_port']}/")
+    print(f"  MCP SSE:        http://127.0.0.1:{cfg['mcp_port']}/sse")
+    print(f"  Admin UI:       http://127.0.0.1:7420/")
+    print(f"  Logs:           {PROJECT_ROOT / '.meta-viz'}")
 
 
-def cmd_stop():
-    stop_viz()
-    stop_mcp()
+def cmd_stop() -> None:
+    _get_viz_manager().stop_all()
 
 
-def cmd_status():
-    cfg = _load_server_config()
-    viz = viz_running()
-    mcp = mcp_running()
+def cmd_status() -> None:
+    if not _IMPORT_OK:
+        print("  !  Could not import admin-server.py helpers.", file=sys.stderr)
+        sys.exit(1)
+    status = _get_viz_manager().status()
+    viz = status["viz"]
+    mcp = status["mcp"]
 
-    print(f"  Dashboard  (Port {cfg['viz_port']}): {'LAUFT' if viz else 'GESTOPPT'}")
-    if viz:
-        print(f"    PID: {_read_pid(VIZ_PID_FILE)}  |  http://localhost:{cfg['viz_port']}/")
+    print(f"  Viz dashboard (port {viz['port']}): {'RUNNING' if viz['running'] else 'STOPPED'}")
+    if viz["running"]:
+        print(f"    PID: {viz['pid']}  |  {viz['url']}")
+    print(f"  MCP server    (port {mcp['port']}): {'RUNNING' if mcp['running'] else 'STOPPED'}")
+    if mcp["running"]:
+        print(f"    PID: {mcp['pid']}  |  {mcp['url']}")
 
-    print(f"  MCP-Server (Port {cfg['mcp_port']}): {'LAUFT' if mcp else 'GESTOPPT'}")
-    if mcp:
-        print(f"    PID: {_read_pid(MCP_PID_FILE)}  |  http://127.0.0.1:{cfg['mcp_port']}/sse")
 
-
-def cmd_toggle():
-    if viz_running() or mcp_running():
-        print("  i  Server laufen — stoppe...")
+def cmd_toggle() -> None:
+    if not _IMPORT_OK:
+        print("  !  Could not import admin-server.py helpers.", file=sys.stderr)
+        sys.exit(1)
+    status = _get_viz_manager().status()
+    if status["viz"]["running"] or status["mcp"]["running"]:
+        print("  i  Servers running — stopping...")
         cmd_stop()
     else:
-        print("  i  Server gestoppt — starte...")
+        print("  i  Servers stopped — starting...")
         cmd_start()
 
 
-def cmd_restart():
+def cmd_restart() -> None:
     cmd_stop()
     time.sleep(1)
     cmd_start()
 
 
-def cmd_open():
-    import webbrowser
-    cfg = _load_server_config()
+def cmd_open() -> None:
+    if not _IMPORT_OK:
+        print("  !  Could not import admin-server.py helpers.", file=sys.stderr)
+        sys.exit(1)
+    cfg = _load_viz_config(PROJECT_ROOT)
     webbrowser.open(f"http://localhost:{cfg['viz_port']}/")
 
 
-def main():
+def main() -> None:
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(1)
@@ -290,13 +149,13 @@ def main():
     cmd = sys.argv[1].lower()
 
     commands = {
-        "start": lambda: cmd_start(),
+        "start":    lambda: cmd_start(),
         "mcp-only": lambda: cmd_start(mcp_only=True),
-        "stop": cmd_stop,
-        "status": cmd_status,
-        "restart": cmd_restart,
-        "toggle": cmd_toggle,
-        "open": cmd_open,
+        "stop":     cmd_stop,
+        "status":   cmd_status,
+        "restart":  cmd_restart,
+        "toggle":   cmd_toggle,
+        "open":     cmd_open,
     }
 
     handler = commands.get(cmd)


### PR DESCRIPTION
## Summary

- **Feature A (Target Repo View):** In `super_admin` mode the Admin UI now exposes the meta-repo's own `.meta-config/project.yaml` as a separate "Target repo" section on the dashboard and a dedicated sidebar nav item. The `/api/mode` endpoint signals `project_admin_available` so both views are visible simultaneously without switching modes.

- **Feature B (Unified Entry-Point):** `admin-server.py` is now the single entry-point that starts the Viz dashboard (`viz-report.py`) and MCP SSE server (`viz-logger.py`) as supervised subprocesses on startup. A `--no-viz` flag skips sub-server startup for lightweight/CI use. A new `/api/subserver-status` REST endpoint exposes running state, PIDs and URLs — displayed in a "Sub-servers" panel on the dashboard. `viz-server.py` is rewritten as a thin backward-compatible wrapper that imports `VizManager` from `admin-server.py`.

## Changed files

| File | Change |
|------|--------|
| `scripts/admin-server.py` | `VizManager` class, `--no-viz` flag, `/api/subserver-status`, `/api/mode` extended, `AdminServer.enable_viz` param |
| `scripts/viz-server.py` | Rewritten as thin wrapper importing from `admin-server.py`; all existing commands preserved |
| `docs/admin-ui.html` | Dashboard: Target Repo panel + Sub-servers status panel; sidebar: target project.yaml nav item; `/config/project-target` route |

## Test plan

- [ ] `python scripts/admin-server.py --help` shows `--no-viz` flag
- [ ] `python scripts/admin-server.py --no-viz` starts only Admin UI (no viz/mcp subprocesses)
- [ ] `python scripts/admin-server.py` starts Admin UI + Viz + MCP; dashboard shows Sub-servers panel with running status
- [ ] In browser (super_admin mode): dashboard shows "Target repo" section linking to `/config/project-target`
- [ ] `/config/project-target` sidebar item only visible in `super_admin` mode when `.meta-config/project.yaml` exists
- [ ] `python scripts/viz-server.py start/stop/status` still works (backward compat)
- [ ] In a target repo (project_admin mode): no regression — only `project.yaml` is shown, no Target Repo section

🤖 Generated with [Claude Code](https://claude.com/claude-code)