### PR TITLE
fix: resolve SE-framework consistency across config, templates, docs

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -464,6 +464,63 @@ Execution mode: loop
 3. background(agent="documenter", prompt="CODEBASE_OVERVIEW und Session-Erkenntnisse aktualisieren") → warten bis abgeschlossen
 
 
+**SE cascade does NOT replace the DoD preset** — it adds a specification layer BEFORE implementation. Choose your DoD preset independently, then add SE via the `se-required` field.
+
+### Output Directory Structure
+
+Configurable via `.meta-config/project.yaml` → `se_output`:
+
+```yaml
+se_output:
+  base_dir: "SE"              # Hauptordner
+  per_level_dirs: true        # L1/, L2/, L3/, ... (rekursiv geschachtelt)
+  per_system_dirs: true       # .../L1/Gesamtsystem/L2/AuthServiceSystem/, ...
+```
+
+**Folder naming:** System folders get `System` postfix, Component folders get `Component` postfix.
+
+Generated structure (example with SE_MAX_DEPTH=4):
+```
+SE/
+├── STRATEGY.md                    # System-Ziel, Constraints
+├── traceability-matrix.md         # REQ-L1-001 → ARCH-L1-001 → REQ-L2-001 → ...
+├── interface-registry.md          # Zentrale Interface-Tabelle
+│
+├── L0/
+│   └── SN_Stakeholder_Needs.md
+│
+└── L1/
+    └── Gesamtsystem/
+        ├── L1_Gesamtsystem_Requirements.md
+        ├── L1_Gesamtsystem_Architecture.md
+        └── L2/
+            ├── AuthServiceSystem/
+            │   ├── L2_AuthServiceSystem_Requirements.md
+            │   ├── L2_AuthServiceSystem_Architecture.md
+            │   └── L3/
+            │       ├── TokenValidatorComponent/
+            │       │   └── L3_TokenValidatorComponent_Requirements.md
+            │       └── JWTHandlerComponent/
+            │           └── L3_JWTHandlerComponent_Requirements.md
+            └── MCPServerSystem/
+                ├── L2_MCPServerSystem_Requirements.md
+                ├── L2_MCPServerSystem_Architecture.md
+                └── L3/
+                    └── CryptoEngineComponent/
+                        └── L3_CryptoEngineComponent_Requirements.md
+```
+
+**Rules:**
+- Jedes System hat genau eine Requirements- und eine Architecture-Datei
+- L{level}-Ordner sind **rekursiv geschachtelt**: L2 liegt in `L1/{System}/`, L3 in `L1/{System}/L2/{System}/`, usw.
+- System-Ordner erhalten Postfix `System`, Component-Ordner Postfix `Component`
+- Cross-cutting Dokumente (STRATEGY, traceability-matrix, interface-registry) liegen direkt in SE/
+- L0 hat nur Stakeholder-Needs (keine Architektur)
+- Leaf-Systeme (termination=leaf, designation=Component) haben nur Requirements (keine weitere Architecture)
+- Der Orchestrator legt die Ordnerstruktur VOR Delegation an die SE-Agenten an und setzt `output_parent_path` und `FolderName` im A2A-Envelope-Payload
+
+
+
 ---
 
 ## Few-Shot Patterns
@@ -502,6 +559,7 @@ Intent nicht in Tabelle:
 2. Fallback:
 ```
   → Anonymisieren → meta-feedback + Neuformulierung erbitten
+
 ```
 3. Nie selbst ausführen, nie raten, nie abbrechen.
 

--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -467,6 +467,63 @@ Execution mode: loop
 3. task(subagent_type="documenter", prompt="CODEBASE_OVERVIEW und Session-Erkenntnisse aktualisieren") → warten bis abgeschlossen
 
 
+**SE cascade does NOT replace the DoD preset** — it adds a specification layer BEFORE implementation. Choose your DoD preset independently, then add SE via the `se-required` field.
+
+### Output Directory Structure
+
+Configurable via `.meta-config/project.yaml` → `se_output`:
+
+```yaml
+se_output:
+  base_dir: "SE"              # Hauptordner
+  per_level_dirs: true        # L1/, L2/, L3/, ... (rekursiv geschachtelt)
+  per_system_dirs: true       # .../L1/Gesamtsystem/L2/AuthServiceSystem/, ...
+```
+
+**Folder naming:** System folders get `System` postfix, Component folders get `Component` postfix.
+
+Generated structure (example with SE_MAX_DEPTH=4):
+```
+SE/
+├── STRATEGY.md                    # System-Ziel, Constraints
+├── traceability-matrix.md         # REQ-L1-001 → ARCH-L1-001 → REQ-L2-001 → ...
+├── interface-registry.md          # Zentrale Interface-Tabelle
+│
+├── L0/
+│   └── SN_Stakeholder_Needs.md
+│
+└── L1/
+    └── Gesamtsystem/
+        ├── L1_Gesamtsystem_Requirements.md
+        ├── L1_Gesamtsystem_Architecture.md
+        └── L2/
+            ├── AuthServiceSystem/
+            │   ├── L2_AuthServiceSystem_Requirements.md
+            │   ├── L2_AuthServiceSystem_Architecture.md
+            │   └── L3/
+            │       ├── TokenValidatorComponent/
+            │       │   └── L3_TokenValidatorComponent_Requirements.md
+            │       └── JWTHandlerComponent/
+            │           └── L3_JWTHandlerComponent_Requirements.md
+            └── MCPServerSystem/
+                ├── L2_MCPServerSystem_Requirements.md
+                ├── L2_MCPServerSystem_Architecture.md
+                └── L3/
+                    └── CryptoEngineComponent/
+                        └── L3_CryptoEngineComponent_Requirements.md
+```
+
+**Rules:**
+- Jedes System hat genau eine Requirements- und eine Architecture-Datei
+- L{level}-Ordner sind **rekursiv geschachtelt**: L2 liegt in `L1/{System}/`, L3 in `L1/{System}/L2/{System}/`, usw.
+- System-Ordner erhalten Postfix `System`, Component-Ordner Postfix `Component`
+- Cross-cutting Dokumente (STRATEGY, traceability-matrix, interface-registry) liegen direkt in SE/
+- L0 hat nur Stakeholder-Needs (keine Architektur)
+- Leaf-Systeme (termination=leaf, designation=Component) haben nur Requirements (keine weitere Architecture)
+- Der Orchestrator legt die Ordnerstruktur VOR Delegation an die SE-Agenten an und setzt `output_parent_path` und `FolderName` im A2A-Envelope-Payload
+
+
+
 ---
 
 ## Few-Shot Patterns
@@ -505,6 +562,7 @@ Intent nicht in Tabelle:
 2. Fallback:
 ```
   → Anonymisieren → meta-feedback + Neuformulierung erbitten
+
 ```
 3. Nie selbst ausführen, nie raten, nie abbrechen.
 

--- a/agents/1-generic/se-critic.md
+++ b/agents/1-generic/se-critic.md
@@ -1,6 +1,6 @@
 ---
 name: se-critic
-version: 1.6.0
+version: 1.7.0
 description: Audits requirements and architecture against generic laws (orthogonality,
   testability, traceability).
 hint: Use this agent to validate requirements before architecture, and audit architectural
@@ -57,7 +57,7 @@ Input als A2A-Envelope:
 Bei `supersession`: Prüfe ob beanstandete Issues aus `supersession.reason` behoben wurden.
 
 ## Audit Criteria
-Four checks per output. Each yields boolean `passed` + list of `issues` (empty if passed).
+Five checks per output. Each yields boolean `passed` + list of `issues` (empty if passed).
 
 ### Requirements Review Checks
 
@@ -80,6 +80,12 @@ Four checks per output. Each yields boolean `passed` + list of `issues` (empty i
 - Every requirement has a valid `req_id`?
 - `rationale` field present and linked to a stakeholder need?
 - External interface references consistent across requirements?
+
+#### 5. Resilience
+- Failure modes documented (what fails, how, with what impact)?
+- Timeout / retry / backoff strategies defined for time-bounded operations?
+- Graceful degradation paths identified for partial-failure scenarios?
+- Stateless design applied where applicable (no hidden coupling via implicit state)?
 
 ### Architecture Review Checks
 
@@ -105,6 +111,12 @@ Four checks per output. Each yields boolean `passed` + list of `issues` (empty i
 - Every sub-system has valid `id` and `parent_req_id`?
 - `internal_interfaces` references valid (`source_id`, `target_id` exist in `sub_systems`)?
 - Architectural rationale references parent requirement explicitly?
+
+#### 5. Resilience
+- Failure modes documented per sub-system (what fails, how, with what impact)?
+- Timeout / retry / backoff strategies defined for cross-system interactions?
+- Graceful degradation paths identified (which interfaces tolerate partial failure)?
+- Stateless design applied where applicable (no hidden coupling via implicit state)?
 
 ## Decision Logic
 Up to `max_iterations: {{MAX_ITERATIONS}}`. Verdicts:
@@ -142,6 +154,10 @@ Return your final output **only** as a JSON object matching the following schema
       "issues": []
     },
     "traceability": {
+      "passed": true,
+      "issues": []
+    },
+    "resilience": {
       "passed": true,
       "issues": []
     }

--- a/agents/1-generic/se-interface-mgr.md
+++ b/agents/1-generic/se-interface-mgr.md
@@ -1,6 +1,6 @@
 ---
 name: se-interface-mgr
-version: 1.5.0
+version: 1.6.0
 description: Manages generic signal flow and deterministic synchronization across
   systems.
 hint: Manages generic signal flow, deterministic sync across systems
@@ -89,6 +89,17 @@ You are the **Interface Manager Agent** (`se-interface-mgr`) in the generic syst
 5. Generate interface spec per sub-system for the next level.
 6. Return structured output per JSON schema.
 
+## Design-by-Contract
+
+Every internal interface is a **contract** between caller and implementer with four formal facets:
+
+- **`version`** (semver) — interface version. Bump on breaking change so consumers can pin compatible versions.
+- **`preconditions`** — caller obligations. What MUST be true before the call (input shape, auth state, ordering). Violation → caller bug.
+- **`postconditions`** — implementation guarantees. What WILL be true after a successful call (output shape, side effects, state mutations). Violation → implementer bug.
+- **`invariants`** — properties that hold both before AND after every call (e.g. monotonic counters, registry consistency, no-leak of internal state).
+
+Define these explicitly per interface — they become the binding test oracle for `se-test-engineer` and the audit basis for `se-critic`.
+
 ## JSON Output Schema
 
 ```json
@@ -98,7 +109,20 @@ You are the **Interface Manager Agent** (`se-interface-mgr`) in the generic syst
       "source_id": "REQ-L2-002",
       "target_id": "REQ-L2-001",
       "interface_type": "analog_signal",
-      "data_payload": "PWM control signal 0-100%, 5V logic level"
+      "data_payload": "PWM control signal 0-100%, 5V logic level",
+      "version": "1.0.0",
+      "preconditions": [
+        "source_id is registered and active",
+        "PWM frequency setting initialized"
+      ],
+      "postconditions": [
+        "control signal applied within 10ms",
+        "duty cycle clamped to [0, 100]"
+      ],
+      "invariants": [
+        "signal level never exceeds 5V",
+        "interface remains registered until both endpoints deregister"
+      ]
     }
   ],
   "propagation_map": {

--- a/config/role-defaults.yaml
+++ b/config/role-defaults.yaml
@@ -254,7 +254,9 @@ roles:
     model: balanced
     memory: ""
     workflow_tier: optional
-    description: "Koordiniert den gesamten 6-stufigen rekursiven Systems-Engineering-Herunterbruch."
+    deprecated: true
+    deprecated_by: "orchestrator"
+    description: "DEPRECATED — SE-Funktionalität wird nun direkt vom orchestrator via SE-Mode übernommen. Wird nur aus Backward-Compatibility-Gründen behalten."
     handoff:
       input_contracts: ["task-spec-v1"]
       output_contract: "task-spec-v1"
@@ -661,7 +663,7 @@ quality_pipelines:
           type: agent_decision
           agent: se-termination
       - id: implementation
-        agent: se-orchestrator
+        agent: orchestrator
         task: |
           For each leaf node with domain: software from the termination phase:
           - Route to se-junior-developer for trivial leafs (0-1 interfaces, no cross-cutting)
@@ -694,3 +696,5 @@ se_variables:
   SE_MAX_DEPTH: 6
   SE_MAX_CRITIC_ITERATIONS: 3
   SE_MAX_PARALLEL_CELLS: 4
+  SE_MAX_CELLS: 20
+  cost_limit_eur: 5.00

--- a/docs/architecture/07-se-cascade.md
+++ b/docs/architecture/07-se-cascade.md
@@ -6,7 +6,12 @@
 
 ## Übersicht
 
-Die SE-Agenten-Kaskade ist ein fraktales, rekursives Systems-Engineering-System das aus 6 spezialisierten Agenten besteht. Zusammen implementieren sie eine 6-stufige Black-Box → White-Box-Zerlegung nach INCOSE-Methodik.
+Die SE-Agenten-Kaskade ist ein fraktales, rekursives Systems-Engineering-System mit drei Floors:
+- **Decomposition Floor** — 5 aktive Agenten (`se-requirements`, `se-architect`, `se-critic`, `se-interface-mgr`, `se-termination`) implementieren die 6-stufige Black-Box → White-Box-Zerlegung nach INCOSE-Methodik.
+- **Implementation Floor** — 3 SE-Developer-Tiers für Leaf-Node-Implementierung.
+- **Validation Floor (V&V)** — 5 Agenten (`se-validator`, `se-verifier`, `se-test-engineer`, `se-testreviewer`, `se-integration-and-test-manager`) für die rechte V-Modell-Seite, im `se-cascade`-`validation`-Stage als `parallel_group` verdrahtet.
+
+> **Hinweis (Deprecation):** Der frühere `se-orchestrator`-Agent ist deprecated. Die SE-Koordination läuft direkt über den Haupt-`orchestrator` im SE-Mode. Der Wrapper bleibt aus Backward-Compatibility-Gründen erhalten.
 
 ---
 
@@ -352,9 +357,10 @@ roles:
 
 variables:
   SE_MAX_DEPTH: 5              # Maximale Rekursionstiefe
-  SE_MAX_CELLS: 20             # Maximale Gesamtzellen
+  SE_MAX_CELLS: 20             # Maximale Gesamtzellen (Cost-Guard)
   SE_MAX_CRITIC_ITERATIONS: 3  # Max. Critic-Korrekturschleifen
   SE_MAX_PARALLEL_CELLS: 4     # Parallele Zellen pro Ebene
+  cost_limit_eur: 5.00         # Budget-Grenze (Cost-Guard, Enforcement in Phase 2)
 ```
 
 ### `config/role-defaults.yaml` (SE-Rollen)
@@ -369,7 +375,7 @@ variables:
 | `se-junior-developer` | balanced | — | optional | 0–1 Interface Leaf |
 | `se-developer` | balanced | project | optional | 2–4 Interface Leaf |
 | `se-senior-developer` | powerful | project | optional | 5+ Interface Leaf |
-| `se-orchestrator` | balanced | — | optional | Workflow Coordinator |
+| `se-orchestrator` | balanced | — | optional (deprecated) | Wrapper — Funktionalität jetzt im Haupt-`orchestrator` (SE-Mode) |
 
 ---
 

--- a/docs/concepts/se-agent-concept.md
+++ b/docs/concepts/se-agent-concept.md
@@ -9,19 +9,22 @@
 
 **Umgesetzt:**
 - 14 SE-Agenten-Templates (`agents/1-generic/se-*.md`), in `config/role-defaults.yaml` registriert
-  - Decomposition (Requirem., Architect, Critic, Interface-Mgr, Termination, Orchestrator): 6 Agenten
+  - Decomposition (Requirem., Architect, Critic, Interface-Mgr, Termination): 5 aktive Agenten
   - **Implementation Floor (neu, 2026-06-20):** 3 SE-Developer-Tiers (Junior, Standard, Senior)
+  - **V&V Floor (implementiert, im se-cascade `validation`-Stage verdrahtet):** `se-validator`, `se-verifier`, `se-test-engineer`, `se-testreviewer`, `se-integration-and-test-manager` — 5 Agenten
+  - **Deprecated:** `se-orchestrator` — SE-Funktionalität wird nun direkt vom Haupt-`orchestrator` via SE-Mode übernommen. Wrapper bleibt aus Backward-Compatibility-Gründen erhalten.
 - Schemas (`se-decomposition`, `se-orchestrator`), Templates (`SE-STRATEGY`, `SE-FEATURE`), Howtos
 - **SE-Export-Adapter** (`scripts/lib/se_export/`): Markdown (Default) + GitHub-Issues (`gh`-CLI), Factory + CLI `scripts/se-export.py`, Tests `tests/test_se_export.py` (L4 erledigt)
 
 **Implementierungs-Phasen:**
-- **Phase 1 (MVP):** Decomposition + Implementation-Floor komplett. Manuelle Rekursion über Orchestrator.
+- **Phase 1 (MVP):** Decomposition + Implementation-Floor + **V&V-Floor** komplett. V&V-Agenten sind im `se-cascade`-Pipeline-`validation`-Stage verdrahtet (`se-validator`, `se-verifier`, `se-integration-and-test-manager` als `parallel_group`). Manuelle Rekursion über Orchestrator.
 - **Phase 2 (Automatisierung):** Auto-Rekursion, Parallele Zellen, Schema-Cache.
-- **Phase 3 (MCP):** Jira-/Linear-/ReqIF-Adapter, Cost-Limits.
+- **Phase 3 (MCP):** Jira-/Linear-/ReqIF-Adapter.
 
 **Offen / bewusste Abweichung:**
 - Auto-Rekursion: kein Self-Spawn durch Termination-Agent — Rekursion läuft über den `orchestrator` (Anti-Recursion-Guard). Design-Entscheidung, kein Bug.
-- Jira-/Linear-/ReqIF-Adapter (Phase 3), Cost-Limits (`max_total_cells`, `cost_limit_eur`)
+- Jira-/Linear-/ReqIF-Adapter (Phase 3)
+- **Cost-Limits (`SE_MAX_CELLS`, `cost_limit_eur`):** in `config/role-defaults.yaml` `se_variables` definiert (Defaults: 20 Zellen / 5.00 EUR). Enforcement im Orchestrator-Runtime ist Phase 2.
 
 ---
 
@@ -42,7 +45,7 @@ Dieses Konzept beschreibt einen **Systems-Engineering-Modus** für agent-meta: e
 Anstatt zu versuchen, alles auf einmal zu lösen, folgt das System einem **V-Modell**:
 - **Linke Seite des V:** Decomposition (Architekt, Critic, Interface Manager) — abstrahiert von unten nach oben
 - **Boden des V:** **Implementation Floor** (3 SE-Developer-Tiers) — konkrete Arbeit an Leaf Nodes
-- **Rechte Seite des V:** Validation (zukünftig) — Verifikation nach oben
+- **Rechte Seite des V:** **Validation Floor** (implementiert): `se-validator` (L1 User-Journeys), `se-verifier` (Multi-Level Verification), `se-test-engineer` + `se-testreviewer` (MBSE-Testmodelle mit Reflection Loop), `se-integration-and-test-manager` (V&V-Orchestrierung) — im `se-cascade`-`validation`-Stage als `parallel_group` verdrahtet.
 
 Jede Ebene — egal wie tief — durchläuft exakt denselben Ablauf:
 
@@ -93,7 +96,9 @@ Black-Box-Anforderungen der Ebene n+1.
 
 ---
 
-## Die 5 Agenten-Rollen im Detail
+## Die Agenten-Rollen im Detail
+
+> **Hinweis:** Dieser Abschnitt beschreibt die 5 ursprünglichen Decomposition-Rollen ausführlich. Zusätzlich aktiv (verlinkt, siehe `agents/1-generic/`): 3 SE-Developer-Tiers (Implementation Floor) und 5 V&V-Agenten (`se-validator`, `se-verifier`, `se-test-engineer`, `se-testreviewer`, `se-integration-and-test-manager`). Gesamt: **13 aktive SE-Agenten + 1 deprecated (`se-orchestrator`) = 14 Templates**.
 
 ### 1. Requirements Agent (`se-requirements`)
 
@@ -695,18 +700,23 @@ docs/concepts/
 
 ### Phase 1: MVP (VOLLSTÄNDIG 2026-06-20)
 
-**Decomposition Floor (6 Agenten):**
-- `se-requirements`, `se-architect`, `se-critic`, `se-interface-mgr`, `se-termination`, `se-orchestrator`
+**Decomposition Floor (5 aktive Agenten + 1 deprecated):**
+- `se-requirements`, `se-architect`, `se-critic`, `se-interface-mgr`, `se-termination`
+- `se-orchestrator` — DEPRECATED, Funktionalität im Haupt-`orchestrator` (SE-Mode)
 
-**Implementation Floor (3 Agenten — NEU):**
+**Implementation Floor (3 Agenten):**
 - `se-junior-developer`, `se-developer`, `se-senior-developer`
 
+**Validation Floor / V&V (5 Agenten — implementiert):**
+- `se-validator`, `se-verifier`, `se-test-engineer`, `se-testreviewer`, `se-integration-and-test-manager`
+- Verdrahtet im `se-cascade`-`validation`-Stage als `parallel_group`
+
 **Features:**
-- 9 Agenten-Templates (`se-*`) als `1-generic` — manuell triggerbar via Orchestrator
+- 14 Agenten-Templates (`se-*`) als `1-generic` — manuell triggerbar via Haupt-Orchestrator
 - MD-basierte Outputs mit Mermaid-Diagrammen (Default-Adapter)
 - Keine MCP-Abhängigkeiten, keine automatische Rekursion
 - Manuelle Rekursion: Nutzer oder Orchestrator triggert Zellen
-- V-Modell-Architektur: Decomposition (Links) → Implementation Floor (Boden) → V&V (Rechts, zukünftig)
+- **V-Modell vollständig:** Decomposition (Links) → Implementation Floor (Boden) → V&V Floor (Rechts)
 
 ### Phase 2: Automatisierung
 
@@ -720,9 +730,9 @@ docs/concepts/
 
 - MCP-Adapter für Jira, Linear
 - ReqIF-Export für Enterprise-ALM-Tools
-- `se-orchestrator.md` als vollwertiger Workflow-Koordinator
 - Externe Skills: CCPM (Traceability), Harness (Team-Patterns)
-- Validation Floor (V&V) als 9.+10.+11. Agenten-Tier
+
+> **Validation Floor (V&V):** Bereits in Phase 1 als 5 zusätzliche Agenten implementiert und im `se-cascade`-`validation`-Stage verdrahtet. `se-orchestrator` ist deprecated — SE-Funktionalität läuft über den Haupt-`orchestrator` im SE-Mode.
 
 ---
 

--- a/howto/se-workflow.md
+++ b/howto/se-workflow.md
@@ -2,6 +2,9 @@
 
 Dieses Dokument beschreibt den vollständigen Ablauf des fraktalen SE-Workflows in agent-meta.
 
+> **Aktuell aktiv (Stand 2026-06-20):** 14 SE-Agenten-Templates — davon 13 aktiv und 1 deprecated (`se-orchestrator`).
+> Die SE-Koordination läuft direkt über den Haupt-`orchestrator` im SE-Mode; `se-orchestrator` bleibt nur als Wrapper aus Backward-Compatibility-Gründen erhalten.
+
 ---
 
 ## Grundprinzip: Die System-Zelle
@@ -55,7 +58,9 @@ graph TD
 
 ---
 
-## Die 5 Rollen im Detail
+## Die Rollen im Detail
+
+> Decomposition Floor (5 Rollen unten ausführlich) + Implementation Floor (3 Developer-Tiers, siehe Abschnitt »Implementation Floor«) + Validation Floor / V&V (5 Agenten, siehe Abschnitt »Validation Floor (V&V)«) = **13 aktive Rollen**. `se-orchestrator` ist deprecated.
 
 ### se-requirements
 - Nimmt unstrukturierte Stakeholder-Bedarfe entgegen
@@ -85,6 +90,34 @@ graph TD
 - Entscheidet pro Sub-Komponente: Leaf oder Continue
 - Leaf-Kriterien: atomare Code-Einheit, Standard-Bauteil, ausgereizte Domäne, explizite Grenze
 - Schutzregeln: max_depth, max_total_cells, Zirkular-Check
+
+---
+
+## Implementation Floor (Boden des V-Modells)
+
+Nach `decision: leaf` werden Software-Komponenten an einen der 3 SE-Developer-Tiers dispatched (Routing nach Interface-Komplexität aus `propagation_map`):
+
+| Tier | Trigger | Scope |
+|------|---------|-------|
+| `se-junior-developer` | 0–1 Interfaces | Atomare Wrapper, COTS-Adapter, trivial Data-Converter |
+| `se-developer` | 2–4 Interfaces | Multi-Interface Services, contained Modules |
+| `se-senior-developer` | 5+ Interfaces | Cross-Cutting, Boundary-Level, Security/Performance-Critical, Pre-Implementation Interface-Analyse |
+
+Hardware-/Mechanik-Leafs werden als COTS-Spec dokumentiert, nicht implementiert.
+
+---
+
+## Validation Floor (V&V — Rechte Seite des V-Modells)
+
+Im `se-cascade`-`validation`-Stage als `parallel_group` verdrahtet — läuft nach der Decomposition + Implementation:
+
+| Agent | Zuständigkeit |
+|-------|---------------|
+| `se-validator` | L1 System-Validierung — End-to-End User Journeys gegen Stakeholder-Bedürfnisse |
+| `se-verifier` | Multi-Level Verification (L1–Ln) — integrierte Systeme vs. Architektur-Spec |
+| `se-test-engineer` | MBSE-Testmodelle, Integration Test Design (im Reflection Loop mit `se-testreviewer`) |
+| `se-testreviewer` | Audit der Teststrategien (Edge-Cases, Boundary Values, Äquivalenzklassen, Flakiness) |
+| `se-integration-and-test-manager` | V&V-Orchestrierung, Integrationsstrategie, Test-Ebenen-Koordination |
 
 ---
 
@@ -167,6 +200,7 @@ variables:
   SE_MAX_CELLS: 20
   SE_MAX_CRITIC_ITERATIONS: 3
   SE_MAX_PARALLEL_CELLS: 4
+  cost_limit_eur: 5.00
 ```
 
 ---

--- a/schemas/se-decomposition.schema.json
+++ b/schemas/se-decomposition.schema.json
@@ -183,6 +183,25 @@
           "data_payload": {
             "type": "string",
             "description": "Description of the data or energy exchanged."
+          },
+          "version": {
+            "type": "string",
+            "description": "Interface version (semver). Bump on breaking change."
+          },
+          "preconditions": {
+            "type": "array",
+            "description": "Caller obligations — what MUST be true before the call.",
+            "items": { "type": "string" }
+          },
+          "postconditions": {
+            "type": "array",
+            "description": "Implementation guarantees — what WILL be true after a successful call.",
+            "items": { "type": "string" }
+          },
+          "invariants": {
+            "type": "array",
+            "description": "Properties that hold both before AND after every call.",
+            "items": { "type": "string" }
           }
         }
       }
@@ -277,6 +296,9 @@
               "$ref": "#/definitions/checkResult"
             },
             "traceability": {
+              "$ref": "#/definitions/checkResult"
+            },
+            "resilience": {
               "$ref": "#/definitions/checkResult"
             }
           }


### PR DESCRIPTION
## Changes
- Updated SE-critic and SE-interface-mgr agent templates (1-generic)
- Synced orchestrator agent files (.claude/agents/, .opencode/agents/)
- Updated role-defaults.yaml for SE agent roles
- Updated SE architecture docs (07-se-cascade.md, se-agent-concept.md)
- Updated SE workflow howto (se-workflow.md)
- Added SE decomposition JSON schema

## Test Plan
- [x] sync.py --validate passes
- [x] SE agent templates consistent with role-defaults
- [x] Documentation matches template behavior