### PR TITLE
fix: surface silent pipeline config errors, guard malformed stages (#402, #403)

### DIFF
--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -356,11 +356,13 @@ def read_git_version(agent_meta_root: Path) -> str:
     return "unknown"
 
 
-def _load_se_variable_defaults(agent_meta_root: Path) -> dict:
+def _load_se_variable_defaults(agent_meta_root: Path, warnings: list[str] | None = None) -> dict:
     """Load SE cascade variable defaults from config/role-defaults.yaml se_variables block.
 
     Returns a dict of {TEMPLATE_VAR_NAME: default_value} for variables not set
     in the project config. Template var names are the same as the YAML keys (uppercase).
+    Load errors resolve to an empty dict either way; if `warnings` is passed, the
+    error is also recorded there instead of failing silently (audit #402).
     """
     defaults_path = agent_meta_root / "config" / "role-defaults.yaml"
     if not defaults_path.exists():
@@ -371,7 +373,9 @@ def _load_se_variable_defaults(agent_meta_root: Path) -> dict:
         if not isinstance(se_vars, dict):
             return {}
         return {str(k): v for k, v in se_vars.items()}
-    except Exception:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001
+        if warnings is not None:
+            warnings.append(f"se-variables: {e}")
         return {}
 
 
@@ -594,7 +598,10 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
             _deps = analyze_project(agent_meta_root)
             _analyzer = FileAffinityAnalyzer(agent_meta_root)
             variables["FILE_AFFINITY_HINT"] = _analyzer.format_hint(_deps)
-        except Exception:  # noqa: BLE001
+        except (ImportError, ModuleNotFoundError):
+            variables["FILE_AFFINITY_HINT"] = ""  # optional feature, module not available
+        except Exception as e:  # noqa: BLE001
+            unmapped.append(f"analysis: {e}")
             variables["FILE_AFFINITY_HINT"] = ""
     else:
         variables["FILE_AFFINITY_HINT"] = ""
@@ -618,7 +625,7 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
     se_output = config.get("se_output", {})
     variables["SE_BASE_DIR"] = se_output.get("base_dir", "SE") if isinstance(se_output, dict) else "SE"
     # SE cascade variables — fall back to role-defaults.yaml defaults if not set in project config.
-    _se_vars_defaults = _load_se_variable_defaults(agent_meta_root)
+    _se_vars_defaults = _load_se_variable_defaults(agent_meta_root, unmapped)
     for _sv_key, _sv_val in _se_vars_defaults.items():
         if _sv_key not in variables:
             variables[_sv_key] = str(_sv_val)
@@ -722,8 +729,8 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
                     roles_defaults = _yaml.safe_load(f) or {}
                 if roles_defaults.get("reflection_pairs"):
                     variables["REFLECTION_PAIRS_ENABLED"] = "true"
-        except Exception:  # noqa: BLE001, S110
-            pass
+        except Exception as e:  # noqa: BLE001
+            unmapped.append(f"reflection-pairs (fallback): {e}")
     # QUALITY_PIPELINES_ENABLED: auto-detect from role-defaults.yaml + project overrides
     variables["QUALITY_PIPELINES_ENABLED"] = "false"
     effective = {}
@@ -746,6 +753,14 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
         pipeline_errors = validate_pipelines(effective, list(available_roles))
         for err in pipeline_errors:
             unmapped.append(f"quality-pipelines: {err}")
+        # Drop structurally malformed pipelines (e.g. 'stages' left as a dict
+        # by a stale per-stage override, see audit #402/#403) before they
+        # reach rendering — validate_pipelines() already reported them above,
+        # rendering them would only re-crash the functions it protects.
+        effective = {
+            name: pl for name, pl in effective.items()
+            if isinstance(pl.get("stages", []), list)
+        }
         if effective:
             variables["QUALITY_PIPELINES_ENABLED"] = "true"
         # Build variables for active pipelines; also set BLOCK="" for disabled
@@ -761,8 +776,8 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
                 variables[block_key] = ""
             if enabled_key not in variables:
                 variables[enabled_key] = "false"
-    except Exception:  # noqa: BLE001, S110
-        pass
+    except Exception as e:  # noqa: BLE001
+        unmapped.append(f"quality-pipelines: {e}")
 
     # INTENT_ROUTING_TABLE: role rows plus pipeline signal_keywords rows,
     # using the same `effective` quality-pipelines dict resolved above.

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -116,7 +116,12 @@ def _validate_pipeline_composition(pipelines: dict, name: str, pipeline: dict) -
                 f"Pipeline '{name}': referenced pipeline '{current_name}' not found"
             )
             return
-        for stage in current.get("stages", []):
+        current_stages = current.get("stages", [])
+        if not isinstance(current_stages, list):
+            return  # malformed structure already reported by validate_pipelines()
+        for stage in current_stages:
+            if not isinstance(stage, dict):
+                continue
             ref = stage.get("run_pipeline")
             if not ref:
                 continue
@@ -148,6 +153,13 @@ def validate_pipelines(pipelines: dict, available_roles: list) -> list[str]:
 
     for name, pipeline in pipelines.items():
         stages = pipeline.get("stages", [])
+        if not isinstance(stages, list):
+            errors.append(
+                f"Pipeline '{name}': 'stages' must be a list, got "
+                f"{type(stages).__name__} (check for a malformed override in "
+                f".meta-config/project.yaml)"
+            )
+            continue
         providers_cfg = pipeline.get("providers")
         if providers_cfg:
             default = providers_cfg.get("default", "active")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -61,6 +61,83 @@ def test_validate_pipelines_rejects_bad_default_value():
     assert any("providers.default" in e for e in errors)
 
 
+def test_validate_pipelines_reports_dict_stages_instead_of_crashing():
+    # Regression test for audit #403: a malformed override (e.g. a stale
+    # per-stage override fragment adopted as a whole pipeline by
+    # apply_overrides()) can leave 'stages' as a dict instead of a list.
+    # This must surface as a clean validation error, not an AttributeError.
+    pipelines = {"p1": {"stages": {"review": {"loop": {"max_iterations": 5}}}}}
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("'stages' must be a list" in e and "dict" in e for e in errors)
+
+
+def test_validate_pipelines_reports_string_stages_instead_of_crashing():
+    pipelines = {"p1": {"stages": "not-a-list"}}
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("'stages' must be a list" in e and "str" in e for e in errors)
+
+
+def test_validate_pipelines_malformed_stages_referenced_via_run_pipeline_does_not_crash():
+    # A second pipeline with valid stages that run_pipeline-references the
+    # malformed one must not crash while walking the composition graph.
+    pipelines = {
+        "p1": {"stages": {"review": {"loop": {"max_iterations": 5}}}},
+        "p2": {"stages": [{"id": "x", "agent": "developer", "task": "t",
+                            "mode": "sequential", "run_pipeline": "p1"}]},
+    }
+    errors = validate_pipelines(pipelines, available_roles=["developer"])
+    assert any("'stages' must be a list" in e for e in errors)
+
+
+def test_build_variables_surfaces_malformed_pipeline_override_as_warning():
+    # Regression test for audit #402: a malformed quality-pipelines override
+    # (e.g. targeting a pipeline name that no longer exists after a rename,
+    # exactly what happened in .meta-config/project.yaml before PR #401's
+    # follow-up fix) used to be swallowed by a bare `except Exception: pass`
+    # in build_variables(), leaving PIPELINE_MATCH_TABLE silently unset with
+    # zero indication of why. It must now show up in the warnings list.
+    from pathlib import Path
+
+    from scripts.lib.config import build_variables
+
+    repo_root = Path(__file__).resolve().parents[1]
+    config = {
+        "quality-pipelines": {
+            "overrides": {
+                "this-pipeline-does-not-exist": {
+                    "stages": {"review": {"loop": {"max_iterations": 5}}}
+                }
+            }
+        }
+    }
+    variables, warnings = build_variables(config, repo_root)
+    assert any("quality-pipelines" in w for w in warnings)
+    assert "PIPELINE_MATCH_TABLE" in variables
+
+
+def test_validate_pipelines_all_role_defaults_pipelines_are_clean():
+    # End-to-end guard: every pipeline actually shipped in
+    # config/role-defaults.yaml must validate cleanly against its own
+    # roles. Catches structural drift (e.g. the #402/#403 regression)
+    # without needing one hand-written test per pipeline.
+    from pathlib import Path
+
+    import yaml
+
+    from scripts.lib.pipelines import load_quality_pipelines
+
+    repo_root = Path(__file__).resolve().parents[1]
+    pipelines = load_quality_pipelines(str(repo_root))
+    assert pipelines, "expected at least one pipeline in config/role-defaults.yaml"
+
+    with open(repo_root / "config" / "role-defaults.yaml", encoding="utf-8") as f:
+        roles_cfg = yaml.safe_load(f)
+    all_roles = list(roles_cfg.get("roles", {}).keys())
+
+    errors = validate_pipelines(pipelines, all_roles)
+    assert errors == [], f"Unexpected validation errors: {errors}"
+
+
 def test_generate_pipeline_block_skips_inactive_dod_flag_stage():
     from scripts.lib.pipelines import _generate_pipeline_block
 


### PR DESCRIPTION
## Summary
- Fixes #402: four silent `except Exception: pass` blocks in `build_variables()` now surface errors via the existing `unmapped` warnings list instead of failing invisibly. The quality-pipelines block was already flagged once before in #276 (2026-06-15) with the same fix -- never applied, and it went on to mask the exact regression fixed in PR #401.
- Fixes #403: `validate_pipelines()` and its composition walker now check that `stages` is actually a list before iterating, reporting a clean structural error instead of crashing with an unhandled `AttributeError`. Malformed pipelines are dropped before reaching the render functions that share the same unguarded-iteration shape.
- 5 new regression tests in `tests/test_pipelines.py`.

## Test plan
- [x] `pytest tests/test_pipelines.py -v` -- 36 passed
- [x] `pytest -q --ignore=external` -- 298 passed, 4 pre-existing/branch-unrelated failures (same as baseline)
- [x] `python scripts/sync.py --validate` -- clean (only the known unrelated external-submodule warning)

Closes #402, closes #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em3vfVxQRESDd2za1PcpHe