### PR TITLE
feat: pipeline engine core (run_pipeline, plan-driven, providers, dod_flag/payload_flag)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-pipeline-engine-core.md
+++ b/docs/superpowers/plans/2026-08-05-pipeline-engine-core.md
@@ -1,0 +1,851 @@
+# Pipeline-Engine-Kern Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `scripts/lib/pipelines.py` with the stage-engine primitives the pipeline-driven-orchestration spec needs (`providers`, `dod_flag`/`payload_flag` conditionals, `run_pipeline` composition, `plan-driven`), so later plans (feature-lifecycle migration, output-targets, admin-UI) can build on a working engine.
+
+**Architecture:** All changes live in `scripts/lib/pipelines.py` (the sync-time text generator for agent prompts — it never executes pipelines at runtime, it only renders instructions the orchestrator follows) plus one caller fix in `scripts/lib/agents.py`. No new files except the test file; no changes to `role-defaults.yaml` content (that's Plan 2).
+
+**Tech Stack:** Python 3, pytest, PyYAML (already a soft dependency in `pipelines.py`).
+
+## Global Constraints
+
+- `max_depth` default is exactly `4` when a pipeline defines no `max_depth` field (spec Entscheidung 1).
+- Known providers are exactly `("Claude", "Opencode", "Gemini", "Continue", "Mammouth")` (existing tuple in `build_pipeline_variables`, spec Entscheidung 5).
+- `dod_flag` conditionals resolve at sync time (stage fully omitted from generated text when inactive); missing flag defaults to **active** (`True`), matching the existing `dod_resolved.get(flag, True)` convention in `scripts/lib/config.py:768`.
+- `payload_flag` conditionals stay visible in generated text; the orchestrator skips them at runtime — no sync-time omission (spec Entscheidung 11).
+- `plan-driven` and `run_pipeline` are pure text-generation concerns here — no runtime dispatch logic belongs in `pipelines.py` (that's the orchestrator's job per spec Entscheidung 3).
+- Every new stage field must be handled generically (no per-pipeline-name special casing) — spec Entscheidung 9.
+
+---
+
+## File Structure
+
+- **Modify:** `scripts/lib/pipelines.py` — all engine changes (provider filtering, conditional types, composition, plan-driven, validation).
+- **Modify:** `scripts/lib/agents.py:1497-1501` — `inject_pipeline_blocks()` call currently passes `active_dod={}` (a no-op placeholder); switch to the real resolved DOD dict so `dod_flag` conditionals work in generated output.
+- **Create:** `tests/test_pipelines.py` — no test file for `scripts/lib/pipelines.py` exists today; this plan creates the first one, scoped to the new behavior (not full pre-existing-function coverage).
+
+---
+
+### Task 1: `providers` field — pipeline-wide activation filter
+
+**Files:**
+- Modify: `scripts/lib/pipelines.py` (add `KNOWN_PROVIDERS` constant, `_pipeline_active_for_provider()`, wire into `build_pipeline_variables()` and `inject_pipeline_blocks()`, add validation in `validate_pipelines()`)
+- Test: `tests/test_pipelines.py`
+
+**Interfaces:**
+- Produces: `KNOWN_PROVIDERS: tuple[str, ...]` — module-level constant, reused by Tasks 2-5.
+- Produces: `_pipeline_active_for_provider(pipeline: dict, provider: str) -> bool` — used by later tasks' rendering code.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_pipelines.py
+from scripts.lib.pipelines import (
+    KNOWN_PROVIDERS,
+    _pipeline_active_for_provider,
+    build_pipeline_variables,
+    validate_pipelines,
+)
+
+
+def test_known_providers_constant():
+    assert KNOWN_PROVIDERS == ("Claude", "Opencode", "Gemini", "Continue", "Mammouth")
+
+
+def test_pipeline_active_for_provider_no_field_means_everywhere_active():
+    pipeline = {"stages": []}
+    for provider in KNOWN_PROVIDERS:
+        assert _pipeline_active_for_provider(pipeline, provider) is True
+
+
+def test_pipeline_active_for_provider_exclude():
+    pipeline = {"providers": {"default": "active", "exclude": ["Claude"]}}
+    assert _pipeline_active_for_provider(pipeline, "Claude") is False
+    assert _pipeline_active_for_provider(pipeline, "Opencode") is True
+
+
+def test_pipeline_active_for_provider_include_only():
+    pipeline = {"providers": {"default": "inactive", "include": ["Gemini"]}}
+    assert _pipeline_active_for_provider(pipeline, "Gemini") is True
+    assert _pipeline_active_for_provider(pipeline, "Claude") is False
+
+
+def test_build_pipeline_variables_empty_block_for_excluded_provider():
+    pipelines = {
+        "concept-to-review": {
+            "description": "test",
+            "providers": {"default": "active", "exclude": ["Claude"]},
+            "stages": [{"id": "plan", "agent": "planner", "task": "Plan", "mode": "sequential"}],
+        }
+    }
+    variables = build_pipeline_variables(pipelines, {})
+    blocks = variables["PIPELINE_CONCEPT_TO_REVIEW_PROVIDER_BLOCKS"]
+    assert blocks["Claude"] == ""
+    assert blocks["Opencode"] != ""
+
+
+def test_validate_pipelines_rejects_unknown_provider():
+    pipelines = {
+        "p1": {
+            "providers": {"default": "active", "exclude": ["NotAProvider"]},
+            "stages": [],
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("NotAProvider" in e for e in errors)
+
+
+def test_validate_pipelines_rejects_bad_default_value():
+    pipelines = {"p1": {"providers": {"default": "sometimes"}, "stages": []}}
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("providers.default" in e for e in errors)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: FAIL — `ImportError: cannot import name 'KNOWN_PROVIDERS'` (and the rest, since none of the new symbols exist yet).
+
+- [ ] **Step 3: Implement `KNOWN_PROVIDERS` and `_pipeline_active_for_provider()`**
+
+In `scripts/lib/pipelines.py`, add near the top (after the `import` block, before `load_quality_pipelines`):
+
+```python
+KNOWN_PROVIDERS = ("Claude", "Opencode", "Gemini", "Continue", "Mammouth")
+DEFAULT_MAX_DEPTH = 4
+
+
+def _pipeline_active_for_provider(pipeline: dict, provider: str) -> bool:
+    """Return whether a pipeline is active for `provider` per its `providers` field.
+
+    No `providers` field means active everywhere (backward compatible with
+    pipelines that predate this field, e.g. quick-fix/bugfix).
+    """
+    providers_cfg = pipeline.get("providers")
+    if not providers_cfg:
+        return True
+    default = providers_cfg.get("default", "active")
+    if default == "active":
+        return provider not in providers_cfg.get("exclude", [])
+    return provider in providers_cfg.get("include", [])
+```
+
+- [ ] **Step 4: Wire the filter into `build_pipeline_variables()` and `inject_pipeline_blocks()`**
+
+Replace the provider loop in `build_pipeline_variables()`:
+
+```python
+        provider_blocks = {}
+        for provider in KNOWN_PROVIDERS:
+            if _pipeline_active_for_provider(pipeline, provider):
+                provider_blocks[provider] = _generate_pipeline_block(pipeline, provider)
+            else:
+                provider_blocks[provider] = ""
+        variables[f"PIPELINE_{var_name}_PROVIDER_BLOCKS"] = provider_blocks
+```
+
+Replace the `_replacer` inner function in `inject_pipeline_blocks()`:
+
+```python
+    def _replacer(match):
+        name = match.group(1).lower().replace("_", "-")
+        pipeline = pipelines.get(name)
+        if not pipeline:
+            return match.group(0)
+        if not _pipeline_active_for_provider(pipeline, provider):
+            return ""
+        return _generate_pipeline_block(pipeline, provider)
+```
+
+- [ ] **Step 5: Add provider validation to `validate_pipelines()`**
+
+Inside the `for name, pipeline in pipelines.items():` loop in `validate_pipelines()`, after the existing `stages` loop (still inside the outer `for`, same indentation as `stages = pipeline.get("stages", [])`), add:
+
+```python
+        providers_cfg = pipeline.get("providers")
+        if providers_cfg:
+            default = providers_cfg.get("default", "active")
+            if default not in ("active", "inactive"):
+                errors.append(
+                    f"Pipeline '{name}': providers.default must be 'active' or "
+                    f"'inactive', got '{default}'"
+                )
+            for key in ("include", "exclude"):
+                for p in providers_cfg.get(key, []):
+                    if p not in KNOWN_PROVIDERS:
+                        errors.append(
+                            f"Pipeline '{name}': providers.{key} entry '{p}' is not "
+                            f"a known provider ({', '.join(KNOWN_PROVIDERS)})"
+                        )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: PASS (7/7 so far)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/pipelines.py tests/test_pipelines.py
+git commit -m "feat: add provider activation filter to quality pipelines"
+```
+
+---
+
+### Task 2: `dod_flag` conditional — sync-time stage omission
+
+**Files:**
+- Modify: `scripts/lib/pipelines.py` (`_generate_pipeline_block()` signature gains `active_dod`, stage loop skips `dod_flag`-inactive stages)
+- Test: `tests/test_pipelines.py`
+
+**Interfaces:**
+- Consumes: nothing new from Task 1.
+- Produces: `_generate_pipeline_block(pipeline, provider, all_pipelines=None, active_dod=None, _depth=0)` — the extended signature Tasks 3-5 build on. `all_pipelines` and `_depth` are added now (unused until Task 4) so the signature only changes once.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_generate_pipeline_block_skips_inactive_dod_flag_stage():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {"id": "always", "agent": "git", "task": "Branch anlegen", "mode": "sequential"},
+            {
+                "id": "req",
+                "agent": "requirements",
+                "task": "REQ-ID vergeben",
+                "mode": "conditional",
+                "condition": {"dod_flag": "req-traceability"},
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode", active_dod={"req-traceability": False})
+    assert "Branch anlegen" in block
+    assert "REQ-ID vergeben" not in block
+
+
+def test_generate_pipeline_block_includes_active_dod_flag_stage():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "req",
+                "agent": "requirements",
+                "task": "REQ-ID vergeben",
+                "mode": "conditional",
+                "condition": {"dod_flag": "req-traceability"},
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode", active_dod={"req-traceability": True})
+    assert "REQ-ID vergeben" in block
+
+
+def test_generate_pipeline_block_dod_flag_defaults_to_active_when_missing():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "req",
+                "agent": "requirements",
+                "task": "REQ-ID vergeben",
+                "mode": "conditional",
+                "condition": {"dod_flag": "req-traceability"},
+            },
+        ]
+    }
+    # active_dod does not mention "req-traceability" at all
+    block = _generate_pipeline_block(pipeline, "Opencode", active_dod={})
+    assert "REQ-ID vergeben" in block
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: FAIL — `TypeError: _generate_pipeline_block() got an unexpected keyword argument 'active_dod'`
+
+- [ ] **Step 3: Extend the signature and add the skip check**
+
+Change the function signature:
+
+```python
+def _generate_pipeline_block(
+    pipeline: dict,
+    provider: str,
+    all_pipelines: dict | None = None,
+    active_dod: dict | None = None,
+    _depth: int = 0,
+) -> str:
+    """Generate a provider-specific markdown block for a single pipeline."""
+    provider_key = provider.lower()
+    fmt = _PROVIDER_NOTATION.get(provider_key, _PROVIDER_NOTATION["opencode"])
+    active_dod = active_dod or {}
+    lines = []
+    stages = pipeline.get("stages", [])
+    seq_idx = 0
+```
+
+At the top of the `for stage in stages:` loop, before reading `mode`/`agent`/`task`, add the skip check:
+
+```python
+    for stage in stages:
+        mode = stage.get("mode", "sequential")
+        if mode == "conditional":
+            cond = stage.get("condition", {})
+            if "dod_flag" in cond and not active_dod.get(cond["dod_flag"], True):
+                continue
+        agent = stage.get("agent", "")
+        task = stage.get("task", "")
+        stage_id = stage.get("id", "")
+```
+
+(This replaces the existing four lines that read `mode`, `agent`, `task`, `stage_id` — the new block reorders them so `mode` is available before the skip check, keeping the rest of the loop body unchanged.)
+
+- [ ] **Step 4: Update the two callers to pass `active_dod` through**
+
+In `build_pipeline_variables()`, the call inside the provider loop becomes:
+
+```python
+                provider_blocks[provider] = _generate_pipeline_block(
+                    pipeline, provider, active_dod=active_dod
+                )
+```
+
+In `inject_pipeline_blocks()`'s `_replacer`:
+
+```python
+        return _generate_pipeline_block(pipeline, provider, active_dod=active_dod)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: PASS (10/10 so far)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/pipelines.py tests/test_pipelines.py
+git commit -m "feat: add dod_flag conditional stage omission to pipelines"
+```
+
+---
+
+### Task 3: `payload_flag` conditional — runtime-skip annotation
+
+**Files:**
+- Modify: `scripts/lib/pipelines.py` (`conditional` branch in `_generate_pipeline_block()`)
+- Test: `tests/test_pipelines.py`
+
+**Interfaces:**
+- Consumes: `_generate_pipeline_block(..., active_dod=...)` from Task 2 (unchanged signature).
+- Produces: nothing new consumed by later tasks — this is a leaf rendering change.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_generate_pipeline_block_payload_flag_annotation():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "scope",
+                "agent": "ideation",
+                "task": "Idee scopen",
+                "mode": "conditional",
+                "condition": {"payload_flag": "needs_scoping"},
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    # payload_flag stages stay in the text (unlike dod_flag) — orchestrator
+    # decides at runtime whether to skip them.
+    assert "Idee scopen" in block
+    assert "needs_scoping" in block
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_pipelines.py::test_generate_pipeline_block_payload_flag_annotation -v`
+Expected: FAIL — `assert "needs_scoping" in block` fails (annotation text not generated yet).
+
+- [ ] **Step 3: Add the `payload_flag` branch**
+
+In the `elif mode == "conditional":` block, after the existing `if cond.get("type") == "agent_decision":` block, add an `elif`:
+
+```python
+        elif mode == "conditional":
+            lines.append("")
+            lines.append(f"**{stage_id}** — {fmt['conditional_start']}")
+            lines.append(
+                fmt["conditional_item"].format(agent=agent, task=task)
+            )
+            cond = stage.get("condition", {})
+            if cond.get("type") == "agent_decision":
+                lines.append(f"  Decision agent: {cond.get('agent', agent)}")
+                lines.append("  If 'continue': Orchestrator spawns new cell at level n+1 with sanitized context")
+                lines.append("  If 'leaf': Component is final — handover to implementation discipline")
+            elif "payload_flag" in cond:
+                lines.append(
+                    f"  Laufzeit-Skip: Orchestrator überspringt diese Stage, wenn "
+                    f"payload.{cond['payload_flag']} fehlt oder false ist."
+                )
+            lines.append("")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: PASS (11/11 so far)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/pipelines.py tests/test_pipelines.py
+git commit -m "feat: annotate payload_flag conditional stages for runtime skip"
+```
+
+---
+
+### Task 4: `run_pipeline` composition — cycle detection, depth limit, recursive rendering
+
+**Files:**
+- Modify: `scripts/lib/pipelines.py` (`validate_pipelines()` gains composition checks, `_generate_pipeline_block()` gains a `run_pipeline` branch)
+- Test: `tests/test_pipelines.py`
+
+**Interfaces:**
+- Consumes: `_generate_pipeline_block(pipeline, provider, all_pipelines=None, active_dod=None, _depth=0)` from Task 2 (the `all_pipelines`/`_depth` params were reserved then, used now).
+- Produces: nothing new consumed by later tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_validate_pipelines_detects_direct_cycle():
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}]},
+        "b": {"stages": [{"id": "y", "run_pipeline": "a", "mode": "run_pipeline"}]},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("circular" in e.lower() for e in errors)
+
+
+def test_validate_pipelines_detects_missing_referenced_pipeline():
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "does-not-exist", "mode": "run_pipeline"}]},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("does-not-exist" in e for e in errors)
+
+
+def test_validate_pipelines_enforces_default_max_depth():
+    # a -> b -> c -> d -> e is 4 hops; default max_depth is 4, so 5 pipelines
+    # (depth 5 reached) must fail, depth 4 must pass.
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}]},
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": [{"id": "x", "run_pipeline": "e", "mode": "run_pipeline"}]},
+        "e": {"stages": []},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("max_depth" in e for e in errors)
+
+
+def test_validate_pipelines_max_depth_override_allows_deeper_nesting():
+    pipelines = {
+        "a": {
+            "max_depth": 5,
+            "stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}],
+        },
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": [{"id": "x", "run_pipeline": "e", "mode": "run_pipeline"}]},
+        "e": {"stages": []},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert errors == []
+
+
+def test_generate_pipeline_block_renders_nested_pipeline_indented():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipelines = {
+        "outer": {
+            "stages": [{"id": "implement", "run_pipeline": "inner", "mode": "run_pipeline"}]
+        },
+        "inner": {
+            "stages": [{"id": "step", "agent": "developer", "task": "Feature implementieren", "mode": "sequential"}]
+        },
+    }
+    block = _generate_pipeline_block(pipelines["outer"], "Opencode", all_pipelines=pipelines)
+    assert "enthält Pipeline `inner`" in block
+    assert "Feature implementieren" in block
+
+
+def test_generate_pipeline_block_run_pipeline_missing_reference_is_marked():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {"stages": [{"id": "implement", "run_pipeline": "ghost", "mode": "run_pipeline"}]}
+    block = _generate_pipeline_block(pipeline, "Opencode", all_pipelines={})
+    assert "nicht aufgelöst" in block
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: FAIL — cycle/missing-reference/max_depth errors are never produced (no composition checks yet), and `run_pipeline` stages render nothing (mode falls through every existing `elif`).
+
+- [ ] **Step 3: Add composition validation to `validate_pipelines()`**
+
+Add a module-level helper above `validate_pipelines()`:
+
+```python
+def _validate_pipeline_composition(pipelines: dict, name: str, pipeline: dict) -> list[str]:
+    """Check run_pipeline references for missing targets, cycles, and depth limit."""
+    errors = []
+    max_depth = pipeline.get("max_depth", DEFAULT_MAX_DEPTH)
+
+    def _walk(current_name: str, visited: list[str], depth: int) -> None:
+        if depth > max_depth:
+            errors.append(
+                f"Pipeline '{name}': run_pipeline nesting exceeds max_depth="
+                f"{max_depth} (path: {' -> '.join(visited)})"
+            )
+            return
+        current = pipelines.get(current_name)
+        if current is None:
+            errors.append(
+                f"Pipeline '{name}': referenced pipeline '{current_name}' not found"
+            )
+            return
+        for stage in current.get("stages", []):
+            ref = stage.get("run_pipeline")
+            if not ref:
+                continue
+            if ref in visited:
+                errors.append(
+                    f"Pipeline '{name}': circular run_pipeline reference "
+                    f"({' -> '.join(visited + [ref])})"
+                )
+                continue
+            _walk(ref, visited + [ref], depth + 1)
+
+    _walk(name, [name], 1)
+    return errors
+```
+
+Inside `validate_pipelines()`, in the `for name, pipeline in pipelines.items():` loop, after the `providers_cfg` block added in Task 1, add:
+
+```python
+        errors.extend(_validate_pipeline_composition(pipelines, name, pipeline))
+```
+
+- [ ] **Step 4: Add the `run_pipeline` rendering branch**
+
+At the top of `_generate_pipeline_block()`, compute the depth cap once:
+
+```python
+    max_depth = pipeline.get("max_depth", DEFAULT_MAX_DEPTH)
+```
+
+Add a new `elif` branch (after the existing `conditional` branch, same indentation level as the other mode branches):
+
+```python
+        elif mode == "run_pipeline":
+            ref_name = stage.get("run_pipeline", "")
+            ref_pipeline = (all_pipelines or {}).get(ref_name)
+            lines.append("")
+            lines.append(f"**{stage_id}** — enthält Pipeline `{ref_name}`:")
+            if ref_pipeline is None:
+                lines.append(f"  [nicht aufgelöst — Pipeline '{ref_name}' nicht gefunden]")
+            elif _depth >= max_depth:
+                lines.append(f"  [nicht aufgelöst — max_depth={max_depth} erreicht]")
+            else:
+                sub_block = _generate_pipeline_block(
+                    ref_pipeline,
+                    provider,
+                    all_pipelines=all_pipelines,
+                    active_dod=active_dod,
+                    _depth=_depth + 1,
+                )
+                for sub_line in sub_block.splitlines():
+                    lines.append(f"  {sub_line}")
+            lines.append("")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: PASS (17/17 so far)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/pipelines.py tests/test_pipelines.py
+git commit -m "feat: add run_pipeline composition with cycle and depth checks"
+```
+
+---
+
+### Task 5: `mode: plan-driven` — validation and rendering
+
+**Files:**
+- Modify: `scripts/lib/pipelines.py` (`validate_pipelines()` gains `plan-driven` role checks, `_generate_pipeline_block()` gains a `plan-driven` branch)
+- Test: `tests/test_pipelines.py`
+
+**Interfaces:**
+- Consumes: `available_roles` param already present on `validate_pipelines()`.
+- Produces: nothing new consumed by later tasks — last engine-primitive task in this plan.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_validate_pipelines_plan_driven_rejects_unknown_fallback_agent():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {
+                    "id": "implement",
+                    "mode": "plan-driven",
+                    "plan-driven": {"fallback_agent": "ghost-role"},
+                }
+            ]
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=["developer"])
+    assert any("ghost-role" in e for e in errors)
+
+
+def test_validate_pipelines_plan_driven_rejects_unknown_allowed_agent():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {
+                    "id": "implement",
+                    "mode": "plan-driven",
+                    "plan-driven": {
+                        "fallback_agent": "developer",
+                        "allowed_agents": ["developer", "ghost-role"],
+                    },
+                }
+            ]
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=["developer"])
+    assert any("ghost-role" in e for e in errors)
+
+
+def test_validate_pipelines_plan_driven_accepts_known_roles():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {
+                    "id": "implement",
+                    "mode": "plan-driven",
+                    "plan-driven": {
+                        "fallback_agent": "developer",
+                        "allowed_agents": ["junior-developer", "developer", "senior-developer"],
+                    },
+                }
+            ]
+        }
+    }
+    errors = validate_pipelines(
+        pipelines, available_roles=["junior-developer", "developer", "senior-developer"]
+    )
+    assert errors == []
+
+
+def test_generate_pipeline_block_plan_driven_rendering():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "implement",
+                "mode": "plan-driven",
+                "plan-driven": {
+                    "fallback_agent": "developer",
+                    "allowed_agents": ["junior-developer", "developer", "senior-developer"],
+                },
+            }
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    assert "Plan-driven" in block
+    assert "developer" in block
+    assert "kein stiller Fallback" in block
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: FAIL — no `plan-driven` validation exists, and rendering produces nothing (mode falls through all branches).
+
+- [ ] **Step 3: Add `plan-driven` validation to `validate_pipelines()`**
+
+In the `for stage in stages:` loop in `validate_pipelines()`, after the existing `if mode == "parallel_group":` block, add:
+
+```python
+            if mode == "plan-driven":
+                pd = stage.get("plan-driven", {})
+                fallback = pd.get("fallback_agent")
+                if fallback and fallback not in available_roles:
+                    errors.append(
+                        f"Pipeline '{name}': stage '{stage.get('id')}' plan-driven "
+                        f"fallback_agent '{fallback}' not found in available roles."
+                    )
+                for allowed in pd.get("allowed_agents", []):
+                    if allowed not in available_roles:
+                        errors.append(
+                            f"Pipeline '{name}': stage '{stage.get('id')}' plan-driven "
+                            f"allowed_agents entry '{allowed}' not found in available roles."
+                        )
+```
+
+- [ ] **Step 4: Add the `plan-driven` rendering branch**
+
+Add a new `elif` branch in `_generate_pipeline_block()` (after the `run_pipeline` branch from Task 4):
+
+```python
+        elif mode == "plan-driven":
+            pd = stage.get("plan-driven", {})
+            fallback = pd.get("fallback_agent", "")
+            allowed = pd.get("allowed_agents", [])
+            lines.append("")
+            lines.append(
+                f"**{stage_id}** — Plan-driven: Agent aus payload.plan_ref "
+                f"(Stage-ID '{stage_id}') übernehmen."
+            )
+            if allowed:
+                lines.append(f"  Erlaubte Rollen: {', '.join(allowed)}")
+            lines.append(f"  Ohne plan_ref: fallback_agent = {fallback}")
+            lines.append(
+                "  Plan_ref vorhanden, aber Stage-Zeile fehlt: Fehler, kein stiller Fallback."
+            )
+            lines.append("")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: PASS (21/21 so far)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/pipelines.py tests/test_pipelines.py
+git commit -m "feat: add plan-driven stage validation and rendering"
+```
+
+---
+
+### Task 6: Wire real `dod_resolved` into the `agents.py` call site + full regression pass
+
+**Files:**
+- Modify: `scripts/lib/agents.py:1496-1501`
+- Test: existing suite (no new test file — this task closes a latent gap so `dod_flag` actually works end-to-end when agents are generated)
+
+**Interfaces:**
+- Consumes: `resolve_dod(config: dict, agent_meta_root: Path) -> dict` from `scripts/lib/dod.py` (existing function, already used by `scripts/lib/config.py:680`).
+
+**Context:** `sync_agents_for_provider()` in `agents.py` currently calls `inject_pipeline_blocks(content, effective, provider, {})` — the fourth argument (`active_dod`) is hardcoded to an empty dict. Since Task 2 made `active_dod` actually do something (`dod_flag` stage omission), this hardcoded `{}` means every `dod_flag`-conditional stage would render as if all DOD flags were active (because of the `.get(flag, True)` default) regardless of the project's actual DoD preset — silently wrong for any project with `req-traceability`/`tests-required`/`codebase-overview` disabled.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# In tests/test_pipelines.py — this test exercises agents.py, not pipelines.py directly,
+# so it lives alongside the pipeline tests but imports from agents.
+def test_sync_agents_passes_real_dod_resolved_to_inject_pipeline_blocks(monkeypatch):
+    import scripts.lib.agents as agents_mod
+
+    captured = {}
+
+    def _fake_inject(content, pipelines, provider, active_dod):
+        captured["active_dod"] = active_dod
+        return content
+
+    monkeypatch.setattr(agents_mod, "inject_pipeline_blocks", _fake_inject, raising=False)
+    # This test only asserts the call-site wiring, not the full sync pipeline;
+    # if sync_agents_for_provider is not directly unit-testable in isolation,
+    # assert instead via source inspection:
+    import inspect
+
+    source = inspect.getsource(agents_mod.sync_agents_for_provider)
+    assert "inject_pipeline_blocks(content, effective, provider, {})" not in source
+    assert "resolve_dod(" in source
+```
+
+*(Note: this is a source-inspection test rather than a behavioral one — `sync_agents_for_provider` has too many filesystem/config side effects to unit-test cheaply in isolation. The assertion catches the exact regression described above: the hardcoded `{}` silently reappearing.)*
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_pipelines.py::test_sync_agents_passes_real_dod_resolved_to_inject_pipeline_blocks -v`
+Expected: FAIL — `assert "resolve_dod(" in source` fails, `agents.py` doesn't call it yet.
+
+- [ ] **Step 3: Fix the call site**
+
+In `scripts/lib/agents.py`, inside `sync_agents_for_provider()`, change:
+
+```python
+        # Inject provider-specific pipeline blocks before standard substitution
+        pipelines = load_quality_pipelines(str(agent_meta_root))
+        pipeline_overrides = config.get("quality-pipelines", {})
+        effective = apply_overrides(pipelines, pipeline_overrides)
+        if effective:
+            content = inject_pipeline_blocks(content, effective, provider, {})
+```
+
+to:
+
+```python
+        # Inject provider-specific pipeline blocks before standard substitution
+        pipelines = load_quality_pipelines(str(agent_meta_root))
+        pipeline_overrides = config.get("quality-pipelines", {})
+        effective = apply_overrides(pipelines, pipeline_overrides)
+        if effective:
+            from .dod import resolve_dod
+
+            dod_resolved = resolve_dod(config, agent_meta_root)
+            content = inject_pipeline_blocks(content, effective, provider, dod_resolved)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_pipelines.py -v`
+Expected: PASS (22/22)
+
+- [ ] **Step 5: Run the full existing suite to confirm no regression**
+
+Run: `pytest -q`
+Expected: same pass/skip/known-failure counts as the pre-existing baseline, plus the 22 new tests in `tests/test_pipelines.py`. No new failures.
+
+- [ ] **Step 6: Run `sync.py --validate`**
+
+Run: `python scripts/sync.py --validate`
+Expected: PASS — confirms the engine changes don't break generation for the current (unchanged) `role-defaults.yaml` content, since no pipeline in the repo uses the new fields yet (that's Plan 2 onward).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/agents.py tests/test_pipelines.py
+git commit -m "fix: pass real DOD-resolved flags into pipeline block injection"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Entscheidung 1 (run_pipeline: Task 4), Entscheidung 5 (providers: Task 1), Entscheidung 9 (generic handling: satisfied by design — every new field is data-driven, no pipeline-name special-casing anywhere in Tasks 1-5), Entscheidung 11 (dod_flag/payload_flag: Tasks 2-3). Entscheidung 3 (plan-driven): Task 5 covers validation/rendering; the runtime dispatch/error-on-missing-plan-row half of Entscheidung 3 is explicitly the orchestrator's responsibility, out of scope for this engine-only plan (tracked for the plan that touches `orchestrator.md`/`_wf-orchestrator-reference.md`). Entscheidung 2, 4, 6, 7, 8, 10 are out of scope for this plan by design (separate plans).
+- **Placeholder scan:** no TBD/"add error handling"/"similar to Task N" — every step has literal code.
+- **Type consistency:** `_generate_pipeline_block(pipeline, provider, all_pipelines=None, active_dod=None, _depth=0)` is the final signature after Tasks 2 and 4; Task 3 and 5 use it unchanged. `KNOWN_PROVIDERS` and `DEFAULT_MAX_DEPTH` (Task 1) are reused verbatim in Task 4's `_validate_pipeline_composition()` and `_generate_pipeline_block()`. `validate_pipelines(pipelines: dict, available_roles: list) -> list[str]` signature is unchanged throughout — all new checks append to the same `errors` list.
+
+## Next Plan
+
+Once this lands, Plan 2 (`feature.md` → `feature-lifecycle`) can define the actual pipeline using `mode: conditional` with `dod_flag`, `mode: plan-driven`, and rename `standard-feature`. That plan depends on this one; do not start it before this plan's Task 6 is merged.

--- a/docs/superpowers/specs/2026-08-04-pipeline-driven-orchestration-design.md
+++ b/docs/superpowers/specs/2026-08-04-pipeline-driven-orchestration-design.md
@@ -262,6 +262,16 @@ Die bestehende `/pipelines`-Seite (`docs/ui/admin-ui.html`, `/api/pipelines`) ed
 
 PR #398 ist bereits gepusht (nicht gemerged). Diese Spec berührt zwei seiner Kern-Dateien erneut: `planner.md` (Entscheidung 6 vereinfacht den Workflow), `feature.md` (Entscheidung 2 löscht die Datei komplett). Empfehlung: eigener Branch von `feat/planner-agent-and-cluster-cleanup` (nicht von `main`, da `planner.md`/`feature.md` in ihrer PR-#398-Form dort noch nicht existieren) — PR #398 bleibt fokussiert und review-fähig, dieser Umbau landet als eigene, referenzierende PR obendrauf.
 
+## Entscheidung 11: Neue `condition`-Typen `dod_flag` und `payload_flag` (Nachtrag, Interview 2026-08-05)
+
+**Fund während der Planungsphase:** `mode: conditional` unterstützt in `scripts/lib/pipelines.py` bisher nur `condition: {type: agent_decision, agent: ...}` (einzige heutige Verwendung: `config/role-defaults.yaml:1609`, `se-termination`). Entscheidung 2 (`feature-lifecycle`) verwendet aber durchgängig `condition: {dod_flag: req-traceability}` etc., Entscheidung 4 (`concept-to-review`) verwendet `condition: {payload_flag: needs_scoping}` — beide Formen existieren im Code nicht. War weder in der ursprünglichen Spec noch im Audit-Abschnitt erfasst.
+
+**`dod_flag` (Sync-Zeit):** Neuer `condition`-Typ neben `agent_decision`. `validate_pipelines()`/`_generate_pipeline_block()` prüfen zur Sync-Zeit, ob das benannte DOD-Preset-Flag (aus demselben `active_dod`-Dict, das `build_pipeline_variables()` bereits als Parameter erhält) aktiv ist — ist es inaktiv, wird die Stage vollständig aus dem generierten Block weggelassen (nicht nur textuell markiert), analog zum heutigen `{{#if DOD_...}}`-Verhalten in `feature.md`.
+
+**`payload_flag` (Laufzeit):** Anders als `dod_flag` bleibt eine `payload_flag`-Stage im generierten Prompt-Text sichtbar (der Payload-Inhalt ist zur Sync-Zeit nicht bekannt) — der Orchestrator überspringt sie zur Laufzeit, wenn das benannte Flag im Payload fehlt oder `false` ist. Kein Engine-Codepfad nötig, nur eine dokumentierte Konvention im generierten Stage-Text (z.B. `**scope** — Conditional execution (payload_flag: needs_scoping):`).
+
+Beide Typen sind Ergänzung zu Entscheidung 9 ("generisch, datengetrieben, keine Sonderfälle pro Pipeline-Name") — betreffen ausschließlich den bestehenden `conditional`-Modus, keine neuen Stage-Modi.
+
 ## Audit: Cross-Referenz-Prüfung (Ergebnis, geklärt im Interview 2026-08-05)
 
 Nachträgliche Prüfung (2026-08-05) gegen den aktuellen Code-Stand deckte 12 Lücken auf, die die ursprüngliche Migrationstabelle (Entscheidung 2) und die übrigen Entscheidungen nicht abdeckten. Alle 12 sind mittlerweile in die jeweilige Entscheidung eingearbeitet:

--- a/scripts/lib/agents.py
+++ b/scripts/lib/agents.py
@@ -1498,7 +1498,10 @@ def sync_agents_for_provider(
         pipeline_overrides = config.get("quality-pipelines", {})
         effective = apply_overrides(pipelines, pipeline_overrides)
         if effective:
-            content = inject_pipeline_blocks(content, effective, provider, {})
+            from .dod import resolve_dod
+
+            dod_resolved = resolve_dod(config, agent_meta_root)
+            content = inject_pipeline_blocks(content, effective, provider, dod_resolved)
 
         content = substitute(content, merged_vars, rel_source, log)
         # Apply PAL delegation syntax per provider (Issue #277).

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -201,6 +201,21 @@ def validate_pipelines(pipelines: dict, available_roles: list) -> list[str]:
                             f"Add '{sub_agent}' to roles: in .meta-config/project.yaml to enable this pipeline."
                         )
 
+            if mode == "plan-driven":
+                pd = stage.get("plan-driven", {})
+                fallback = pd.get("fallback_agent")
+                if fallback and fallback not in available_roles:
+                    errors.append(
+                        f"Pipeline '{name}': stage '{stage.get('id')}' plan-driven "
+                        f"fallback_agent '{fallback}' not found in available roles."
+                    )
+                for allowed in pd.get("allowed_agents", []):
+                    if allowed not in available_roles:
+                        errors.append(
+                            f"Pipeline '{name}': stage '{stage.get('id')}' plan-driven "
+                            f"allowed_agents entry '{allowed}' not found in available roles."
+                        )
+
             # Circular orchestration guard
             if agent in orchestrator_roles and not stage.get("allow_orchestrator"):
                 errors.append(
@@ -524,6 +539,23 @@ def _generate_pipeline_block(
                 )
                 for sub_line in sub_block.splitlines():
                     lines.append(f"  {sub_line}")
+            lines.append("")
+
+        elif mode == "plan-driven":
+            pd = stage.get("plan-driven", {})
+            fallback = pd.get("fallback_agent", "")
+            allowed = pd.get("allowed_agents", [])
+            lines.append("")
+            lines.append(
+                f"**{stage_id}** — Plan-driven: Agent aus payload.plan_ref "
+                f"(Stage-ID '{stage_id}') übernehmen."
+            )
+            if allowed:
+                lines.append(f"  Erlaubte Rollen: {', '.join(allowed)}")
+            lines.append(f"  Ohne plan_ref: fallback_agent = {fallback}")
+            lines.append(
+                "  Plan_ref vorhanden, aber Stage-Zeile fehlt: Fehler, kein stiller Fallback."
+            )
             lines.append("")
 
     if not lines:

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -139,6 +139,9 @@ def validate_pipelines(pipelines: dict, available_roles: list) -> list[str]:
     - agent exists in available_roles
     - loop.generator / loop.critic exist
     - no circular orchestration (orchestrator agents inside pipelines)
+    - providers field is well-formed (default/include/exclude, known providers)
+    - run_pipeline composition: referenced pipelines exist, no cycles, depth limit
+    - plan-driven stage roles (fallback_agent, allowed_agents) exist
     """
     errors = []
     orchestrator_roles = {"orchestrator", "feature"}
@@ -526,7 +529,11 @@ def _generate_pipeline_block(
             lines.append(f"**{stage_id}** — enthält Pipeline `{ref_name}`:")
             if ref_pipeline is None:
                 lines.append(f"  [nicht aufgelöst — Pipeline '{ref_name}' nicht gefunden]")
-            elif _depth >= _max_depth:
+            elif not _pipeline_active_for_provider(ref_pipeline, provider):
+                lines.append(
+                    f"  [nicht aufgelöst — Pipeline '{ref_name}' für Provider {provider} inaktiv]"
+                )
+            elif _depth + 1 >= _max_depth:
                 lines.append(f"  [nicht aufgelöst — max_depth={_max_depth} erreicht]")
             else:
                 sub_block = _generate_pipeline_block(

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -98,6 +98,40 @@ def apply_overrides(base: dict, overrides: dict) -> dict:
     return result
 
 
+def _validate_pipeline_composition(pipelines: dict, name: str, pipeline: dict) -> list[str]:
+    """Check run_pipeline references for missing targets, cycles, and depth limit."""
+    errors = []
+    max_depth = pipeline.get("max_depth", DEFAULT_MAX_DEPTH)
+
+    def _walk(current_name: str, visited: list[str], depth: int) -> None:
+        if depth > max_depth:
+            errors.append(
+                f"Pipeline '{name}': run_pipeline nesting exceeds max_depth="
+                f"{max_depth} (path: {' -> '.join(visited)})"
+            )
+            return
+        current = pipelines.get(current_name)
+        if current is None:
+            errors.append(
+                f"Pipeline '{name}': referenced pipeline '{current_name}' not found"
+            )
+            return
+        for stage in current.get("stages", []):
+            ref = stage.get("run_pipeline")
+            if not ref:
+                continue
+            if ref in visited:
+                errors.append(
+                    f"Pipeline '{name}': circular run_pipeline reference "
+                    f"({' -> '.join(visited + [ref])})"
+                )
+                continue
+            _walk(ref, visited + [ref], depth + 1)
+
+    _walk(name, [name], 1)
+    return errors
+
+
 def validate_pipelines(pipelines: dict, available_roles: list) -> list[str]:
     """Validate pipelines and return a list of error messages (empty = valid).
 
@@ -126,6 +160,9 @@ def validate_pipelines(pipelines: dict, available_roles: list) -> list[str]:
                             f"Pipeline '{name}': providers.{key} entry '{p}' is not "
                             f"a known provider ({', '.join(KNOWN_PROVIDERS)})"
                         )
+
+        errors.extend(_validate_pipeline_composition(pipelines, name, pipeline))
+
         for stage in stages:
             agent = stage.get("agent")
             if agent and agent not in available_roles:
@@ -367,6 +404,7 @@ def _generate_pipeline_block(
     lines = []
     stages = pipeline.get("stages", [])
     seq_idx = 0
+    max_depth = pipeline.get("max_depth", DEFAULT_MAX_DEPTH)
 
     # Execution mode header (Issue #285)
     exec_mode = _execution_mode_for_pipeline(stages)
@@ -455,6 +493,27 @@ def _generate_pipeline_block(
                     f"  Laufzeit-Skip: Orchestrator überspringt diese Stage, wenn "
                     f"payload.{cond['payload_flag']} fehlt oder false ist."
                 )
+            lines.append("")
+
+        elif mode == "run_pipeline":
+            ref_name = stage.get("run_pipeline", "")
+            ref_pipeline = (all_pipelines or {}).get(ref_name)
+            lines.append("")
+            lines.append(f"**{stage_id}** — enthält Pipeline `{ref_name}`:")
+            if ref_pipeline is None:
+                lines.append(f"  [nicht aufgelöst — Pipeline '{ref_name}' nicht gefunden]")
+            elif _depth >= max_depth:
+                lines.append(f"  [nicht aufgelöst — max_depth={max_depth} erreicht]")
+            else:
+                sub_block = _generate_pipeline_block(
+                    ref_pipeline,
+                    provider,
+                    all_pipelines=all_pipelines,
+                    active_dod=active_dod,
+                    _depth=_depth + 1,
+                )
+                for sub_line in sub_block.splitlines():
+                    lines.append(f"  {sub_line}")
             lines.append("")
 
     if not lines:

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -274,7 +274,7 @@ def build_pipeline_variables(pipelines: dict, active_dod: dict) -> dict:
         for provider in KNOWN_PROVIDERS:
             if _pipeline_active_for_provider(pipeline, provider):
                 provider_blocks[provider] = _generate_pipeline_block(
-                    pipeline, provider, active_dod=active_dod
+                    pipeline, provider, all_pipelines=pipelines, active_dod=active_dod
                 )
             else:
                 provider_blocks[provider] = ""
@@ -297,7 +297,9 @@ def inject_pipeline_blocks(content: str, pipelines: dict, provider: str, active_
             return match.group(0)
         if not _pipeline_active_for_provider(pipeline, provider):
             return ""
-        return _generate_pipeline_block(pipeline, provider, active_dod=active_dod)
+        return _generate_pipeline_block(
+            pipeline, provider, all_pipelines=pipelines, active_dod=active_dod
+        )
 
     return pattern.sub(_replacer, content)
 
@@ -396,6 +398,7 @@ def _generate_pipeline_block(
     all_pipelines: dict | None = None,
     active_dod: dict | None = None,
     _depth: int = 0,
+    _max_depth: int | None = None,
 ) -> str:
     """Generate a provider-specific markdown block for a single pipeline."""
     provider_key = provider.lower()
@@ -404,7 +407,13 @@ def _generate_pipeline_block(
     lines = []
     stages = pipeline.get("stages", [])
     seq_idx = 0
-    max_depth = pipeline.get("max_depth", DEFAULT_MAX_DEPTH)
+    # max_depth is resolved once at the entry point (_depth == 0) from the
+    # root pipeline's own field, then threaded unchanged through recursion —
+    # mirrors _validate_pipeline_composition()'s semantics, so a validated
+    # composition renders consistently instead of being cut off early by a
+    # sub-pipeline's own (possibly lower) default.
+    if _max_depth is None:
+        _max_depth = pipeline.get("max_depth", DEFAULT_MAX_DEPTH)
 
     # Execution mode header (Issue #285)
     exec_mode = _execution_mode_for_pipeline(stages)
@@ -502,8 +511,8 @@ def _generate_pipeline_block(
             lines.append(f"**{stage_id}** — enthält Pipeline `{ref_name}`:")
             if ref_pipeline is None:
                 lines.append(f"  [nicht aufgelöst — Pipeline '{ref_name}' nicht gefunden]")
-            elif _depth >= max_depth:
-                lines.append(f"  [nicht aufgelöst — max_depth={max_depth} erreicht]")
+            elif _depth >= _max_depth:
+                lines.append(f"  [nicht aufgelöst — max_depth={_max_depth} erreicht]")
             else:
                 sub_block = _generate_pipeline_block(
                     ref_pipeline,
@@ -511,6 +520,7 @@ def _generate_pipeline_block(
                     all_pipelines=all_pipelines,
                     active_dod=active_dod,
                     _depth=_depth + 1,
+                    _max_depth=_max_depth,
                 )
                 for sub_line in sub_block.splitlines():
                     lines.append(f"  {sub_line}")

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -4,6 +4,24 @@ import json
 import os
 import re
 
+KNOWN_PROVIDERS = ("Claude", "Opencode", "Gemini", "Continue", "Mammouth")
+DEFAULT_MAX_DEPTH = 4
+
+
+def _pipeline_active_for_provider(pipeline: dict, provider: str) -> bool:
+    """Return whether a pipeline is active for `provider` per its `providers` field.
+
+    No `providers` field means active everywhere (backward compatible with
+    pipelines that predate this field, e.g. quick-fix/bugfix).
+    """
+    providers_cfg = pipeline.get("providers")
+    if not providers_cfg:
+        return True
+    default = providers_cfg.get("default", "active")
+    if default == "active":
+        return provider not in providers_cfg.get("exclude", [])
+    return provider in providers_cfg.get("include", [])
+
 
 def load_quality_pipelines(agent_meta_root: str) -> dict:
     """Load quality_pipelines from config/role-defaults.yaml."""
@@ -93,6 +111,21 @@ def validate_pipelines(pipelines: dict, available_roles: list) -> list[str]:
 
     for name, pipeline in pipelines.items():
         stages = pipeline.get("stages", [])
+        providers_cfg = pipeline.get("providers")
+        if providers_cfg:
+            default = providers_cfg.get("default", "active")
+            if default not in ("active", "inactive"):
+                errors.append(
+                    f"Pipeline '{name}': providers.default must be 'active' or "
+                    f"'inactive', got '{default}'"
+                )
+            for key in ("include", "exclude"):
+                for p in providers_cfg.get(key, []):
+                    if p not in KNOWN_PROVIDERS:
+                        errors.append(
+                            f"Pipeline '{name}': providers.{key} entry '{p}' is not "
+                            f"a known provider ({', '.join(KNOWN_PROVIDERS)})"
+                        )
         for stage in stages:
             agent = stage.get("agent")
             if agent and agent not in available_roles:
@@ -201,10 +234,11 @@ def build_pipeline_variables(pipelines: dict, active_dod: dict) -> dict:
         variables[f"PIPELINE_{var_name}_BLOCK"] = ""
         # Pre-compute provider-specific blocks for later injection
         provider_blocks = {}
-        for provider in ("Claude", "Opencode", "Gemini", "Continue", "Mammouth"):
-            provider_blocks[provider] = _generate_pipeline_block(
-                pipeline, provider
-            )
+        for provider in KNOWN_PROVIDERS:
+            if _pipeline_active_for_provider(pipeline, provider):
+                provider_blocks[provider] = _generate_pipeline_block(pipeline, provider)
+            else:
+                provider_blocks[provider] = ""
         variables[f"PIPELINE_{var_name}_PROVIDER_BLOCKS"] = provider_blocks
     return variables
 
@@ -222,6 +256,8 @@ def inject_pipeline_blocks(content: str, pipelines: dict, provider: str, active_
         pipeline = pipelines.get(name)
         if not pipeline:
             return match.group(0)
+        if not _pipeline_active_for_provider(pipeline, provider):
+            return ""
         return _generate_pipeline_block(pipeline, provider)
 
     return pattern.sub(_replacer, content)

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -450,6 +450,11 @@ def _generate_pipeline_block(
                 lines.append(f"  Decision agent: {cond.get('agent', agent)}")
                 lines.append("  If 'continue': Orchestrator spawns new cell at level n+1 with sanitized context")
                 lines.append("  If 'leaf': Component is final — handover to implementation discipline")
+            elif "payload_flag" in cond:
+                lines.append(
+                    f"  Laufzeit-Skip: Orchestrator überspringt diese Stage, wenn "
+                    f"payload.{cond['payload_flag']} fehlt oder false ist."
+                )
             lines.append("")
 
     if not lines:

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -236,7 +236,9 @@ def build_pipeline_variables(pipelines: dict, active_dod: dict) -> dict:
         provider_blocks = {}
         for provider in KNOWN_PROVIDERS:
             if _pipeline_active_for_provider(pipeline, provider):
-                provider_blocks[provider] = _generate_pipeline_block(pipeline, provider)
+                provider_blocks[provider] = _generate_pipeline_block(
+                    pipeline, provider, active_dod=active_dod
+                )
             else:
                 provider_blocks[provider] = ""
         variables[f"PIPELINE_{var_name}_PROVIDER_BLOCKS"] = provider_blocks
@@ -258,7 +260,7 @@ def inject_pipeline_blocks(content: str, pipelines: dict, provider: str, active_
             return match.group(0)
         if not _pipeline_active_for_provider(pipeline, provider):
             return ""
-        return _generate_pipeline_block(pipeline, provider)
+        return _generate_pipeline_block(pipeline, provider, active_dod=active_dod)
 
     return pattern.sub(_replacer, content)
 
@@ -351,10 +353,17 @@ def _execution_mode_for_pipeline(stages: list) -> str:
     return "sequential"
 
 
-def _generate_pipeline_block(pipeline: dict, provider: str) -> str:
+def _generate_pipeline_block(
+    pipeline: dict,
+    provider: str,
+    all_pipelines: dict | None = None,
+    active_dod: dict | None = None,
+    _depth: int = 0,
+) -> str:
     """Generate a provider-specific markdown block for a single pipeline."""
     provider_key = provider.lower()
     fmt = _PROVIDER_NOTATION.get(provider_key, _PROVIDER_NOTATION["opencode"])
+    active_dod = active_dod or {}
     lines = []
     stages = pipeline.get("stages", [])
     seq_idx = 0
@@ -366,6 +375,10 @@ def _generate_pipeline_block(pipeline: dict, provider: str) -> str:
 
     for stage in stages:
         mode = stage.get("mode", "sequential")
+        if mode == "conditional":
+            cond = stage.get("condition", {})
+            if "dod_flag" in cond and not active_dod.get(cond["dod_flag"], True):
+                continue
         agent = stage.get("agent", "")
         task = stage.get("task", "")
         stage_id = stage.get("id", "")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -116,3 +116,24 @@ def test_generate_pipeline_block_dod_flag_defaults_to_active_when_missing():
     # active_dod does not mention "req-traceability" at all
     block = _generate_pipeline_block(pipeline, "Opencode", active_dod={})
     assert "REQ-ID vergeben" in block
+
+
+def test_generate_pipeline_block_payload_flag_annotation():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "scope",
+                "agent": "ideation",
+                "task": "Idee scopen",
+                "mode": "conditional",
+                "condition": {"payload_flag": "needs_scoping"},
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    # payload_flag stages stay in the text (unlike dod_flag) — orchestrator
+    # decides at runtime whether to skip them.
+    assert "Idee scopen" in block
+    assert "needs_scoping" in block

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -59,3 +59,60 @@ def test_validate_pipelines_rejects_bad_default_value():
     pipelines = {"p1": {"providers": {"default": "sometimes"}, "stages": []}}
     errors = validate_pipelines(pipelines, available_roles=[])
     assert any("providers.default" in e for e in errors)
+
+
+def test_generate_pipeline_block_skips_inactive_dod_flag_stage():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {"id": "always", "agent": "git", "task": "Branch anlegen", "mode": "sequential"},
+            {
+                "id": "req",
+                "agent": "requirements",
+                "task": "REQ-ID vergeben",
+                "mode": "conditional",
+                "condition": {"dod_flag": "req-traceability"},
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode", active_dod={"req-traceability": False})
+    assert "Branch anlegen" in block
+    assert "REQ-ID vergeben" not in block
+
+
+def test_generate_pipeline_block_includes_active_dod_flag_stage():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "req",
+                "agent": "requirements",
+                "task": "REQ-ID vergeben",
+                "mode": "conditional",
+                "condition": {"dod_flag": "req-traceability"},
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode", active_dod={"req-traceability": True})
+    assert "REQ-ID vergeben" in block
+
+
+def test_generate_pipeline_block_dod_flag_defaults_to_active_when_missing():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "req",
+                "agent": "requirements",
+                "task": "REQ-ID vergeben",
+                "mode": "conditional",
+                "condition": {"dod_flag": "req-traceability"},
+            },
+        ]
+    }
+    # active_dod does not mention "req-traceability" at all
+    block = _generate_pipeline_block(pipeline, "Opencode", active_dod={})
+    assert "REQ-ID vergeben" in block

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,0 +1,61 @@
+"""Test suite for quality pipeline configuration management."""
+
+from scripts.lib.pipelines import (
+    KNOWN_PROVIDERS,
+    _pipeline_active_for_provider,
+    build_pipeline_variables,
+    validate_pipelines,
+)
+
+
+def test_known_providers_constant():
+    assert KNOWN_PROVIDERS == ("Claude", "Opencode", "Gemini", "Continue", "Mammouth")
+
+
+def test_pipeline_active_for_provider_no_field_means_everywhere_active():
+    pipeline = {"stages": []}
+    for provider in KNOWN_PROVIDERS:
+        assert _pipeline_active_for_provider(pipeline, provider) is True
+
+
+def test_pipeline_active_for_provider_exclude():
+    pipeline = {"providers": {"default": "active", "exclude": ["Claude"]}}
+    assert _pipeline_active_for_provider(pipeline, "Claude") is False
+    assert _pipeline_active_for_provider(pipeline, "Opencode") is True
+
+
+def test_pipeline_active_for_provider_include_only():
+    pipeline = {"providers": {"default": "inactive", "include": ["Gemini"]}}
+    assert _pipeline_active_for_provider(pipeline, "Gemini") is True
+    assert _pipeline_active_for_provider(pipeline, "Claude") is False
+
+
+def test_build_pipeline_variables_empty_block_for_excluded_provider():
+    pipelines = {
+        "concept-to-review": {
+            "description": "test",
+            "providers": {"default": "active", "exclude": ["Claude"]},
+            "stages": [{"id": "plan", "agent": "planner", "task": "Plan", "mode": "sequential"}],
+        }
+    }
+    variables = build_pipeline_variables(pipelines, {})
+    blocks = variables["PIPELINE_CONCEPT_TO_REVIEW_PROVIDER_BLOCKS"]
+    assert blocks["Claude"] == ""
+    assert blocks["Opencode"] != ""
+
+
+def test_validate_pipelines_rejects_unknown_provider():
+    pipelines = {
+        "p1": {
+            "providers": {"default": "active", "exclude": ["NotAProvider"]},
+            "stages": [],
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("NotAProvider" in e for e in errors)
+
+
+def test_validate_pipelines_rejects_bad_default_value():
+    pipelines = {"p1": {"providers": {"default": "sometimes"}, "stages": []}}
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("providers.default" in e for e in errors)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -267,6 +267,55 @@ def test_generate_pipeline_block_render_cutoff_when_depth_exceeds_max_depth():
     assert "max_depth=2 erreicht" in block
 
 
+def test_generate_pipeline_block_run_pipeline_respects_provider_filter():
+    """Final-review finding F1: run_pipeline recursion must honour the
+    referenced sub-pipeline's own `providers` filter instead of always
+    inlining it regardless of the current provider."""
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipelines = {
+        "outer": {
+            "stages": [{"id": "implement", "run_pipeline": "inner", "mode": "run_pipeline"}]
+        },
+        "inner": {
+            "providers": {"default": "inactive", "include": ["Gemini"]},
+            "stages": [
+                {"id": "step", "agent": "developer", "task": "Feature implementieren", "mode": "sequential"}
+            ],
+        },
+    }
+    block = _generate_pipeline_block(pipelines["outer"], "Claude", all_pipelines=pipelines)
+    assert "Feature implementieren" not in block
+    assert "inaktiv" in block
+    assert "inner" in block
+
+    active_block = _generate_pipeline_block(pipelines["outer"], "Gemini", all_pipelines=pipelines)
+    assert "Feature implementieren" in active_block
+    assert "inaktiv" not in active_block
+
+
+def test_generate_pipeline_block_default_max_depth_cuts_off_five_chain():
+    """Final-review finding F2: with the default max_depth=4, a 5-pipeline
+    chain (root + 4 hops) must be cut off exactly at the last hop — mirroring
+    validate_pipelines(), which rejects this chain as exceeding max_depth."""
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}]},
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": [{"id": "x", "run_pipeline": "e", "mode": "run_pipeline"}]},
+        "e": {
+            "stages": [
+                {"id": "leaf", "agent": "developer", "task": "Leaf-Stage erreicht", "mode": "sequential"}
+            ]
+        },
+    }
+    block = _generate_pipeline_block(pipelines["a"], "Opencode", all_pipelines=pipelines)
+    assert "Leaf-Stage erreicht" not in block
+    assert "max_depth=4 erreicht" in block
+
+
 def test_build_pipeline_variables_resolves_run_pipeline_via_all_pipelines():
     """Integration test proving all_pipelines actually reaches
     _generate_pipeline_block() through build_pipeline_variables() (task-4

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -137,3 +137,81 @@ def test_generate_pipeline_block_payload_flag_annotation():
     # decides at runtime whether to skip them.
     assert "Idee scopen" in block
     assert "needs_scoping" in block
+
+
+def test_validate_pipelines_detects_direct_cycle():
+    from scripts.lib.pipelines import validate_pipelines
+
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}]},
+        "b": {"stages": [{"id": "y", "run_pipeline": "a", "mode": "run_pipeline"}]},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("circular" in e.lower() for e in errors)
+
+
+def test_validate_pipelines_detects_missing_referenced_pipeline():
+    from scripts.lib.pipelines import validate_pipelines
+
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "does-not-exist", "mode": "run_pipeline"}]},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("does-not-exist" in e for e in errors)
+
+
+def test_validate_pipelines_enforces_default_max_depth():
+    from scripts.lib.pipelines import validate_pipelines
+
+    # a -> b -> c -> d -> e is 4 hops; default max_depth is 4, so 5 pipelines
+    # (depth 5 reached) must fail, depth 4 must pass.
+    pipelines = {
+        "a": {"stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}]},
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": [{"id": "x", "run_pipeline": "e", "mode": "run_pipeline"}]},
+        "e": {"stages": []},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("max_depth" in e for e in errors)
+
+
+def test_validate_pipelines_max_depth_override_allows_deeper_nesting():
+    from scripts.lib.pipelines import validate_pipelines
+
+    pipelines = {
+        "a": {
+            "max_depth": 5,
+            "stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}],
+        },
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": [{"id": "x", "run_pipeline": "e", "mode": "run_pipeline"}]},
+        "e": {"stages": []},
+    }
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert errors == []
+
+
+def test_generate_pipeline_block_renders_nested_pipeline_indented():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipelines = {
+        "outer": {
+            "stages": [{"id": "implement", "run_pipeline": "inner", "mode": "run_pipeline"}]
+        },
+        "inner": {
+            "stages": [{"id": "step", "agent": "developer", "task": "Feature implementieren", "mode": "sequential"}]
+        },
+    }
+    block = _generate_pipeline_block(pipelines["outer"], "Opencode", all_pipelines=pipelines)
+    assert "enthält Pipeline `inner`" in block
+    assert "Feature implementieren" in block
+
+
+def test_generate_pipeline_block_run_pipeline_missing_reference_is_marked():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {"stages": [{"id": "implement", "run_pipeline": "ghost", "mode": "run_pipeline"}]}
+    block = _generate_pipeline_block(pipeline, "Opencode", all_pipelines={})
+    assert "nicht aufgelöst" in block

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -215,3 +215,98 @@ def test_generate_pipeline_block_run_pipeline_missing_reference_is_marked():
     pipeline = {"stages": [{"id": "implement", "run_pipeline": "ghost", "mode": "run_pipeline"}]}
     block = _generate_pipeline_block(pipeline, "Opencode", all_pipelines={})
     assert "nicht aufgelöst" in block
+
+
+def test_generate_pipeline_block_cuts_off_at_root_max_depth():
+    """Rendering must honour the ROOT pipeline's max_depth for the whole chain,
+    not re-derive a fresh default at every nesting level (mirrors
+    _validate_pipeline_composition()'s semantics — see task-4 review finding 2).
+    """
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    # a -> b -> c -> d -> e is a 5-hop chain. Root "a" overrides max_depth to 6,
+    # so validate_pipelines() would accept it in full. Intermediate pipelines
+    # deliberately set no max_depth of their own (implicit default 4) to prove
+    # the root override — not a per-level recomputed default — governs rendering.
+    pipelines = {
+        "a": {
+            "max_depth": 6,
+            "stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}],
+        },
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": [{"id": "x", "run_pipeline": "e", "mode": "run_pipeline"}]},
+        "e": {
+            "stages": [
+                {"id": "leaf", "agent": "developer", "task": "Leaf-Stage erreicht", "mode": "sequential"}
+            ]
+        },
+    }
+    block = _generate_pipeline_block(pipelines["a"], "Opencode", all_pipelines=pipelines)
+    # The full chain must resolve (root max_depth=6 covers 5 hops) — no
+    # intermediate level may cut off early using its own default-4.
+    assert "Leaf-Stage erreicht" in block
+    assert "max_depth" not in block
+
+
+def test_generate_pipeline_block_render_cutoff_when_depth_exceeds_max_depth():
+    """Covers the _depth >= _max_depth render branch directly (not just via
+    validate_pipelines' separate walk)."""
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipelines = {
+        "a": {
+            "max_depth": 2,
+            "stages": [{"id": "x", "run_pipeline": "b", "mode": "run_pipeline"}],
+        },
+        "b": {"stages": [{"id": "x", "run_pipeline": "c", "mode": "run_pipeline"}]},
+        "c": {"stages": [{"id": "x", "run_pipeline": "d", "mode": "run_pipeline"}]},
+        "d": {"stages": []},
+    }
+    block = _generate_pipeline_block(pipelines["a"], "Opencode", all_pipelines=pipelines)
+    assert "max_depth=2 erreicht" in block
+
+
+def test_build_pipeline_variables_resolves_run_pipeline_via_all_pipelines():
+    """Integration test proving all_pipelines actually reaches
+    _generate_pipeline_block() through build_pipeline_variables() (task-4
+    review finding 1) — a run_pipeline composition must render the sub-pipeline
+    content, not the "nicht aufgelöst" fallback."""
+    from scripts.lib.pipelines import build_pipeline_variables
+
+    pipelines = {
+        "outer": {
+            "stages": [{"id": "implement", "run_pipeline": "inner", "mode": "run_pipeline"}]
+        },
+        "inner": {
+            "stages": [
+                {"id": "step", "agent": "developer", "task": "Feature implementieren", "mode": "sequential"}
+            ]
+        },
+    }
+    variables = build_pipeline_variables(pipelines, active_dod={})
+    provider_blocks = variables["PIPELINE_OUTER_PROVIDER_BLOCKS"]
+    for provider, block in provider_blocks.items():
+        assert "nicht aufgelöst" not in block, f"provider={provider}"
+        assert "Feature implementieren" in block, f"provider={provider}"
+
+
+def test_inject_pipeline_blocks_resolves_run_pipeline_via_all_pipelines():
+    """Integration test proving all_pipelines reaches _generate_pipeline_block()
+    through inject_pipeline_blocks() as well (task-4 review finding 1)."""
+    from scripts.lib.pipelines import inject_pipeline_blocks
+
+    pipelines = {
+        "outer": {
+            "stages": [{"id": "implement", "run_pipeline": "inner", "mode": "run_pipeline"}]
+        },
+        "inner": {
+            "stages": [
+                {"id": "step", "agent": "developer", "task": "Feature implementieren", "mode": "sequential"}
+            ]
+        },
+    }
+    content = "{{PIPELINE_OUTER_BLOCK}}"
+    result = inject_pipeline_blocks(content, pipelines, "Opencode", active_dod={})
+    assert "nicht aufgelöst" not in result
+    assert "Feature implementieren" in result

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -387,3 +387,23 @@ def test_generate_pipeline_block_plan_driven_rendering():
     assert "Plan-driven" in block
     assert "developer" in block
     assert "kein stiller Fallback" in block
+
+
+def test_sync_agents_passes_real_dod_resolved_to_inject_pipeline_blocks(monkeypatch):
+    import scripts.lib.agents as agents_mod
+
+    captured = {}
+
+    def _fake_inject(content, pipelines, provider, active_dod):
+        captured["active_dod"] = active_dod
+        return content
+
+    monkeypatch.setattr(agents_mod, "inject_pipeline_blocks", _fake_inject, raising=False)
+    # This test only asserts the call-site wiring, not the full sync pipeline;
+    # if sync_agents_for_provider is not directly unit-testable in isolation,
+    # assert instead via source inspection:
+    import inspect
+
+    source = inspect.getsource(agents_mod.sync_agents_for_provider)
+    assert "inject_pipeline_blocks(content, effective, provider, {})" not in source
+    assert "resolve_dod(" in source

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -310,3 +310,80 @@ def test_inject_pipeline_blocks_resolves_run_pipeline_via_all_pipelines():
     result = inject_pipeline_blocks(content, pipelines, "Opencode", active_dod={})
     assert "nicht aufgelöst" not in result
     assert "Feature implementieren" in result
+
+
+def test_validate_pipelines_plan_driven_rejects_unknown_fallback_agent():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {
+                    "id": "implement",
+                    "mode": "plan-driven",
+                    "plan-driven": {"fallback_agent": "ghost-role"},
+                }
+            ]
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=["developer"])
+    assert any("ghost-role" in e for e in errors)
+
+
+def test_validate_pipelines_plan_driven_rejects_unknown_allowed_agent():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {
+                    "id": "implement",
+                    "mode": "plan-driven",
+                    "plan-driven": {
+                        "fallback_agent": "developer",
+                        "allowed_agents": ["developer", "ghost-role"],
+                    },
+                }
+            ]
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=["developer"])
+    assert any("ghost-role" in e for e in errors)
+
+
+def test_validate_pipelines_plan_driven_accepts_known_roles():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {
+                    "id": "implement",
+                    "mode": "plan-driven",
+                    "plan-driven": {
+                        "fallback_agent": "developer",
+                        "allowed_agents": ["junior-developer", "developer", "senior-developer"],
+                    },
+                }
+            ]
+        }
+    }
+    errors = validate_pipelines(
+        pipelines, available_roles=["junior-developer", "developer", "senior-developer"]
+    )
+    assert errors == []
+
+
+def test_generate_pipeline_block_plan_driven_rendering():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "implement",
+                "mode": "plan-driven",
+                "plan-driven": {
+                    "fallback_agent": "developer",
+                    "allowed_agents": ["junior-developer", "developer", "senior-developer"],
+                },
+            }
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    assert "Plan-driven" in block
+    assert "developer" in block
+    assert "kein stiller Fallback" in block


### PR DESCRIPTION
## Summary
- Extends `scripts/lib/pipelines.py` (sync-time text generator for agent prompts) with 5 new stage-engine primitives needed by the pipeline-driven-orchestration spec: `providers` field (per-pipeline provider activation), `dod_flag`/`payload_flag` conditionals, `run_pipeline` composition (with cycle detection and depth limit), and `mode: plan-driven`.
- Fixes a latent bug in `scripts/lib/agents.py` where `inject_pipeline_blocks()` was called with a hardcoded empty `active_dod={}`, which would have silently made `dod_flag` conditionals inert in production.
- First plan in a sequence implementing `docs/superpowers/specs/2026-08-04-pipeline-driven-orchestration-design.md`. No pipeline in `role-defaults.yaml` uses the new fields yet — zero behavior change for existing projects (verified: `sync.py --validate` output is byte-identical before/after).

## Process
- Implemented via Subagent-Driven-Development: 6 tasks, each with a fresh implementer + task review. Task 4 needed one fix round (two real bugs found: `all_pipelines` wasn't threaded to the real call sites, and `max_depth` semantics diverged between validation and rendering).
- Final whole-branch review (opus) found 2 more cross-task issues (provider filter not respected inside `run_pipeline` recursion; depth-limit off-by-one between validate/render) — both fixed in one bundled fix wave, scoped re-review clean.
- One item deliberately NOT fixed here, tracked for the next plan (`feature-lifecycle` migration): a `dod_flag`-conditional stage that survives the sync-time check renders as generic "Conditional execution" text instead of a resolved instruction — currently unreachable (no pipeline uses `dod_flag` yet), will need fixing before/with the next plan.

## Test plan
- [x] `pytest tests/test_pipelines.py -v` — 30/30 passing (new test file, created by this branch)
- [x] Full suite: `pytest -q --ignore=external` — 275 passed, 3 skipped, 1 failed (pre-existing, unrelated — `test_admin_server.py::test_super_admin_only_key_rejected_in_project_mode`, verified untouched by this branch's diff)
- [x] `python scripts/sync.py --validate` — PASS, zero generated-output drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)