### PR TITLE
fix: CLAUDE.md block separation (#373) and env var masking guard (#356)

### DIFF
--- a/docs/ui/admin-ui.html
+++ b/docs/ui/admin-ui.html
@@ -5860,9 +5860,15 @@ async function viewProjectEnvironments() {
       if (!newName) { toast("Name is required", "error"); return; }
       const oldName = isNew ? null : name;
       if (oldName && oldName !== newName) delete envs[oldName];
+      // Guard: never persist masked placeholder values as actual defaults.
+      const rawDefault = defInput.value.trim();
+      const MASK_PATTERNS = ["***", "••••••••", "********"];
+      const effectiveDefault = MASK_PATTERNS.includes(rawDefault)
+        ? (isNew ? "" : (envs[newName]?.default || ""))
+        : rawDefault;
       envs[newName] = {
         description: descInput.value.trim(),
-        default: defInput.value.trim(),
+        default: effectiveDefault,
         required: reqCheck.checked,
         secret: secCheck.checked,
       };
@@ -5870,6 +5876,7 @@ async function viewProjectEnvironments() {
       hideModal();
       render();
     } }, ["Save"]);
+
 
     showModal(title, body, [saveBtn, el("button", { class: "btn", onclick: hideModal }, ["Cancel"])]);
   }

--- a/templates/configs/CLAUDE.project-template.md
+++ b/templates/configs/CLAUDE.project-template.md
@@ -93,11 +93,3 @@ Generiert von agent-meta v{{AGENT_META_VERSION}} — `{{AGENT_META_DATE}}`
 
 {{AGENT_HINTS}}
 <!-- agent-meta:managed-end -->
-
----
-
-## Sprachregeln
-
-Siehe `.claude/rules/language.md` für die Sprachkonventionen (von sync.py generiert, automatisch geladen).
-
-<!-- Nur projektspezifische Abweichungen hier eintragen — sonst leer lassen. -->


### PR DESCRIPTION
Fixes #373 — removed redundant Sprachregeln footer outside managed block (already generated as separate rule file).\nFixes #356 — added guard preventing masked placeholder values (***) from being persisted as actual env var defaults.\nCloses #375 — already fixed (auto-setup wizard).\nCloses #341 and #328 — already fixed (glob prefix for file patterns in isolation).