### PR TITLE
feat: 5 framework improvements — security, docs, max_tokens, commands, CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,39 @@
+name: Validate Generated Files
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Validate sync output
+        run: python scripts/sync.py --validate
+      - name: Lint agent frontmatter
+        run: |
+          python3 -c "
+          import yaml, sys
+          from pathlib import Path
+          errors = []
+          for f in Path('agents').rglob('*.md'):
+              txt = f.read_text()
+              if txt.startswith('---'):
+                  end = txt.find('\n---', 3)
+                  if end != -1:
+                      try: yaml.safe_load(txt[3:end])
+                      except yaml.YAMLError as e: errors.append(f'{f}: {e}')
+          if errors:
+              print('\n'.join(errors)); sys.exit(1)
+          print(f'OK: {len(list(Path(\"agents\").rglob(\"*.md\")))} files checked')
+          "

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -407,6 +407,16 @@
         ]
       }
     },
+    "temperature-overrides": {
+      "type": "object",
+      "description": "Override sampling temperature per role. Float 0.0–1.0.",
+      "additionalProperties": { "type": "number", "minimum": 0.0, "maximum": 1.0 }
+    },
+    "max-tokens-overrides": {
+      "type": "object",
+      "description": "Override max output tokens per role. Positive integer.",
+      "additionalProperties": { "type": "integer", "minimum": 1 }
+    },
     "dod-preset": {
       "type": "string",
       "description": "DoD quality profile. Sets defaults for all dod criteria. Individual overrides via 'dod' block. Presets defined in dod-presets.config.json.",

--- a/config/role-defaults.yaml
+++ b/config/role-defaults.yaml
@@ -30,6 +30,9 @@
 #
 # workflow_tier: Empfehlungsstufe. 'required' = Kern-Workflow; 'recommended' = Standard-Qualität;
 #   'optional' = bei Bedarf. User steuert via 'roles' in .meta-config/project.yaml.
+#
+# temperature: Sampling-Temperatur. Optional. Float 0.0–1.0. Leer = Provider-Default.
+# max_tokens: Max Output-Tokens. Optional. Positive Ganzzahl. Leer = Provider-Default.
 
 roles:
 

--- a/hooks/1-generic/dod-push-check.sh
+++ b/hooks/1-generic/dod-push-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hook: dod-push-check
-# version: 1.1.0
+# version: 1.2.0
 # event: PreToolUse
 # matcher: Bash
 # provider: Claude
@@ -82,7 +82,7 @@ if [ -z "$TEST_CMD" ]; then
 fi
 
 echo "DoD-Check: Running '$TEST_CMD'..."
-if ! eval "$TEST_CMD" 2>&1; then
+if ! bash -c "$TEST_CMD" 2>&1; then  # Note: TEST_CMD executed via bash -c (no eval) — value from project.yaml
   echo ""
   echo "DoD-Check FAILED: Tests must pass before pushing."
   echo "Fix failing tests and retry, or disable the hook temporarily."

--- a/howto/features/commands.md
+++ b/howto/features/commands.md
@@ -1,0 +1,202 @@
+# Commands — Slash Commands im agent-meta Layer-System
+
+Commands sind Markdown-Dateien die Claude Code (und andere Plattformen) als aufrufbare
+Slash-Commands bereitstellen. Agent-meta verwaltet sie im selben Schichten-Modell wie Rules und Agents.
+
+---
+
+## Konzept
+
+```
+commands/
+  0-external/     ← Commands aus externen Skill-Repos (via Git Submodule)
+  1-generic/      ← universelle Commands, gelten für alle Projekte
+  2-platform/     ← plattformspezifisch (überschreibt 1-generic bei gleichem Dateinamen)
+  ← 3-project: .claude/commands/ im Zielprojekt — nie von sync.py berührt (außer managed)
+```
+
+```
+commands/1-generic/doc-now.md    ← Quelldatei in agent-meta
+    ↓  sync.py COPY + Variablen-Substitution
+.claude/commands/doc-now.md       ← immer synchronisiert
+    ↓  Claude Code registriert automatisch als Slash Command
+/project:doc-now [args]           ← im Hauptchat aufrufbar
+```
+
+---
+
+## Schichten-Modell
+
+| Schicht | Pfad | Prio | Wann |
+|---------|------|------|------|
+| 0-external | `commands/0-external/` | niedrig | Commands aus externen Skill-Repos |
+| 1-generic | `commands/1-generic/` | mittel | universell, alle Projekte |
+| 2-platform | `commands/2-platform/` | hoch | Plattform-Overrides (Prefix: `<platform>-`) |
+| 3-project | `.claude/commands/` im Zielprojekt | — | Projekt-eigene Commands (nie überschrieben) |
+
+**Naming für 2-platform:** `<platform>-<thema>.md` → Output: `<thema>.md`
+
+---
+
+## Sync-Verhalten je Provider
+
+`sync.py` kopiert Command-Dateien automatisch bei jedem normalen Sync:
+
+| Provider | Zielverzeichnis | Format | Besonderheiten |
+|----------|----------------|--------|---------------|
+| **Claude** | `.claude/commands/` | `.md` | As-is, keine Konvertierung |
+| **Continue** | `.continue/prompts/` | `.md` | `invokable: true` wird in Frontmatter injiziert |
+| **Gemini** | `.gemini/commands/` | `.toml` | Automatisch aus `.md` konvertiert; `$ARGUMENTS` → `{{args}}` |
+| **Opencode** | `.opencode/commands/` | `.md` | As-is, `$ARGUMENTS`-Syntax identisch zu Claude |
+
+- **Variablen-Substitution:** `{{VARIABLE}}` Platzhalter werden wie in Rules substituiert
+- **Stale-Tracking** via `.agent-meta-managed` in jedem Zielverzeichnis — veraltete Commands werden gelöscht
+- **Projekt-eigene Commands** (nicht in `.agent-meta-managed`) werden nie angefasst
+
+---
+
+## Command-Format (Frontmatter)
+
+### Claude / Opencode
+
+```markdown
+---
+description: Short description shown in the slash command picker
+allowed-tools: ["Agent", "Bash", "Read"]
+argument-hint: "[optional argument description]"
+---
+
+Command body here. Use $ARGUMENTS to receive optional user input.
+```
+
+| Feld | Pflicht | Bedeutung |
+|------|---------|-----------|
+| `description` | Ja | Kurzbeschreibung im Command-Picker |
+| `allowed-tools` | Nein | Werkzeuge die dieser Command nutzen darf |
+| `argument-hint` | Nein | Platzhalter-Hinweis für Argumente |
+
+### Continue
+
+Continue-Commands nutzen dasselbe Format — `sync.py` injiziert automatisch `invokable: true`:
+
+```markdown
+---
+name: doc-now
+description: Update CODEBASE_OVERVIEW.md immediately
+invokable: true   ← wird automatisch eingefügt
+---
+```
+
+---
+
+## $ARGUMENTS-Token
+
+`$ARGUMENTS` ist ein spezieller Platzhalter im Command-Body:
+
+```markdown
+Delegate to the `documenter` agent with this task:
+
+Update `CODEBASE_OVERVIEW.md` immediately. $ARGUMENTS
+```
+
+- Claude ersetzt `$ARGUMENTS` durch alles was der User nach dem Command-Namen eingibt
+- Bei Gemini wird `$ARGUMENTS` automatisch in `{{args}}` konvertiert
+- Kein Argument übergeben → `$ARGUMENTS` wird leer (kein Fehler)
+
+---
+
+## Projektspezifische Commands anlegen
+
+```bash
+# Erstellt .claude/commands/<name>.md als leeres Template (nie überschrieben)
+py .agent-meta/scripts/sync.py --create-command mein-command
+```
+
+Das erzeugte File liegt in `.claude/commands/mein-command.md` und wird von sync.py **nie überschrieben**
+(kein Eintrag in `.agent-meta-managed`).
+
+Alternativ: Command manuell in `.claude/commands/` anlegen — ebenfalls nie überschrieben.
+
+---
+
+## Stale-Tracking
+
+Jedes Zielverzeichnis enthält eine `.agent-meta-managed` Datei (bei Continue: `.agent-meta-commands-managed`):
+
+```
+doc-now.md
+feedback.md
+commit.md
+analyze-logs.md
+```
+
+- Commands die in dieser Liste stehen aber nicht mehr in den Quellen existieren → werden gelöscht
+- Commands die **nicht** in dieser Liste stehen (projekt-eigen) → werden nie angefasst
+
+---
+
+## Beispiel: doc-now.md
+
+`commands/1-generic/doc-now.md` ist der einfachste generische Command:
+
+```markdown
+---
+description: Delegate to documenter agent to update CODEBASE_OVERVIEW.md immediately
+allowed-tools: ["Agent"]
+argument-hint: "[area or file to focus on]"
+---
+
+Delegate to the `documenter` agent with this task:
+
+Update `CODEBASE_OVERVIEW.md` immediately. $ARGUMENTS
+```
+
+Aufruf: `/project:doc-now src/api` → delegiert mit dem Argument `src/api` an den `documenter`-Agenten.
+
+---
+
+## Verfügbare Framework-Commands (nach Sync)
+
+| Command | Beschreibung |
+|---------|-------------|
+| `/project:doc-now` | CODEBASE_OVERVIEW sofort aktualisieren |
+| `/project:feedback` | Bug oder Feature als GitHub Issue einreichen |
+| `/project:commit` | Commit mit Conventional-Commits-Format erstellen |
+| `/project:merge` | Feature-Branch mergen |
+| `/project:analyze-logs` | Log-Dateien analysieren |
+| `/project:diagnose` | Codebase-Problem diagnostizieren |
+| `/project:upgrade-meta` | agent-meta auf neue Version upgraden |
+| `/project:report-bug` | Bug-Report erstellen |
+| `/project:set-preset` | DoD-Preset wechseln |
+| `/project:pipelines` | Quality-Pipeline starten |
+
+Vollständige Liste: `commands/1-generic/` Verzeichnis.
+
+---
+
+## Abgrenzung zu Agenten
+
+| | Agenten (`.claude/agents/`) | Commands (`.claude/commands/`) |
+|---|---|---|
+| Format | Vollständige Persona / Markdown | Kurze Instruktion / Markdown |
+| Kontext | Isoliertes Context Window | Läuft im Hauptchat |
+| Scope | Komplexe, mehrstufige Aufgaben | Schnelle, wiederkehrende Einzel-Aktionen |
+| Aufruf | `Agent(subagent_type="...")` | `/project:<name> [args]` |
+| Von agent-meta generiert | Ja (1-generic / 2-platform) | Ja (1-generic / 2-platform) |
+
+---
+
+## Troubleshooting
+
+**Command erscheint nicht im Picker:**
+- Sync laufen lassen: `py .agent-meta/scripts/sync.py --config .meta-config/project.yaml`
+- Datei in `.claude/commands/` vorhanden?
+- Frontmatter korrekt (YAML valide, `description` gesetzt)?
+
+**$ARGUMENTS wird nicht ersetzt:**
+- Claude ersetzt `$ARGUMENTS` automatisch — keine manuelle Konfiguration nötig
+- Bei Gemini: `{{args}}` prüfen (automatisch konvertiert)
+
+**Command wird bei Sync gelöscht:**
+- Liegt die Datei in `.agent-meta-managed`? → Projekt-eigene Commands dürfen dort **nicht** eingetragen sein
+- Lösung: Command aus `.agent-meta-managed` entfernen (oder neu als projekt-eigen anlegen)

--- a/howto/setup/instantiate-project.md
+++ b/howto/setup/instantiate-project.md
@@ -66,6 +66,8 @@ Geeignet für schnelle, wiederkehrende Einzel-Aktionen.
 agent-meta verwaltet einen Teil der Commands automatisch (generisch und plattformspezifisch,
 analog zu Agenten). Projekt-eigene Commands in `.claude/3-project/commands/` werden nie überschrieben.
 
+> Vollständige Dokumentation: [howto/features/commands.md](../features/commands.md) — Layer-System, Frontmatter-Felder, `$ARGUMENTS`, `--create-command`, Stale-Tracking.
+
 | `.claude/agents/` | `.claude/commands/` |
 |-------------------|---------------------|
 | Vollständige Persona, isolierter Kontext | Schneller Einzel-Workflow im Hauptchat |

--- a/rules/2-platform/agent-meta-conventions.md
+++ b/rules/2-platform/agent-meta-conventions.md
@@ -65,5 +65,6 @@ Folgende Artefakte werden beim nächsten `sync.py`-Lauf automatisch generiert/ak
 | `agents/0-external/_skill-wrapper.md` | Alle aktivierten Skills neu syncen |
 | `config/skills-registry.yaml` | Projekte neu syncen |
 | `config/role-defaults.yaml` (neue Rolle) | Tabellen in CLAUDE.md + howto-Dateien |
+| `config/project-config.schema.json` | IDE-Autocomplete prüfen, jsonschema-Validation testen |
 | `hint:` Feld in Agent-Template | Projekte syncen (AGENT_HINTS wird neu generiert) |
 | Rules oder Hooks in `rules/` / `hooks/` | Projekte syncen (werden überschrieben) |

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -790,7 +790,7 @@ def sync_agents(
     """Generate all .claude/agents/*.md files (legacy Claude-only path)."""
     from .config import substitute, strip_inactive_conditional_blocks
     from .providers import load_providers_config
-    from .roles import build_role_map, resolve_model, resolve_memory, resolve_permission_mode
+    from .roles import build_role_map, resolve_model, resolve_memory, resolve_permission_mode, resolve_temperature, resolve_max_tokens
     from .skills import load_external_skills_config, _skill_is_active
 
     provider_config = load_providers_config(agent_meta_root)
@@ -874,6 +874,18 @@ def sync_agents(
         if permission_mode:
             pm_src = "project override" if role in config.get("permission-mode-overrides", {}) else "meta default"
             log.info(str(target_path.relative_to(project_root)), f"permissionMode: {permission_mode} (from {pm_src})")
+
+        temperature = resolve_temperature(role, config, agent_meta_root)
+        if temperature:
+            content = _update_frontmatter_dict(content, {"temperature": float(temperature)})
+            temp_src = "project override" if role in config.get("temperature-overrides", {}) else "meta default"
+            log.info(str(target_path.relative_to(project_root)), f"temperature: {temperature} (from {temp_src})")
+
+        max_tokens = resolve_max_tokens(role, config, agent_meta_root)
+        if max_tokens:
+            content = _update_frontmatter_dict(content, {"max_tokens": int(max_tokens)})
+            mt_src = "project override" if role in config.get("max-tokens-overrides", {}) else "meta default"
+            log.info(str(target_path.relative_to(project_root)), f"max_tokens: {max_tokens} (from {mt_src})")
 
         # Visualization: inject event-logging prompt block when dynamic/full mode is enabled
         viz_cfg = config.get("viz", {})
@@ -973,7 +985,7 @@ def sync_agents_for_provider(
     from .config import substitute, strip_inactive_conditional_blocks
     from .pipelines import inject_pipeline_blocks, load_quality_pipelines, apply_overrides
     from .platform import substitute_platform
-    from .roles import build_role_map, resolve_model, resolve_memory, resolve_temperature, resolve_steps, resolve_permission_mode, load_roles_config
+    from .roles import build_role_map, resolve_model, resolve_memory, resolve_temperature, resolve_max_tokens, resolve_steps, resolve_permission_mode, load_roles_config
     from .skills import load_external_skills_config, _skill_is_active
 
     pc = provider_config.get(provider)
@@ -1217,6 +1229,10 @@ def sync_agents_for_provider(
                 if temperature:
                     src = 'project override' if role in config.get('temperature-overrides', {}) else 'meta default'
                     log.info(str(target_path.relative_to(project_root)), f'temperature: {temperature} (from {src})')
+                max_tokens = resolve_max_tokens(role, config, agent_meta_root)
+                if max_tokens:
+                    mt_src = 'project override' if role in config.get('max-tokens-overrides', {}) else 'meta default'
+                    log.info(str(target_path.relative_to(project_root)), f'max_tokens: {max_tokens} (from {mt_src})')
                 steps = resolve_steps(role, config, agent_meta_root)
                 if steps:
                     src = 'project override' if role in config.get('steps-overrides', {}) else 'meta default'
@@ -1553,7 +1569,11 @@ def _transform_frontmatter_for_opencode(
     if "temperature" in template_fm:
         updates["temperature"] = template_fm["temperature"]
     elif temperature:
-        updates["temperature"] = temperature
+        updates["temperature"] = float(temperature)
+
+    # Preserve max_tokens: template frontmatter takes precedence over role defaults
+    if "max_tokens" in template_fm:
+        updates["max_tokens"] = template_fm["max_tokens"]
 
     # Remove fields not used by opencode
     removes = [

--- a/scripts/lib/roles.py
+++ b/scripts/lib/roles.py
@@ -183,6 +183,21 @@ def resolve_temperature(role: str, project_config: dict, agent_meta_root: Path) 
     return roles_cfg["roles"].get(role, {}).get("temperature", "")
 
 
+def resolve_max_tokens(role: str, project_config: dict, agent_meta_root: Path) -> str:
+    """Resolve the max_tokens for a role.
+
+    Precedence (highest to lowest):
+    1. Project override: project_config["max-tokens-overrides"][role]
+    2. Meta default:     role-defaults.yaml roles[role].max_tokens
+    3. Empty string:     no max_tokens: field injected
+    """
+    project_overrides = project_config.get("max-tokens-overrides", {})
+    if role in project_overrides:
+        return str(project_overrides[role])
+    roles_cfg = load_roles_config(agent_meta_root)
+    return str(roles_cfg["roles"].get(role, {}).get("max_tokens", "")) or ""
+
+
 def resolve_steps(role: str, project_config: dict, agent_meta_root: Path) -> str:
     """Resolve the steps limit for a role.
 


### PR DESCRIPTION
## Summary

- **#305 Security:** Replace `eval` with `bash -c` in `dod-push-check.sh` to prevent shell injection; version bumped to 1.2.0
- **#301 Docs:** Add `config/project-config.schema.json` entry to the conventions change checklist
- **#303 Feature:** Add `max_tokens` support across Claude + Opencode providers; fix temperature injection in Claude provider block; add schema entries for `temperature-overrides` and `max-tokens-overrides`
- **REQ-CMD-09 Docs:** New `howto/features/commands.md` covering the full Commands layer-system (4 layers, provider sync behavior, frontmatter fields, `$ARGUMENTS`, `--create-command`, stale-tracking); add reference in `instantiate-project.md`
- **#304 CI:** New `.github/workflows/validate.yml` — runs `sync.py --validate` + YAML frontmatter lint on push/PR/schedule

## Test plan

- [ ] `python scripts/sync.py --dry-run` completes without errors
- [ ] `resolve_max_tokens('developer', {'max-tokens-overrides': {'developer': 4096}}, root)` returns `'4096'`
- [ ] `hooks/1-generic/dod-push-check.sh` line 85 uses `bash -c` (not `eval`)
- [ ] `config/project-config.schema.json` validates as valid JSON with new `temperature-overrides` and `max-tokens-overrides` keys
- [ ] `howto/features/commands.md` exists and covers all 8 required topics
- [ ] `.github/workflows/validate.yml` triggers on push/PR to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)