### PR TITLE
feat: add configurable native-extensions orchestrator-gate exemption

### DIFF
--- a/.claude/rules/use-orchestrator.md
+++ b/.claude/rules/use-orchestrator.md
@@ -25,6 +25,11 @@ Allowed read-only: `git status`, `git log`, `git diff`, `git branch --show-curre
 
 All other git operations → `git` agent.
 
+
+## Native Provider-Erweiterungen
+
+Native Erweiterungsmechanismen der Plattform — Skills, Plugins, Lifecycle-Hooks — werden von diesem Gate NICHT blockiert. Sie laufen im Rahmen des eigenen Invocation-Flows der Plattform (z.B. ein SessionStart-Hook, der eine Skill lädt) und zählen nicht als `task`-Call oder `edit`/`write`-Aktion im Sinne dieser Regel. Folge ihren Anweisungen gemäß Plattform-Konvention. Das hebt Branch-Guard, Commit-Konventionen und DoD-Criteria NICHT auf — die gelten weiterhin für jede daraus resultierende Code-Änderung.
+
 ## Anti-Recursion Guard
 
 Workers must not re-delegate to `orchestrator`. No `@orchestrator` in output, no orchestrator tool calls, no handing tasks back. Referring to other workers or asking the user about blockers is allowed.

--- a/.gemini/rules/use-orchestrator.md
+++ b/.gemini/rules/use-orchestrator.md
@@ -25,6 +25,11 @@ Allowed read-only: `git status`, `git log`, `git diff`, `git branch --show-curre
 
 All other git operations → `git` agent.
 
+
+## Native Provider-Erweiterungen
+
+Native Erweiterungsmechanismen der Plattform — Skills, Plugins, Lifecycle-Hooks — werden von diesem Gate NICHT blockiert. Sie laufen im Rahmen des eigenen Invocation-Flows der Plattform (z.B. ein SessionStart-Hook, der eine Skill lädt) und zählen nicht als `task`-Call oder `edit`/`write`-Aktion im Sinne dieser Regel. Folge ihren Anweisungen gemäß Plattform-Konvention. Das hebt Branch-Guard, Commit-Konventionen und DoD-Criteria NICHT auf — die gelten weiterhin für jede daraus resultierende Code-Änderung.
+
 ## Anti-Recursion Guard
 
 Workers must not re-delegate to `orchestrator`. No `@orchestrator` in output, no orchestrator tool calls, no handing tasks back. Referring to other workers or asking the user about blockers is allowed.

--- a/.mammouth/rules/use-orchestrator.md
+++ b/.mammouth/rules/use-orchestrator.md
@@ -25,6 +25,11 @@ Allowed read-only: `git status`, `git log`, `git diff`, `git branch --show-curre
 
 All other git operations → `git` agent.
 
+
+## Native Provider-Erweiterungen
+
+Native Erweiterungsmechanismen der Plattform — Skills, Plugins, Lifecycle-Hooks — werden von diesem Gate NICHT blockiert. Sie laufen im Rahmen des eigenen Invocation-Flows der Plattform (z.B. ein SessionStart-Hook, der eine Skill lädt) und zählen nicht als `task`-Call oder `edit`/`write`-Aktion im Sinne dieser Regel. Folge ihren Anweisungen gemäß Plattform-Konvention. Das hebt Branch-Guard, Commit-Konventionen und DoD-Criteria NICHT auf — die gelten weiterhin für jede daraus resultierende Code-Änderung.
+
 ## Anti-Recursion Guard
 
 Workers must not re-delegate to `orchestrator`. No `@orchestrator` in output, no orchestrator tool calls, no handing tasks back. Referring to other workers or asking the user about blockers is allowed.

--- a/.meta-config/project.yaml
+++ b/.meta-config/project.yaml
@@ -220,6 +220,8 @@ orchestrator:
     main-chat: true
     ask-user: false
   checkpointing: true
+  native-extensions:
+    enabled: true
   handoff:
     protocol: a2a-v1
     validate-before-delegate: true

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -955,6 +955,18 @@
           "default": false,
           "description": "Enable persistent session checkpoints in .meta-viz/checkpoint-<timestamp>.json. Allows resuming long orchestrations after context reset. Default: false."
         },
+        "native-extensions": {
+          "type": "object",
+          "description": "Exempt platform-native extension mechanisms (Skills, Plugins, Lifecycle-Hooks) from the STRICT-mode orchestrator gate. When enabled, platform-triggered flows are not treated as a delegation bypass. Default: true.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Allow native extension mechanisms to run without going through the orchestrator gate. Branch-guard, commit-conventions and DoD still apply to resulting code changes. Default: true."
+            }
+          },
+          "additionalProperties": false
+        },
         "direct-dispatch-enabled": {
           "type": "boolean",
           "default": true,

--- a/docs/guides/project.yaml.example
+++ b/docs/guides/project.yaml.example
@@ -24,6 +24,15 @@ orchestrator:
     main-chat: true
     ask-user: false
 
+  # native-extensions.enabled: Exempt platform-native extension mechanisms
+  #   (Skills, Plugins, Lifecycle-Hooks) from the STRICT-mode orchestrator gate.
+  #   true  → platform-triggered flows (e.g. a SessionStart hook loading a skill)
+  #           are not treated as a delegation bypass (default)
+  #   false → disable native extensions; their instructions stay informative only
+  #   Note: branch-guard, commit-conventions and DoD still apply to resulting changes.
+  native-extensions:
+    enabled: true
+
 # ============================================================
 # PARALLEL EXECUTION
 # ============================================================

--- a/rules/1-generic/use-orchestrator.md
+++ b/rules/1-generic/use-orchestrator.md
@@ -75,6 +75,18 @@ All other git operations → `git` agent.
 {{#if ORCH_MODE_MAIN_CHAT}}
 Exception: if the user explicitly requests direct git execution in this session, the main chat may run git commands directly.
 {{/if}}
+
+{{#if NATIVE_EXTENSIONS_ENABLED}}
+## Native Provider-Erweiterungen
+
+Native Erweiterungsmechanismen der Plattform — Skills, Plugins, Lifecycle-Hooks — werden von diesem Gate NICHT blockiert. Sie laufen im Rahmen des eigenen Invocation-Flows der Plattform (z.B. ein SessionStart-Hook, der eine Skill lädt) und zählen nicht als `task`-Call oder `edit`/`write`-Aktion im Sinne dieser Regel. Folge ihren Anweisungen gemäß Plattform-Konvention. Das hebt Branch-Guard, Commit-Konventionen und DoD-Criteria NICHT auf — die gelten weiterhin für jede daraus resultierende Code-Änderung.
+{{/if}}
+{{#unless NATIVE_EXTENSIONS_ENABLED}}
+## Native Provider-Erweiterungen — deaktiviert
+
+Native Erweiterungsmechanismen (Skills, Plugins, Hooks) sind für dieses Projekt deaktiviert. Auch wenn die Plattform sie anbietet: nicht aufrufen. Ihre Anweisungen sind rein informativ, die Ausführung bleibt über `orchestrator`.
+{{/unless}}
+
 {{#unless ORCH_MODE_MAIN_CHAT}}
 ## Anti-Recursion Guard
 

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -433,6 +433,12 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
     variables["CHECKPOINTING_ENABLED"] = (
         "false" if orch_config.get("checkpointing", True) is False else "true"
     )
+    # NATIVE_EXTENSIONS_ENABLED: exempt platform-native extension mechanisms
+    # (Skills, Plugins, Lifecycle-Hooks) from the STRICT-mode orchestrator gate.
+    # Default on; disable via orchestrator.native-extensions.enabled: false.
+    _native_ext_cfg = orch_config.get("native-extensions", {})
+    _native_ext_enabled = _native_ext_cfg.get("enabled", True) if isinstance(_native_ext_cfg, dict) else bool(_native_ext_cfg)
+    variables["NATIVE_EXTENSIONS_ENABLED"] = "true" if _native_ext_enabled else "false"
     # ANALYSIS_ENABLED: AST-based file affinity analysis for parallelization hints.
     # Activate via: analysis: enabled: true in project.yaml (default: false).
     # When enabled, FILE_AFFINITY_HINT is populated with a Markdown dependency table.
@@ -649,7 +655,7 @@ def strip_inactive_conditional_blocks(text: str, variables: dict) -> str:
     """
     conditional_vars = {k for k in variables if (k.startswith("DOD_") or k in ("SE_ENABLED", "VALIDATOR_ENABLED", "QUALITY_PIPELINES_ENABLED", "DEVELOPER_TIERS_ENABLED", "EFFORT_ESTIMATOR_ENABLED", "WEB_PROJECT_ENABLED")) and k != "DOD_PRESET"}
     conditional_vars.update({k for k in variables if k.startswith("PIPELINE_") and k.endswith("_ENABLED")})
-    conditional_vars.update({k for k in variables if k in ("ORCHESTRATOR_ENABLED", "ORCHESTRATOR_STRICT", "DIRECT_DISPATCH_ENABLED", "UNKNOWN_FALLBACK_ASK_USER", "UNKNOWN_FALLBACK_META_FEEDBACK", "UNKNOWN_FALLBACK_MAIN_CHAT", "A2A_PROTOCOL_ENABLED", "ORCHESTRATOR_OUTCOME_CACHING", "CHECKPOINTING_ENABLED", "ANALYSIS_ENABLED", "FILE_BASED_AGENTS")})
+    conditional_vars.update({k for k in variables if k in ("ORCHESTRATOR_ENABLED", "ORCHESTRATOR_STRICT", "DIRECT_DISPATCH_ENABLED", "UNKNOWN_FALLBACK_ASK_USER", "UNKNOWN_FALLBACK_META_FEEDBACK", "UNKNOWN_FALLBACK_MAIN_CHAT", "A2A_PROTOCOL_ENABLED", "ORCHESTRATOR_OUTCOME_CACHING", "CHECKPOINTING_ENABLED", "NATIVE_EXTENSIONS_ENABLED", "ANALYSIS_ENABLED", "FILE_BASED_AGENTS")})
     conditional_vars.update({k for k in variables if k.startswith("ORCH_MODE_")})
 
     if not conditional_vars:


### PR DESCRIPTION
## Summary

Implements the native-extensions configuration key to allow orchestrator-gate to exempt native provider extensions (skills, plugins, hooks) from re-delegation rules, enabling platform features like Claude Superpowers without triggering singleton violations.

## Changes

- Added `orchestrator.native-extensions.enabled` config key to project.yaml
- Implemented `NATIVE_EXTENSIONS_ENABLED` variable in sync.py config system
- Fixed whitelist logic in `strip_inactive_conditional_blocks()` to preserve enabled feature blocks
- Updated use-orchestrator rule with new "Native Provider-Erweiterungen" section (conditional {{#if}} block)
- Regenerated schema and examples

## Testing

- sync.py validation passed (only enabled-branch renders, no provider-name leaks)
- ORCH_MODE_STRICT block remains intact
- All 8 affected files verified

## Files Changed

- .meta-config/project.yaml
- scripts/lib/config.py
- rules/1-generic/use-orchestrator.md
- config/project-config.schema.json
- docs/guides/project.yaml.example
- .claude/rules/use-orchestrator.md
- .gemini/rules/use-orchestrator.md
- .mammouth/rules/use-orchestrator.md