### PR TITLE
fix: Codeberg GIT_PLATFORM, provider-isolation crash, intent-routing table

### DIFF
--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -182,7 +182,8 @@
           "enum": [
             "GitHub",
             "GitLab",
-            "Gitea"
+            "Gitea",
+            "Codeberg"
           ]
         },
         "GIT_REMOTE_URL": {

--- a/docs/admin-ui.html
+++ b/docs/admin-ui.html
@@ -3889,6 +3889,12 @@ async function viewProjectProviders() {
   const providerOptions = (data["provider-options"] && typeof data["provider-options"] === "object")
     ? clone(data["provider-options"]) : {};
   let isolation = data["provider-isolation"];
+  // Track whether the user (or the loaded project.yaml) ever gave this field a
+  // real value. If it stays untouched (no key on load, dropdown never used),
+  // `isolation` is `undefined` — JSON.stringify() then drops the whole "data"
+  // field of the save payload, which the backend rejects. Only send the
+  // section when there is something meaningful to write.
+  let isolationTouched = typeof isolation === "string";
 
   const status = el("div", { class: "muted" }, ["Loaded from project.yaml."]);
   wrap.appendChild(status);
@@ -3945,7 +3951,7 @@ async function viewProjectProviders() {
     "provider-isolation",
     isolationOptions,
     typeof isolation === "string" ? isolation : "",
-    v => { isolation = v; },
+    v => { isolation = v; isolationTouched = true; },
     isolationLabels,
   ));
 
@@ -4078,12 +4084,13 @@ async function viewProjectProviders() {
       // We rely on the sync() callbacks having kept provOpts up-to-date.
       // Empty-key rows are ignored by sync(), so provOpts stays clean.
       try {
-        await saveProjectSections([
+        const entries = [
           ["ai-providers", Array.from(selProviders)],
           ["platforms", Array.from(selPlatforms)],
           ["provider-options", providerOptions],
-          ["provider-isolation", isolation],
-        ], status);
+        ];
+        if (isolationTouched) entries.push(["provider-isolation", isolation]);
+        await saveProjectSections(entries, status);
       } catch { /* toast shown */ }
     } }, ["Save"]),
     el("button", { class: "btn", onclick: () => runDryRun() }, ["Dry-run"]),

--- a/docs/concepts/active/main-chat-orchestrator-mode.md
+++ b/docs/concepts/active/main-chat-orchestrator-mode.md
@@ -104,7 +104,7 @@ Im `main-chat`-Modus soll `agents/1-generic/orchestrator.md` **gar nicht** in `.
 
 ### 4.2 Konsequenzen für abgeleitete Artefakte
 
-- `AGENT_DELEGATION_TABLE` wird für den `main_chat` (in `use-orchestrator.md`) aufbereitet statt für einen Orchestrator-Subagenten
+- `INTENT_ROUTING_TABLE` (bisher nur für `orchestrator.md` verwendet) wird für den `main_chat` (in `use-orchestrator.md`) aufbereitet statt der vollen `AGENT_DELEGATION_TABLE` — vermeidet Duplikation der Agent-Beschreibungen, die Claude Code bereits nativ über Subagent-Descriptions injiziert
 - Routing-Tabellen wandern in die Main-Chat-Rule
 - Der Singleton-Guard-Hook (`orchestrator-guard.sh`) entfällt oder wird deaktiviert, da es keinen Orchestrator gibt
 

--- a/rules/1-generic/use-orchestrator.md
+++ b/rules/1-generic/use-orchestrator.md
@@ -46,6 +46,9 @@ The main chat acts as both router and worker. No separate orchestrator subagent 
 - Apply HITL gates before risky operations (branch delete, force-push, schema migration, DELETE, release)
 - Delegate to specialist agents for isolated work — one level deep, sequential
 
+**Intent-Routing:**
+{{INTENT_ROUTING_TABLE}}
+
 **Reduced overhead (no multi-agent protocol):**
 - No BARRIER / FANOUT
 - No A2A envelope protocol

--- a/scripts/lib/setup.py
+++ b/scripts/lib/setup.py
@@ -156,7 +156,7 @@ def run_setup_wizard(
     # 6. Git
     # ------------------------------------------------------------------
     _section("6/7  Git-Konfiguration")
-    git_platform = _ask_choice("Git-Plattform", ["GitHub", "GitLab", "Gitea"], default="GitHub")
+    git_platform = _ask_choice("Git-Plattform", ["GitHub", "GitLab", "Gitea", "Codeberg"], default="GitHub")
     git_remote = _ask("Remote-URL (z.B. https://github.com/owner/repo)", default="")
     git_branch = _ask("Haupt-Branch", default="main")
     agent_meta_repo = _ask(


### PR DESCRIPTION
## Summary

- Add Codeberg as GIT_PLATFORM option and fix provider-isolation save crash
- Expose intent-routing table to main-chat orchestrator mode
- Correct main-chat-orchestrator-mode.md to reference INTENT_ROUTING_TABLE

## Commits

1. fix: add Codeberg as GIT_PLATFORM option and fix provider-isolation save crash
2. fix: expose intent-routing table to main-chat orchestrator mode
3. docs: correct main-chat-orchestrator-mode.md to reference INTENT_ROUTING_TABLE