### PR TITLE
docs: surface known governance-hook limits (#404, #405, #406)

### DIFF
--- a/.claude/rules/a2a-delegation-gates.md
+++ b/.claude/rules/a2a-delegation-gates.md
@@ -8,3 +8,8 @@ alwaysApply: false
 3. No Re-Delegation (payload starts with "Du bist...").
 4. Singleton Orchestrator: NUR der `main_chat` darf den `orchestrator` spawnen.
 5. Execution-Trace-Isolation: Worker-Output muss strukturiert sein (STATUS, RESULT, ARTIFACTS). Keine rohen Logs propagieren.
+
+## Bekannte Grenzen
+
+- **Tiefenlimit (Punkt 1) ist modellbasiert, keine technische Barriere.** Eine passende Implementierung existiert (`validate_envelope(max_depth=...)` in `scripts/lib/delegation_syntax.py`), wird aber im aktiven Delegationspfad nirgends aufgerufen. Die Regel verlässt sich auf Modell-Gehorsam, nicht auf Enforcement.
+- **Singleton-Orchestrator (Punkt 4) wird nur über eine Selbstdeklaration der Agenten-Identität gestützt** (`#agent-meta:agent=<name>` in `.claude/hooks/orchestrator-guard.sh`), die im Hook-Quelltext selbst als "soft, self-reported convention, not a security boundary" dokumentiert ist. Jeder Agent kann sich technisch als privilegiert deklarieren.

--- a/.claude/rules/branch-guard.md
+++ b/.claude/rules/branch-guard.md
@@ -1,3 +1,7 @@
 # Branch-Guard
 
 Verwende Feature-Branches (`feat/`, `fix/`, `chore/`). Keine Code-Änderungen direkt auf `main` oder `master`.
+
+## Bekannte Grenzen
+
+Die technische Durchsetzung (`orchestrator-guard.sh`) erkennt Git-Mutationen über eine Regex-/shlex-basierte Analyse des Bash-Befehls, kein vollständiger Shell-Parser. Bekannte Lücken: `eval "git commit ..."` wird nicht erkannt, direkte Schreibzugriffe auf `.git/` werden nicht geprüft, andere Git-Tools (`hub`, `gh repo ...`) sind nicht erfasst. Bewusster Trade-off, kein Bug (siehe Kommentar in `.claude/hooks/orchestrator-guard.sh:18-30`) — nur relevant für Nutzer, die sich vollständig auf den Schutz statt auf die Konvention verlassen.

--- a/.gemini/rules/a2a-delegation-gates.md
+++ b/.gemini/rules/a2a-delegation-gates.md
@@ -5,3 +5,8 @@
 3. No Re-Delegation (payload starts with "Du bist...").
 4. Singleton Orchestrator: NUR der `main_chat` darf den `orchestrator` spawnen.
 5. Execution-Trace-Isolation: Worker-Output muss strukturiert sein (STATUS, RESULT, ARTIFACTS). Keine rohen Logs propagieren.
+
+## Bekannte Grenzen
+
+- **Tiefenlimit (Punkt 1) ist modellbasiert, keine technische Barriere.** Eine passende Implementierung existiert (`validate_envelope(max_depth=...)` in `scripts/lib/delegation_syntax.py`), wird aber im aktiven Delegationspfad nirgends aufgerufen. Die Regel verlässt sich auf Modell-Gehorsam, nicht auf Enforcement.
+- **Singleton-Orchestrator (Punkt 4) wird nur über eine Selbstdeklaration der Agenten-Identität gestützt** (`#agent-meta:agent=<name>` in `.claude/hooks/orchestrator-guard.sh`), die im Hook-Quelltext selbst als "soft, self-reported convention, not a security boundary" dokumentiert ist. Jeder Agent kann sich technisch als privilegiert deklarieren.

--- a/.gemini/rules/branch-guard.md
+++ b/.gemini/rules/branch-guard.md
@@ -1,3 +1,7 @@
 # Branch-Guard
 
 Verwende Feature-Branches (`feat/`, `fix/`, `chore/`). Keine Code-Änderungen direkt auf `main` oder `master`.
+
+## Bekannte Grenzen
+
+Die technische Durchsetzung (`orchestrator-guard.sh`) erkennt Git-Mutationen über eine Regex-/shlex-basierte Analyse des Bash-Befehls, kein vollständiger Shell-Parser. Bekannte Lücken: `eval "git commit ..."` wird nicht erkannt, direkte Schreibzugriffe auf `.git/` werden nicht geprüft, andere Git-Tools (`hub`, `gh repo ...`) sind nicht erfasst. Bewusster Trade-off, kein Bug (siehe Kommentar in `.claude/hooks/orchestrator-guard.sh:18-30`) — nur relevant für Nutzer, die sich vollständig auf den Schutz statt auf die Konvention verlassen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,10 @@ Kategorien für `docs/REQUIREMENTS.md`:
 
 Verwende Feature-Branches (`feat/`, `fix/`, `chore/`). Keine Code-Änderungen direkt auf `main` oder `master`.
 
+## Bekannte Grenzen
+
+Die technische Durchsetzung (`orchestrator-guard.sh`) erkennt Git-Mutationen über eine Regex-/shlex-basierte Analyse des Bash-Befehls, kein vollständiger Shell-Parser. Bekannte Lücken: `eval "git commit ..."` wird nicht erkannt, direkte Schreibzugriffe auf `.git/` werden nicht geprüft, andere Git-Tools (`hub`, `gh repo ...`) sind nicht erfasst. Bewusster Trade-off, kein Bug (siehe Kommentar in `.claude/hooks/orchestrator-guard.sh:18-30`) — nur relevant für Nutzer, die sich vollständig auf den Schutz statt auf die Konvention verlassen.
+
 
 
 # Commit-Konventionen
@@ -751,6 +755,8 @@ Die Knowledge Engine ist aktiviert. Domäne: **personal**.
 - **Gardening:** `knowledge-gardener` pflegt Links, Tags, Typos, Timestamps
 
 <!-- agent-meta:managed-end -->
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,11 @@ Structured JSON envelopes for Agent-to-Agent communication:
 | Continue | CONTINUE.md | .continue/agents/ | .continue/rules/ | — | .continue/prompts/ | .continue/config.yaml |
 | Copilot | .github/copilot/COPILOT.md | .github/copilot/agents/ | .github/copilot/rules/ | — | — | .github/copilot/copilot.json |
 
+Only Claude and Mammouth generate PreToolUse hooks (`config/ai-providers.yaml: has_hooks`).
+`orchestrator.strict` has no runtime effect on the other providers — it's a config value, not an
+enforced restriction there. `sync.py --validate` warns automatically whenever `orchestrator.strict`
+is active for a provider without hook support.
+
 ## Native Extensions Whitelist
 
 Provider-native extensions (plugins, hooks, skills) require explicit approval gates to run safely.

--- a/rules/1-generic/a2a-delegation-gates.md
+++ b/rules/1-generic/a2a-delegation-gates.md
@@ -5,3 +5,8 @@
 3. No Re-Delegation (payload starts with "Du bist...").
 4. Singleton Orchestrator: NUR der `main_chat` darf den `orchestrator` spawnen.
 5. Execution-Trace-Isolation: Worker-Output muss strukturiert sein (STATUS, RESULT, ARTIFACTS). Keine rohen Logs propagieren.
+
+## Bekannte Grenzen
+
+- **Tiefenlimit (Punkt 1) ist modellbasiert, keine technische Barriere.** Eine passende Implementierung existiert (`validate_envelope(max_depth=...)` in `scripts/lib/delegation_syntax.py`), wird aber im aktiven Delegationspfad nirgends aufgerufen. Die Regel verlässt sich auf Modell-Gehorsam, nicht auf Enforcement.
+- **Singleton-Orchestrator (Punkt 4) wird nur über eine Selbstdeklaration der Agenten-Identität gestützt** (`#agent-meta:agent=<name>` in `.claude/hooks/orchestrator-guard.sh`), die im Hook-Quelltext selbst als "soft, self-reported convention, not a security boundary" dokumentiert ist. Jeder Agent kann sich technisch als privilegiert deklarieren.

--- a/rules/1-generic/branch-guard.md
+++ b/rules/1-generic/branch-guard.md
@@ -1,3 +1,7 @@
 # Branch-Guard
 
 Verwende Feature-Branches (`feat/`, `fix/`, `chore/`). Keine Code-Änderungen direkt auf `main` oder `master`.
+
+## Bekannte Grenzen
+
+Die technische Durchsetzung (`orchestrator-guard.sh`) erkennt Git-Mutationen über eine Regex-/shlex-basierte Analyse des Bash-Befehls, kein vollständiger Shell-Parser. Bekannte Lücken: `eval "git commit ..."` wird nicht erkannt, direkte Schreibzugriffe auf `.git/` werden nicht geprüft, andere Git-Tools (`hub`, `gh repo ...`) sind nicht erfasst. Bewusster Trade-off, kein Bug (siehe Kommentar in `.claude/hooks/orchestrator-guard.sh:18-30`) — nur relevant für Nutzer, die sich vollständig auf den Schutz statt auf die Konvention verlassen.


### PR DESCRIPTION
## Summary
- Fixes #404: `orchestrator-guard.sh`'s soft agent-identity check and its git-mutation regex parser have known, accepted limits that were only documented in the hook's own source comment. Added a "Bekannte Grenzen" section to `a2a-delegation-gates.md` and `branch-guard.md` cross-referencing them, so users relying on the protection actually see the boundaries.
- Fixes #405: documented that the A2A `max_depth`/no-self-handoff rule is model-enforced only (`validate_envelope()` exists but is never called from the active delegation path) rather than leaving that implicit. Technical enforcement is a separate, larger follow-up.
- Fixes #406: confirmed the `orchestrator-strict.no-hook-support` consistency check is already wired into `sync.py --validate` and fires correctly for this project. Added a short note to README's Provider Generation Matrix making the Claude/Mammouth-only hook support explicit.

## Test plan
- [x] `pytest -k "rule or consistency or sync"` -- 23 passed
- [x] `python scripts/sync.py --validate` -- clean except expected findings (the two strict-mode warnings this PR documents, the known external-submodule warning, unrelated #410 schema warnings)
- [x] `python scripts/sync.py` -- regenerated `.claude/rules/`, `.gemini/rules/`, `AGENTS.md` from the updated sources, diff confined to expected files

Closes #404, closes #405, closes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em3vfVxQRESDd2za1PcpHe
