### PR TITLE
fix: silence false-positive sync.py warnings

### DIFF
--- a/config/skills-registry.yaml
+++ b/config/skills-registry.yaml
@@ -11,7 +11,7 @@ repos:
   reqogniloom:
     repo: https://github.com/Popoboxxo/ReqogniLoom
     local_path: external/ReqogniLoom
-    pinned_commit: main
+    pinned_commit: a05f6d567450f439fbdfbfc11af90bec2096a894
 
   neat-little-package:
     repo: https://github.com/racurry/neat-little-package

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -282,11 +282,21 @@ def fill_defaults(
         log.info("fill-defaults", "all structural fields already set — nothing to write")
 
     # --- Warn about missing variable keys ---
-    known_vars = _load_schema_variable_keys(agent_meta_root)
-    set_vars = set(config.get("variables", {}).keys())
-    missing_vars = [v for v in known_vars if v not in set_vars]
-    for var in missing_vars:
-        log.warning(f"Variable not set in config: variables.{var}")
+    # Respect `silent` per the docstring ("only the summary line is logged for
+    # auto-fill during sync") — sync.py calls fill_defaults() twice per run
+    # (once normally, once silent at the end), so without this guard every
+    # warning below fired twice on every sync.
+    if not silent:
+        from .consistency.placeholders import _BUILTIN_VARS
+        known_vars = _load_schema_variable_keys(agent_meta_root)
+        set_vars = set(config.get("variables", {}).keys())
+        # Skip vars auto-injected by build_variables() (see _BUILTIN_VARS) —
+        # they never need to be set in project.yaml, so flagging them as
+        # "missing" was a false positive caused by this check and the
+        # build_variables() auto-injection list drifting out of sync.
+        missing_vars = [v for v in known_vars if v not in set_vars and v not in _BUILTIN_VARS]
+        for var in missing_vars:
+            log.warning(f"Variable not set in config: variables.{var}")
 
 
 def _write_yaml_with_comments(path: Path, data: dict, auto_filled: list[tuple[str, str]]) -> None:

--- a/scripts/lib/skills.py
+++ b/scripts/lib/skills.py
@@ -1,6 +1,8 @@
 """External skills: loading, commit checks, sync, add."""
 
+import os
 import re
+import stat
 import subprocess
 from pathlib import Path
 
@@ -10,6 +12,22 @@ from .log import SyncLog
 EXTERNAL_SKILLS_CONFIG = "config/skills-registry.yaml"
 _EXTERNAL_SKILLS_CONFIG_LEGACY = "external-skills.config.yaml"
 _EXTERNAL_SKILLS_CONFIG_JSON = "external-skills.config.json"  # legacy fallback
+
+
+def _rmtree_force(path) -> None:
+    """shutil.rmtree that survives Windows' read-only .git pack/idx files.
+
+    Git marks objects in .git/objects/pack/* read-only; plain shutil.rmtree()
+    fails there with [WinError 5] Access Denied. On error, clear the
+    read-only bit and retry the removal once.
+    """
+    import shutil
+
+    def _on_error(func, target_path, exc_info):
+        os.chmod(target_path, stat.S_IWRITE)
+        func(target_path)
+
+    shutil.rmtree(path, onerror=_on_error)
 
 
 def _normalize_project_skills(raw) -> dict:
@@ -245,16 +263,16 @@ def deinit_skill_repo(agent_meta_root: Path, project_root: Path, local_path: str
             modules_dir = Path(cwd) / ".git" / "modules" / local_path
             if modules_dir.exists():
                 try:
-                    shutil.rmtree(modules_dir)
+                    _rmtree_force(modules_dir)
                 except Exception as e:
                     log.warn(f"Failed to remove .git/modules/{local_path}: {e}")
             try:
-                shutil.rmtree(target_dir, ignore_errors=True)
+                _rmtree_force(target_dir)
             except Exception as e:
                 log.warn(f"Failed to remove working directory {local_path}: {e}")
         else:
             try:
-                shutil.rmtree(target_dir)
+                _rmtree_force(target_dir)
             except Exception as e:
                 log.warn(f"Failed to remove cloned repo {local_path}: {e}")
 


### PR DESCRIPTION
## Summary

Fixes three false-positive warnings in `sync.py` runs, reducing warning count from 5 to 0 while maintaining consistency.

## Changes

1. **fill_defaults() silent parameter** (`scripts/lib/config.py`)
   - Docstring claimed it silenced variable warnings, but code ignored it
   - Now properly gates "Variable not set in config" messages
   - Prevents duplicate warnings per sync run

2. **BUILTIN_VARS false-positive** (`scripts/lib/config.py`)
   - Variables like `AGENTS_DIR`, `PLUGIN_DIR_NAME` auto-injected by `build_variables()`
   - Were being reported as "missing" in warning loop anyway
   - Skip reporting variables already in `consistency/placeholders.py`

3. **Windows .git cleanup** (`scripts/lib/skills.py`)
   - `shutil.rmtree()` fails on Windows: `[WinError 5] Zugriff verweigert`
   - Git pack files (`.git/objects/pack/*.pack|*.idx`) are read-only
   - New `_rmtree_force()` helper with error handler fixes dynamic skill cleanup

4. **reqogniloom pinned_commit** (`config/skills-registry.yaml`)
   - Was set to branch name `main` instead of actual commit hash
   - Caused `check_pinned_commits()` to fail on every sync (string != hash prefix)
   - Corrected to: `a05f6d567450f439fbdfbfc11af90bec2096a894`

## Verification

```
python scripts/sync.py --dry-run: 0 warning(s) ✓
python scripts/consistency-check.py: PASS ✓
```

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>