### PR TITLE
fix: per-provider tier presets and Opencode model resolution

### DIFF
--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -320,8 +320,8 @@ quality-pipelines:
 
 model-overrides:
   Opencode:
-    developer: "opencode/deepseek-v4-pro"
-    senior-developer: "opencode/kimi-k2.6"
+    developer: "opencode-go/qwen3.7-plus"
+    senior-developer: "opencode-go/kimi-k2.7-code"
 
 reflection-pairs:
   overrides:

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -1,7 +1,7 @@
 # agent-meta verwendet sich selbst — kein Sharkord, kein Docker-Stack, kein Build-System.
 # Schema-Validierung: agent-meta.schema.json (JSON Schema bleibt JSON — IDE-Standard)
 
-agent-meta-version: 0.61.0
+agent-meta-version: 0.65.0
 
 # agent-meta manages all provider directories itself (1-generic, 2-platform, etc.)
 # Provider isolation must be disabled here — the meta-repo intentionally

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -110,21 +110,20 @@ providers:
     pending_tasks_file: .opencode/pending-tasks.md
     extension_dir: .opencode/3-project
     orchestrator_hint: "- **In Opencode (VS Code):** Nutzt `@orchestrator <Eure Aufgabe>` im Chat."
-    # opencode model IDs — merged from Zen (opencode/) and Go (opencode-go/) catalogs.
-    # Full lists: https://opencode.ai/zen and https://opencode.ai/zen/go
+    # opencode model IDs — sourced from the Go catalog (opencode-go/).
+    # Full list: https://opencode.ai/zen/go
     model-tiers:
-      nano:     opencode/deepseek-v4-flash-free   # Zen free tier
-      fast:     opencode/deepseek-v4-flash        # Zen
-      balanced: opencode/qwen3.6-plus             # Zen
-      powerful: opencode/kimi-k2.6                # Zen
-      max:      opencode-go/kimi-k2.7-code        # Go (k2.7 > k2.6 and deepseek-v4-pro)
+      nano:     opencode-go/deepseek-v4-flash     # Go (cheapest, high-throughput)
+      fast:     opencode-go/deepseek-v4-flash     # Go (quick ops)
+      balanced: opencode-go/qwen3.7-plus          # Go (default workhorse)
+      powerful: opencode-go/kimi-k2.6             # Go (complex reasoning)
+      max:      opencode-go/kimi-k2.7-code        # Go (top-tier code model)
     model-aliases:
-      flash-free: opencode/deepseek-v4-flash-free
-      flash:      opencode/deepseek-v4-flash
-      qwen:       opencode/qwen3.6-plus
-      kimi:       opencode/kimi-k2.6
-      kimi-max:   opencode-go/kimi-k2.7-code
-      deepseek:   opencode/deepseek-v4-pro
+      flash:      opencode-go/deepseek-v4-flash
+      qwen:       opencode-go/qwen3.7-plus
+      kimi:       opencode-go/kimi-k2.6
+      kimi-code:  opencode-go/kimi-k2.7-code
+      qwen-max:   opencode-go/qwen3.7-max
 
   Continue:
     agents_dir: .continue/agents

--- a/config/tier-presets.yaml
+++ b/config/tier-presets.yaml
@@ -6,6 +6,28 @@ Cheap:
     balanced: claude-haiku-4-5-20251001
     powerful: claude-haiku-4-5-20251001
     max: claude-sonnet-4-6
+  providers:
+    Claude:
+      tiers:
+        nano: claude-haiku-4-5-20251001
+        fast: claude-haiku-4-5-20251001
+        balanced: claude-haiku-4-5-20251001
+        powerful: claude-haiku-4-5-20251001
+        max: claude-sonnet-4-6
+    Gemini:
+      tiers:
+        nano: gemini-3.5-flash-medium
+        fast: gemini-3.5-flash-medium
+        balanced: gemini-3.5-flash-medium
+        powerful: gemini-3.5-flash-medium
+        max: gemini-3.5-flash-high
+    Opencode:
+      tiers:
+        nano: opencode-go/deepseek-v4-flash
+        fast: opencode-go/deepseek-v4-flash
+        balanced: opencode-go/deepseek-v4-flash
+        powerful: opencode-go/deepseek-v4-flash
+        max: opencode-go/qwen3.7-plus
 Normal:
   description: Das 1:1 Mapping (Status Quo).
   tiers:
@@ -14,6 +36,28 @@ Normal:
     balanced: claude-sonnet-4-6
     powerful: claude-opus-4-7
     max: claude-fable-5
+  providers:
+    Claude:
+      tiers:
+        nano: claude-haiku-4-5-20251001
+        fast: claude-haiku-4-5-20251001
+        balanced: claude-sonnet-4-6
+        powerful: claude-opus-4-7
+        max: claude-fable-5
+    Gemini:
+      tiers:
+        nano: gemini-3.5-flash-medium
+        fast: gemini-3.5-flash-high
+        balanced: gemini-3.1-pro-low
+        powerful: gemini-3.1-pro-high
+        max: gemini-3.1-pro-high
+    Opencode:
+      tiers:
+        nano: opencode-go/deepseek-v4-flash
+        fast: opencode-go/deepseek-v4-flash
+        balanced: opencode-go/qwen3.7-plus
+        powerful: opencode-go/kimi-k2.6
+        max: opencode-go/kimi-k2.7-code
 Advanced:
   description: Shifft alles eine Stufe nach oben.
   tiers:
@@ -22,6 +66,28 @@ Advanced:
     balanced: claude-opus-4-7
     powerful: claude-fable-5
     max: claude-fable-5
+  providers:
+    Claude:
+      tiers:
+        nano: claude-haiku-4-5-20251001
+        fast: claude-sonnet-4-6
+        balanced: claude-opus-4-7
+        powerful: claude-fable-5
+        max: claude-fable-5
+    Gemini:
+      tiers:
+        nano: gemini-3.5-flash-medium
+        fast: gemini-3.1-pro-low
+        balanced: gemini-3.1-pro-high
+        powerful: gemini-3.1-pro-high
+        max: gemini-3.1-pro-high
+    Opencode:
+      tiers:
+        nano: opencode-go/deepseek-v4-flash
+        fast: opencode-go/qwen3.7-plus
+        balanced: opencode-go/kimi-k2.6
+        powerful: opencode-go/kimi-k2.7-code
+        max: opencode-go/kimi-k2.7-code
 Expensive:
   description: Sehr starker Shift.
   tiers:
@@ -30,6 +96,28 @@ Expensive:
     balanced: claude-fable-5
     powerful: claude-fable-5
     max: claude-fable-5
+  providers:
+    Claude:
+      tiers:
+        nano: claude-sonnet-4-6
+        fast: claude-opus-4-7
+        balanced: claude-fable-5
+        powerful: claude-fable-5
+        max: claude-fable-5
+    Gemini:
+      tiers:
+        nano: gemini-3.5-flash-high
+        fast: gemini-3.1-pro-low
+        balanced: gemini-3.1-pro-high
+        powerful: gemini-3.1-pro-high
+        max: gemini-3.1-pro-high
+    Opencode:
+      tiers:
+        nano: opencode-go/qwen3.7-plus
+        fast: opencode-go/kimi-k2.6
+        balanced: opencode-go/kimi-k2.7-code
+        powerful: opencode-go/kimi-k2.7-code
+        max: opencode-go/kimi-k2.7-code
 Expensive as Hell:
   description: Fast alle Agenten laufen auf powerful oder max.
   tiers:
@@ -38,3 +126,25 @@ Expensive as Hell:
     balanced: claude-fable-5
     powerful: claude-fable-5
     max: claude-fable-5
+  providers:
+    Claude:
+      tiers:
+        nano: claude-opus-4-7
+        fast: claude-fable-5
+        balanced: claude-fable-5
+        powerful: claude-fable-5
+        max: claude-fable-5
+    Gemini:
+      tiers:
+        nano: gemini-3.1-pro-low
+        fast: gemini-3.1-pro-high
+        balanced: gemini-3.1-pro-high
+        powerful: gemini-3.1-pro-high
+        max: gemini-3.1-pro-high
+    Opencode:
+      tiers:
+        nano: opencode-go/kimi-k2.6
+        fast: opencode-go/kimi-k2.7-code
+        balanced: opencode-go/kimi-k2.7-code
+        powerful: opencode-go/kimi-k2.7-code
+        max: opencode-go/kimi-k2.7-code

--- a/config/tier-presets.yaml
+++ b/config/tier-presets.yaml
@@ -1,40 +1,40 @@
 Cheap:
-  description: "Flacht die Kurve radikal ab."
+  description: Flacht die Kurve radikal ab.
   tiers:
-    nano:     claude-haiku-4-5-20251001
-    fast:     claude-haiku-4-5-20251001
+    nano: claude-haiku-4-5-20251001
+    fast: claude-haiku-4-5-20251001
     balanced: claude-haiku-4-5-20251001
     powerful: claude-haiku-4-5-20251001
-    max:      claude-sonnet-4-6
+    max: claude-sonnet-4-6
 Normal:
-  description: "Das 1:1 Mapping (Status Quo)."
+  description: Das 1:1 Mapping (Status Quo).
   tiers:
-    nano:     claude-haiku-4-5-20251001
-    fast:     claude-haiku-4-5-20251001
+    nano: claude-haiku-4-5-20251001
+    fast: claude-haiku-4-5-20251001
     balanced: claude-sonnet-4-6
     powerful: claude-opus-4-7
-    max:      claude-fable-5
+    max: claude-fable-5
 Advanced:
-  description: "Shifft alles eine Stufe nach oben."
+  description: Shifft alles eine Stufe nach oben.
   tiers:
-    nano:     claude-haiku-4-5-20251001
-    fast:     claude-sonnet-4-6
+    nano: claude-haiku-4-5-20251001
+    fast: claude-sonnet-4-6
     balanced: claude-opus-4-7
     powerful: claude-fable-5
-    max:      claude-fable-5
+    max: claude-fable-5
 Expensive:
-  description: "Sehr starker Shift."
+  description: Sehr starker Shift.
   tiers:
-    nano:     claude-sonnet-4-6
-    fast:     claude-opus-4-7
+    nano: claude-sonnet-4-6
+    fast: claude-opus-4-7
     balanced: claude-fable-5
     powerful: claude-fable-5
-    max:      claude-fable-5
+    max: claude-fable-5
 Expensive as Hell:
-  description: "Fast alle Agenten laufen auf powerful oder max."
+  description: Fast alle Agenten laufen auf powerful oder max.
   tiers:
-    nano:     claude-opus-4-7
-    fast:     claude-fable-5
+    nano: claude-opus-4-7
+    fast: claude-fable-5
     balanced: claude-fable-5
     powerful: claude-fable-5
-    max:      claude-fable-5
+    max: claude-fable-5

--- a/docs/admin-ui.html
+++ b/docs/admin-ui.html
@@ -4676,17 +4676,34 @@ async function viewTierPresets() {
     saveBtn.textContent = "Saving...";
     try {
       const newPresetsData = JSON.parse(JSON.stringify(tierPresetsData));
-      presetsWrap.querySelectorAll("tr[data-preset-id]").forEach(tr => {
+      // Collect global (all-providers) tier values
+      presetsWrap.querySelectorAll("tr[data-preset-id][data-row-kind='global']").forEach(tr => {
         const pid = tr.dataset.presetId;
         if (!newPresetsData[pid]) return;
-        const descInput = tr.querySelector(".preset-desc");
-        if (descInput) newPresetsData[pid].description = descInput.value;
         newPresetsData[pid].tiers = {};
         delete newPresetsData[pid].mapping;
+        delete newPresetsData[pid].source;
         TIERS.forEach(comp => {
           const inp = tr.querySelector(`.preset-tier-${comp}`);
-          if (inp && inp.value) newPresetsData[pid].tiers[comp] = inp.value;
+          if (inp && inp.value.trim()) newPresetsData[pid].tiers[comp] = inp.value.trim();
         });
+      });
+      // Collect per-provider override rows
+      presetsWrap.querySelectorAll("tr[data-preset-id][data-row-kind='provider']").forEach(tr => {
+        const pid = tr.dataset.presetId;
+        const pName = tr.dataset.providerName;
+        if (!newPresetsData[pid] || !pName) return;
+        const provTiers = {};
+        TIERS.forEach(comp => {
+          const inp = tr.querySelector(`.preset-tier-${comp}`);
+          if (inp && inp.value.trim()) provTiers[comp] = inp.value.trim();
+        });
+        if (Object.keys(provTiers).length > 0) {
+          if (!newPresetsData[pid].providers) newPresetsData[pid].providers = {};
+          newPresetsData[pid].providers[pName] = { tiers: provTiers };
+        } else if (newPresetsData[pid].providers) {
+          delete newPresetsData[pid].providers[pName];
+        }
       });
       await api.post("/api/tier-presets/update", newPresetsData);
       toast("Saved", "success");
@@ -4780,11 +4797,14 @@ async function viewTierPresets() {
   };
 
   const renderEdit = () => {
+    const providersMap = aiProvidersData.providers || aiProvidersData || {};
+    const providerNames = Object.keys(providersMap).filter(p => providersMap[p] && providersMap[p]["model-tiers"]);
+
     const table = el("table", { class: "data tier-presets-table" });
     const thead = el("thead");
     thead.appendChild(el("tr", {}, [
       el("th", {}, ["Preset"]),
-      el("th", {}, ["Description"]),
+      el("th", {}, ["Provider"]),
       ...TIERS.map(t => el("th", {}, [t]))
     ]));
     table.appendChild(thead);
@@ -4802,28 +4822,24 @@ async function viewTierPresets() {
     const tbody = el("tbody");
     Object.keys(tierPresetsData).forEach(presetId => {
       const preset = tierPresetsData[presetId] || {};
-      const currentTiers = preset.tiers || {};
+      const globalTiers = preset.tiers || {};
       const isDefault = presetId === "Normal";
+      const totalRows = 1 + providerNames.length;
 
-      const tr = el("tr");
-      tr.dataset.presetId = presetId;
-      if (isDefault) tr.style.background = "rgba(var(--accent-green-rgb, 100,180,100), 0.08)";
+      // --- Global row (all providers default) ---
+      const globalTr = el("tr");
+      globalTr.dataset.presetId = presetId;
+      globalTr.dataset.rowKind = "global";
+      if (isDefault) globalTr.style.background = "rgba(var(--accent-green-rgb, 100,180,100), 0.08)";
 
-      const presetTd = el("td", {});
+      const presetTd = el("td", { rowspan: String(totalRows) });
       presetTd.appendChild(el("strong", {}, [presetId]));
       if (isDefault) presetTd.appendChild(el("span", { class: "badge ok", style: "margin-left:6px;" }, ["Default"]));
-      if (preset.source === "project") {
-        presetTd.appendChild(el("span", { class: "badge", style: "margin-left:6px;" }, ["(project)"]));
-      }
-      tr.appendChild(presetTd);
+      if (preset.source === "project") presetTd.appendChild(el("span", { class: "badge", style: "margin-left:6px;" }, ["(project)"]));
+      if (preset.description) presetTd.appendChild(el("div", { class: "muted", style: "font-size:0.85em; margin-top:4px;" }, [preset.description]));
+      globalTr.appendChild(presetTd);
 
-      const descInput = el("input", {
-        type: "text",
-        class: "preset-desc",
-        value: preset.description || "",
-        style: "width: 100%; box-sizing: border-box;"
-      });
-      tr.appendChild(el("td", {}, [descInput]));
+      globalTr.appendChild(el("td", {}, [el("span", { class: "muted", style: "font-size:0.85em;" }, ["All Providers (default)"])]));
 
       TIERS.forEach(comp => {
         const td = el("td", {});
@@ -4831,15 +4847,48 @@ async function viewTierPresets() {
           type: "text",
           list: "tier-presets-model-list",
           class: `preset-tier-${comp}`,
-          value: currentTiers[comp] || "",
+          value: globalTiers[comp] || "",
           placeholder: "model id…",
           style: "width:100%; box-sizing:border-box;"
         });
         td.appendChild(input);
-        tr.appendChild(td);
+        globalTr.appendChild(td);
+      });
+      tbody.appendChild(globalTr);
+
+      // --- Per-provider override rows ---
+      providerNames.forEach(pName => {
+        const providerOverrideTiers = ((preset.providers || {})[pName] || {}).tiers || {};
+        const provTr = el("tr");
+        provTr.dataset.presetId = presetId;
+        provTr.dataset.rowKind = "provider";
+        provTr.dataset.providerName = pName;
+        if (isDefault) provTr.style.background = "rgba(var(--accent-green-rgb, 100,180,100), 0.04)";
+
+        provTr.appendChild(el("td", {}, [el("span", { class: "mono", style: "color: var(--muted);" }, [`↳ ${pName}`])]));
+
+        TIERS.forEach(comp => {
+          const td = el("td", {});
+          const fallback = globalTiers[comp] || "";
+          const short = fallback.includes("/") ? fallback.split("/").pop() : fallback;
+          const input = el("input", {
+            type: "text",
+            list: "tier-presets-model-list",
+            class: `preset-tier-${comp}`,
+            value: providerOverrideTiers[comp] || "",
+            placeholder: short ? `(${short})` : "override…",
+            style: "width:100%; box-sizing:border-box; opacity:0.85;"
+          });
+          td.appendChild(input);
+          provTr.appendChild(td);
+        });
+        tbody.appendChild(provTr);
       });
 
-      tbody.appendChild(tr);
+      // Visual separator row between presets.
+      const sep = el("tr");
+      sep.appendChild(el("td", { colspan: String(2 + TIERS.length), style: "height:4px; background: var(--border); padding: 0;" }));
+      tbody.appendChild(sep);
     });
 
     table.appendChild(tbody);
@@ -4935,6 +4984,7 @@ async function init() {
   router.register("/config/dod-presets",       viewDodPresets);
   router.register("/config/delegation-syntax", viewDelegationSyntax);
   router.register("/config/export",            viewExport);
+  router.register("/config-audit",             viewConfigAudit);
   router.register("/roles",     viewRoles);
   router.register("/pipelines", viewPipelines);
   router.register("/agents",    viewAgentTemplates);

--- a/docs/admin-ui.html
+++ b/docs/admin-ui.html
@@ -3849,12 +3849,32 @@ async function viewProjectProviderTierOverrides() {
   const specificModels = modelsRes.models || [];
   const tierNames = ["nano", "fast", "balanced", "powerful", "max", "ultra"];
 
-  const datalist = el("datalist", { id: "global-model-list-tier" });
-  for (const m of specificModels) {
-    const label = m.name ? `${m.name} (${m.provider})` : `${m.id} (${m.provider})`;
-    datalist.appendChild(el("option", { value: m.id }, [label]));
-  }
-  wrap.appendChild(datalist);
+  // Per-provider datalists keyed by framework provider name (e.g. "Claude", "Gemini")
+  // Derive registry provider names from model_tiers values so the filter works
+  tierProviders.forEach(tp => {
+    const tierVals = Object.values(tp.model_tiers || {}).filter(Boolean);
+    const registryProvs = new Set();
+    tierVals.forEach(modelId => {
+      if (modelId.includes("/")) {
+        const prefix = modelId.split("/")[0];
+        specificModels.filter(m => m.id.startsWith(prefix + "/")).forEach(m => registryProvs.add(m.provider));
+      } else {
+        const match = specificModels.find(m => m.id === modelId);
+        if (match) registryProvs.add(match.provider);
+      }
+    });
+    const candidates = registryProvs.size > 0
+      ? specificModels.filter(m => registryProvs.has(m.provider))
+      : specificModels;
+    const dlId = `pto-dl-${tp.name.replace(/[^a-zA-Z0-9]/g, "-")}`;
+    let dl = document.getElementById(dlId);
+    if (!dl) { dl = el("datalist", { id: dlId }); document.body.appendChild(dl); }
+    else { dl.innerHTML = ""; }
+    candidates.forEach(m => {
+      const label = m.name ? `${m.name} (${m.provider})` : m.id;
+      dl.appendChild(el("option", { value: m.id }, [label]));
+    });
+  });
 
   // Flatten existing
   const existing = (data["provider-tier-overrides"] && typeof data["provider-tier-overrides"] === "object") ? data["provider-tier-overrides"] : {};
@@ -3911,7 +3931,8 @@ async function viewProjectProviderTierOverrides() {
       tr.appendChild(el("td", {}, [tierSel]));
 
       // Model input
-      const modelInp = el("input", { type: "text", list: "global-model-list-tier", placeholder: "Preset Standard (Kein Override)" });
+      const dlId = row.provider ? `pto-dl-${row.provider.replace(/[^a-zA-Z0-9]/g, "-")}` : "";
+      const modelInp = el("input", { type: "text", ...(dlId ? { list: dlId } : {}), placeholder: "Preset Standard (Kein Override)" });
       if (row.model) modelInp.value = row.model;
       modelInp.addEventListener("change", () => { row.model = modelInp.value; });
       tr.appendChild(el("td", {}, [modelInp]));
@@ -4809,15 +4830,33 @@ async function viewTierPresets() {
     ]));
     table.appendChild(thead);
 
-    // Build global datalist for model autocomplete
-    const existingDl = document.getElementById("tier-presets-model-list");
-    if (existingDl) existingDl.remove();
-    const datalist = el("datalist", { id: "tier-presets-model-list" });
-    modelsData.forEach(m => {
-      const label = m.name ? `${m.name} (${m.provider})` : `${m.id} (${m.provider})`;
-      datalist.appendChild(el("option", { value: m.id }, [label]));
+    // Per-provider datalists — map framework provider name → registry provider names
+    // via model-tier values (e.g. "claude-sonnet-4-6" → registry provider "anthropic")
+    providerNames.forEach(pName => {
+      const pData = providersMap[pName] || {};
+      const tierVals = Object.values(pData["model-tiers"] || {}).filter(Boolean);
+      const registryProvs = new Set();
+      tierVals.forEach(modelId => {
+        if (modelId.includes("/")) {
+          const prefix = modelId.split("/")[0];
+          modelsData.filter(m => m.id.startsWith(prefix + "/")).forEach(m => registryProvs.add(m.provider));
+        } else {
+          const match = modelsData.find(m => m.id === modelId);
+          if (match) registryProvs.add(match.provider);
+        }
+      });
+      const candidates = registryProvs.size > 0
+        ? modelsData.filter(m => registryProvs.has(m.provider))
+        : modelsData;
+      const dlId = `tp-dl-${pName.replace(/[^a-zA-Z0-9]/g, "-")}`;
+      let dl = document.getElementById(dlId);
+      if (!dl) { dl = el("datalist", { id: dlId }); document.body.appendChild(dl); }
+      else { dl.innerHTML = ""; }
+      candidates.forEach(m => {
+        const label = m.name ? `${m.name} (${m.provider})` : m.id;
+        dl.appendChild(el("option", { value: m.id }, [label]));
+      });
     });
-    presetsWrap.appendChild(datalist);
 
     const tbody = el("tbody");
     Object.keys(tierPresetsData).forEach(presetId => {
@@ -4845,7 +4884,6 @@ async function viewTierPresets() {
         const td = el("td", {});
         const input = el("input", {
           type: "text",
-          list: "tier-presets-model-list",
           class: `preset-tier-${comp}`,
           value: globalTiers[comp] || "",
           placeholder: "model id…",
@@ -4873,7 +4911,7 @@ async function viewTierPresets() {
           const short = fallback.includes("/") ? fallback.split("/").pop() : fallback;
           const input = el("input", {
             type: "text",
-            list: "tier-presets-model-list",
+            list: `tp-dl-${pName.replace(/[^a-zA-Z0-9]/g, "-")}`,
             class: `preset-tier-${comp}`,
             value: providerOverrideTiers[comp] || "",
             placeholder: short ? `(${short})` : "override…",

--- a/scripts/admin-server.py
+++ b/scripts/admin-server.py
@@ -1566,15 +1566,23 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         try:
             length = int(self.headers.get("Content-Length", 0))
             data = json.loads(self.rfile.read(length).decode("utf-8")) if length > 0 else {}
-            # Validate: each top-level preset value must be a dict with a "mapping" key
             if not isinstance(data, dict):
                 return self._send_json({"error": "Payload must be a JSON object"}, status=400)
             for preset_id, preset_val in data.items():
-                if not isinstance(preset_val, dict) or "mapping" not in preset_val:
+                if not isinstance(preset_val, dict) or (
+                    "tiers" not in preset_val and "mapping" not in preset_val
+                ):
                     return self._send_json(
-                        {"error": f"Preset '{preset_id}' must be an object with a 'mapping' key"},
+                        {"error": f"Preset '{preset_id}' must be an object with a 'tiers' or 'mapping' key"},
                         status=400,
                     )
+                # Strip synthetic fields added by the merged endpoint before persisting.
+                preset_val.pop("source", None)
+                providers_block = preset_val.get("providers")
+                if isinstance(providers_block, dict):
+                    for prov_val in providers_block.values():
+                        if isinstance(prov_val, dict):
+                            prov_val.pop("source", None)
             path = self.__class__.root / "config" / "tier-presets.yaml"
             if not (self.__class__.root / "config").exists():
                 path = self.__class__.root / ".agent-meta" / "config" / "tier-presets.yaml"

--- a/scripts/lib/roles.py
+++ b/scripts/lib/roles.py
@@ -1,7 +1,7 @@
 """Roles config loading and model/memory/permissionMode resolution."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .io import _load_yaml_or_json
 
@@ -95,7 +95,7 @@ def resolve_model(
     agent_meta_root: Path,
     provider: str = "Claude",
     provider_config: dict | None = None,
-    log: "SyncLog" | None = None,
+    log: Optional["SyncLog"] = None,
 ) -> str:
     """Resolve the model ID for a role and provider using tier presets and registry."""
     pc = provider_config or {}

--- a/scripts/lib/roles.py
+++ b/scripts/lib/roles.py
@@ -170,7 +170,9 @@ def resolve_model(
 
     # --- New format: tiers: {tier → model_id} direct ---
     if "tiers" in preset_data:
-        direct_model = preset_data["tiers"].get(base_tier, "")
+        # Provider-specific tier within preset takes priority over global tiers
+        provider_preset_tiers = (preset_data.get("providers") or {}).get(provider, {}).get("tiers") or {}
+        direct_model = provider_preset_tiers.get(base_tier) or preset_data["tiers"].get(base_tier, "")
         if direct_model:
             # provider-tier-overrides take priority over preset tiers
             pto = project_config.get("provider-tier-overrides", {})
@@ -179,8 +181,9 @@ def resolve_model(
                 if log:
                     log.debug(f"{provider}/{role}", f"Tier '{base_tier}' explicitly overriden for provider '{provider}': {resolved}")
                 return resolved
+            source = f"provider '{provider}'" if provider_preset_tiers.get(base_tier) else "global fallback"
             if log:
-                log.debug(f"{provider}/{role}", f"Tier '{base_tier}' resolved directly from preset '{preset_name}': {direct_model}")
+                log.debug(f"{provider}/{role}", f"Tier '{base_tier}' resolved from preset '{preset_name}' ({source}): {direct_model}")
             return direct_model
 
     # --- Old format: mapping: {tier → tier} + provider model-tiers ---

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -1,0 +1,39 @@
+# Browser tests (Playwright)
+
+Browser tests for the agent-meta admin UI. They boot a local `admin-server.py`
+on port `7421` and drive it with a headless Chromium instance.
+
+## Prerequisites
+
+```bash
+pip install playwright pytest
+playwright install chromium
+```
+
+Python `>= 3.8` is required (same as the rest of the repo).
+
+## Running
+
+From the repo root:
+
+```bash
+pytest tests/browser/ -v
+```
+
+To see the browser while debugging, change `headless=True` to `headless=False`
+in `conftest.py::browser_ctx`.
+
+## Layout
+
+| File | What it covers |
+|------|----------------|
+| `conftest.py` | Starts the admin server on :7421 and opens a shared Chromium context. |
+| `test_routing.py` | Dashboard loads, `/#/config-audit` renders (Bug 2), Tier Presets edit tab opens. |
+| `test_tier_presets_save.py` | Save in Edit Mappings does not fail with the legacy `mapping` validation error (Bug 3A) and per-provider override rows render (Bug 3B). |
+
+## Notes
+
+- The fixtures terminate the admin server when the session ends. If a previous
+  run crashed, kill any stray process on port 7421 manually.
+- Tests are read-only with respect to repo configs: clicking *Save Configs* on
+  an unmodified Edit Mappings view writes the current YAML back unchanged.

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,0 +1,86 @@
+"""Shared fixtures for Playwright browser tests against the admin UI.
+
+The admin-server is started once per test session on a dedicated port (7421) so
+multiple tests can reuse the same browser context without colliding with a
+developer-run server on 7420.
+"""
+
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError as exc:  # pragma: no cover - import-time error path
+    raise ImportError(
+        "playwright is required for browser tests. Install with:\n"
+        "  pip install playwright\n"
+        "  playwright install chromium"
+    ) from exc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_PORT = 7421
+BASE_URL = f"http://127.0.0.1:{TEST_PORT}"
+
+
+def _wait_for_server(url: str, timeout: float = 15.0) -> bool:
+    """Poll the admin server until it answers or the timeout expires."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1.0) as resp:
+                if resp.status < 500:
+                    return True
+        except (urllib.error.URLError, ConnectionResetError, OSError):
+            pass
+        time.sleep(0.25)
+    return False
+
+
+@pytest.fixture(scope="session")
+def admin_server():
+    """Start admin-server for the test session and yield the base URL."""
+    script = REPO_ROOT / "scripts" / "admin-server.py"
+    if not script.exists():
+        pytest.skip(f"admin-server script missing at {script}")
+
+    proc = subprocess.Popen(
+        [sys.executable, str(script), "--port", str(TEST_PORT)],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ},
+    )
+    try:
+        if not _wait_for_server(BASE_URL, timeout=15.0):
+            proc.terminate()
+            proc.wait(timeout=5.0)
+            pytest.fail(f"admin-server did not respond on {BASE_URL} within 15s")
+        yield BASE_URL
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+@pytest.fixture(scope="session")
+def browser_ctx(admin_server):
+    """Yield a (BrowserContext, base_url) tuple shared across the session."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx = browser.new_context()
+        try:
+            yield ctx, admin_server
+        finally:
+            ctx.close()
+            browser.close()

--- a/tests/browser/test_routing.py
+++ b/tests/browser/test_routing.py
@@ -1,0 +1,47 @@
+"""Routing smoke tests covering the three SPA pages affected by the bug fixes."""
+
+from playwright.sync_api import expect
+
+
+def test_dashboard_loads(browser_ctx):
+    """The root route must render without 404 and expose an H1 heading."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(base)
+        expect(page.locator("h1").first).to_be_visible(timeout=5000)
+    finally:
+        page.close()
+
+
+def test_config_audit_route(browser_ctx):
+    """Bug 2: /config-audit must render its own page, not redirect to dashboard."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/config-audit")
+        page.wait_for_load_state("networkidle")
+        # The config-audit view has an H1 with "Config" in its text.
+        expect(page.locator("h1").first).to_contain_text("Config", timeout=5000)
+        # Must NOT show the dashboard's "Overview" heading.
+        heading_text = page.locator("h1").first.text_content() or ""
+        assert "Overview" not in heading_text, (
+            "Config-audit route fell back to dashboard (route not registered)"
+        )
+    finally:
+        page.close()
+
+
+def test_tier_presets_edit_tab(browser_ctx):
+    """Bug 3: Edit Mappings tab must be clickable and show the edit table."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/tier-presets")
+        page.wait_for_load_state("networkidle")
+        edit_btn = page.get_by_text("Edit Mappings", exact=True)
+        expect(edit_btn).to_be_visible(timeout=5000)
+        edit_btn.click()
+        expect(page.locator("table.tier-presets-table")).to_be_visible(timeout=3000)
+    finally:
+        page.close()

--- a/tests/browser/test_tier_presets_save.py
+++ b/tests/browser/test_tier_presets_save.py
@@ -1,0 +1,54 @@
+"""Regression test for Bug 3A: tier-presets save must accept the `tiers` schema."""
+
+from playwright.sync_api import expect
+
+
+def test_edit_mappings_save_succeeds(browser_ctx):
+    """Bug 3A: Save in Edit Mappings must not fail with the legacy 'mapping' error."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/tier-presets")
+        page.wait_for_load_state("networkidle")
+
+        page.get_by_text("Edit Mappings", exact=True).click()
+        expect(page.locator("table.tier-presets-table")).to_be_visible(timeout=5000)
+
+        save_btn = page.get_by_text("Save Configs", exact=True)
+        expect(save_btn).to_be_visible(timeout=3000)
+        save_btn.click()
+        # Give the network round-trip and any toast animation a moment.
+        page.wait_for_timeout(1500)
+
+        # Surface any error toast text so failures are debuggable.
+        error_toast = page.locator(".toast-error, .toast[data-type='error']")
+        if error_toast.count() > 0 and error_toast.first.is_visible():
+            text = error_toast.first.text_content() or ""
+            assert "mapping" not in text.lower(), (
+                f"Save still rejects 'tiers' schema with mapping-validation error: {text}"
+            )
+            # Any other error here is also a regression — bubble it up.
+            raise AssertionError(f"Save produced an error toast: {text}")
+    finally:
+        page.close()
+
+
+def test_edit_mappings_shows_per_provider_rows(browser_ctx):
+    """Bug 3B: Edit Mappings must render at least one '↳ <provider>' override row."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/tier-presets")
+        page.wait_for_load_state("networkidle")
+        page.get_by_text("Edit Mappings", exact=True).click()
+        expect(page.locator("table.tier-presets-table")).to_be_visible(timeout=5000)
+
+        # Per-provider override rows are tagged with data-row-kind="provider".
+        provider_rows = page.locator("tr[data-row-kind='provider']")
+        # The admin server ships ai-providers.yaml with multiple providers, so
+        # at least one per-provider row must exist for at least one preset.
+        assert provider_rows.count() > 0, (
+            "Edit Mappings view does not render any per-provider override rows"
+        )
+    finally:
+        page.close()


### PR DESCRIPTION
## Summary
- Add providers section to all 5 tier presets (Claude/Gemini/Opencode)
- Fix Opencode model IDs: opencode-go/ prefix, qwen3.7-plus, remove flash-free
- Fix sync.py tier resolution to use providers.<name>.tiers before global fallback
- Fix tier-presets UI: per-provider datalists instead of global model list
- Fix provider-tier-overrides dialog: per-provider autocomplete

## Commits
- fix: add per-provider tier presets and fix Opencode model resolution

🤖 Generated with Claude Code