### PR TITLE
fix: write Claude MCP server config to .mcp.json, not settings.json (#388, #400)

### DIFF
--- a/.claude/agents/agent-meta-manager.md
+++ b/.claude/agents/agent-meta-manager.md
@@ -166,7 +166,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.91.3 (2026-08-06)
+**Version info:** v0.91.3 (2026-08-07)
 </context>
 
 <tools>

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,43 +3,6 @@
     "allow": [],
     "deny": []
   },
-  "mcpServers": {
-    "honcho": {
-      "type": "sse",
-      "url": "${MCP_HONCHO_URL}",
-      "headers": {
-        "Authorization": "Bearer ${MCP_HONCHO_API_KEY}",
-        "X-Honcho-User-Name": "${MCP_HONCHO_USER_NAME}",
-        "X-Honcho-Assistant-Name": "${MCP_HONCHO_ASSISTANT_NAME}",
-        "X-Honcho-Workspace-ID": "${MCP_HONCHO_WORKSPACE_ID}"
-      }
-    },
-    "playwright": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "@playwright/mcp@latest"
-      ]
-    },
-    "reqogniloom": {
-      "type": "sse",
-      "url": "${MCP_REQOGNILOOM_URL}/mcp/sse/",
-      "headers": {
-        "Authorization": "Bearer ${MCP_REQOGNILOOM_API_KEY}",
-        "X-Project-ID": "${MCP_REQOGNILOOM_PROJECT_ID}",
-        "X-User-ID": "${MCP_REQOGNILOOM_USER_ID}",
-        "X-Workspace-ID": "${MCP_REQOGNILOOM_WORKSPACE_ID}"
-      }
-    },
-    "viz-logger": {
-      "type": "stdio",
-      "command": "python",
-      "args": [
-        "scripts/viz-logger.py",
-        "--mcp"
-      ]
-    }
-  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.gemini/agents/agent-meta-manager.md
+++ b/.gemini/agents/agent-meta-manager.md
@@ -166,7 +166,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.91.3 (2026-08-06)
+**Version info:** v0.91.3 (2026-08-07)
 </context>
 
 <tools>

--- a/.opencode/agents/agent-meta-manager.md
+++ b/.opencode/agents/agent-meta-manager.md
@@ -164,7 +164,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.91.3 (2026-08-06)
+**Version info:** v0.91.3 (2026-08-07)
 </context>
 
 <tools>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -829,6 +829,16 @@ Die Knowledge Engine ist aktiviert. Domäne: **personal**.
 
 
 
+
+
+
+
+
+
+
+
+
+
 ## Eigene Notizen
 
 Hier kannst du eigene, projektspezifische Notizen eintragen. Dieser Bereich wird von `agent-meta` nicht überschrieben!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Kategorien für `docs/REQUIREMENTS.md`:
 
 > **AI ROUTING:** Claude -> CLAUDE.md | Opencode, Gemini -> AGENTS.md
 
-Generiert von agent-meta v0.91.3 — `2026-08-06`
+Generiert von agent-meta v0.91.3 — `2026-08-07`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 > **Einstiegspunkt:** Du bist im `main-chat` Modus. Du agierst direkt als Router und Worker (siehe `use-orchestrator.md`).
 

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -37,8 +37,19 @@ providers:
       - sync.log
       - .mcp.json
     mcp-config:
-      committed-file: .claude/settings.json
-      secrets-file: .claude/settings.local.json
+      # Claude Code does NOT read a top-level `mcpServers` key from
+      # settings.json/settings.local.json for MCP server registration — only
+      # from .mcp.json at the project root (or `claude mcp add --scope
+      # project`). Writing here previously produced a fully inert,
+      # silently-broken integration (audit #388, #400). Both entries point
+      # at the same already-gitignored .mcp.json (see gitignore_entries
+      # above): committed-file writes ${VAR}-placeholder entries first (safe
+      # even if this file were ever committed), then secrets-file overwrites
+      # the same mcpServers key with fully resolved values when
+      # secrets.local.yaml exists — matching .mcp.json's own native ${VAR}
+      # expansion as the fallback when it doesn't.
+      committed-file: .mcp.json
+      secrets-file: .mcp.json
       format: claude-settings
     # Provider-specific directories for multi-provider orchestration
     skills_dir: .claude/skills

--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -994,7 +994,7 @@ Die Auflösungslogik ist identisch mit der in `scripts/lib/agents.py` (`_compose
 **Hauptfunktionen:**
 - `load_mcp_registry()`: Lädt und mergt globale und projektspezifische MCP-Registries.
 - `resolve_active_mcp_servers()`: Bestimmt aktive Server (explizit aus `project.yaml` und implizit über Provider-Defaults).
-- `generate_mcp_artifacts()`: Generiert Markdown-Regeldateien (`mcp-<server>.md`) pro Provider und fügt Provider-Konfigurationen (wie `mcpServers` in `settings.json`) ein.
+- `generate_mcp_artifacts()`: Generiert Markdown-Regeldateien (`mcp-<server>.md`) pro Provider und fügt Provider-Konfigurationen (`mcpServers` in `.mcp.json` für Claude, providerspezifisch für andere) ein.
 - `sync_secrets_template()`: Erstellt bzw. ergänzt bei jedem Sync-Lauf die lokale, gitignorierte `.meta-config/secrets.local.yaml` um die Secret-Keys aller aktiven MCP-Server (z.B. API-Keys) — neu aktivierte Server bekommen ihre fehlenden Keys automatisch angehängt, bestehende Werte bleiben unangetastet.
 
 **Integrierte MCP-Server (Registry):**

--- a/scripts/lib/mcp.py
+++ b/scripts/lib/mcp.py
@@ -293,14 +293,20 @@ def _update_json_config(
 
     existing: dict = {}
     if path.exists():
-        parsed = _read_json_lenient(path)
-        if parsed is None:
-            log.warning(
-                f"mcp: could not parse '{rel}' as JSON/JSONC — "
-                "MCP config not injected. Add mcpServers manually."
-            )
-            return
-        existing = parsed
+        if path.stat().st_size == 0:
+            # A zero-byte file is invalid JSON but not a real conflict —
+            # self-heal to {} instead of silently skipping the injection
+            # (audit #400, Secondary Finding A).
+            existing = {}
+        else:
+            parsed = _read_json_lenient(path)
+            if parsed is None:
+                log.warning(
+                    f"mcp: could not parse '{rel}' as JSON/JSONC — "
+                    "MCP config not injected. Add mcpServers manually."
+                )
+                return
+            existing = parsed
 
     # Bereinigung der Legacy-Keys wurde auf Wunsch des Users entfernt,
     # um manuelle Einträge in den Config-Dateien zu erhalten.
@@ -396,6 +402,38 @@ def _update_continue_yaml_config(
 # Provider config generation — main entry point
 # ---------------------------------------------------------------------------
 
+def _warn_stale_mcp_servers_key(
+    project_root: Path,
+    provider_cfg: dict,
+    committed_file: str,
+    secrets_file: str | None,
+    log: SyncLog,
+) -> None:
+    """Warn once if a leftover mcpServers key sits in a file no longer targeted.
+
+    Migration aid for #388/#400: projects synced before Claude's mcp-config
+    moved to .mcp.json can have an inert `mcpServers` block still sitting in
+    settings.json/settings.local.json. sync.py deliberately never strips
+    unrelated keys from those files (manual entries must survive a sync), so
+    this leftover has to be pointed out instead of silently cleaned up.
+    """
+    current_targets = {committed_file, secrets_file}
+    for key in ("settings_file", "settings_local_file"):
+        stale_rel = provider_cfg.get(key)
+        if not stale_rel or stale_rel in current_targets:
+            continue
+        stale_path = safe_path(project_root, stale_rel)
+        if not stale_path.exists():
+            continue
+        parsed = _read_json_lenient(stale_path)
+        if isinstance(parsed, dict) and "mcpServers" in parsed:
+            log.warning(
+                f"mcp: '{stale_rel}' still has a leftover 'mcpServers' key from "
+                f"before MCP config moved to '{committed_file}' — it has no "
+                "effect there and can be removed manually."
+            )
+
+
 def generate_provider_configs(
     agent_meta_root: Path,
     project_root: Path,
@@ -434,6 +472,8 @@ def generate_provider_configs(
 
     if not fmt or not committed_file:
         return
+
+    _warn_stale_mcp_servers_key(project_root, pc, committed_file, secrets_file, log)
 
     # Load secrets.local.yaml if present
     secrets_path = project_root / SECRETS_LOCAL_FILE

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,0 +1,150 @@
+"""Regression tests for MCP provider config generation (scripts/lib/mcp.py).
+
+Covers audit findings #388/#400: Claude Code does not read a top-level
+`mcpServers` key from settings.json/settings.local.json — only from
+.mcp.json at the project root. Writing there previously produced a fully
+inert, silently-broken MCP integration.
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.lib.log import SyncLog
+from scripts.lib.mcp import _update_json_config, generate_provider_configs
+from scripts.lib.providers import load_providers_config
+
+
+def test_claude_mcp_config_targets_mcp_json_not_settings():
+    # Regression test for #388/#400: the real config/ai-providers.yaml must
+    # point Claude's mcp-config at .mcp.json, not at settings.json/
+    # settings.local.json (which Claude Code never reads mcpServers from).
+    repo_root = Path(__file__).resolve().parents[1]
+    provider_config = load_providers_config(repo_root)
+    mcp_cfg = provider_config["Claude"]["mcp-config"]
+    assert mcp_cfg["committed-file"] == ".mcp.json"
+    assert mcp_cfg["secrets-file"] == ".mcp.json"
+    assert ".mcp.json" in provider_config["Claude"]["gitignore_entries"]
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_generate_provider_configs_writes_resolved_secrets_to_mcp_json(tmp_path):
+    agent_meta_root = tmp_path / "agent-meta"
+    project_root = tmp_path / "project"
+
+    _write(
+        agent_meta_root / "config" / "mcp-registry.yaml",
+        yaml.dump({
+            "mcp-servers": {
+                "example-server": {
+                    "description": "test server",
+                    "connection": {
+                        "type": "sse",
+                        "url": "{{EXAMPLE_URL}}",
+                        "headers": {"Authorization": "Bearer {{EXAMPLE_TOKEN}}"},
+                    },
+                }
+            }
+        }),
+    )
+    _write(
+        project_root / ".meta-config" / "secrets.local.yaml",
+        yaml.dump({"EXAMPLE_URL": "https://real.example.com", "EXAMPLE_TOKEN": "sk-real-secret"}),
+    )
+
+    config = {"mcp-servers": ["example-server"], "platforms": []}
+    provider_config = {
+        "Claude": {
+            "mcp-config": {
+                "committed-file": ".mcp.json",
+                "secrets-file": ".mcp.json",
+                "format": "claude-settings",
+            }
+        }
+    }
+    log = SyncLog()
+
+    generate_provider_configs(
+        agent_meta_root, project_root, config, provider_config, log,
+        dry_run=False, provider="Claude",
+    )
+
+    mcp_json_path = project_root / ".mcp.json"
+    assert mcp_json_path.exists()
+    written = json.loads(mcp_json_path.read_text(encoding="utf-8"))
+    assert "example-server" in written["mcpServers"]
+    entry = written["mcpServers"]["example-server"]
+    # Real, resolved secret values — not the {{VAR}}/${VAR} placeholder form.
+    assert entry["url"] == "https://real.example.com"
+    assert entry["headers"]["Authorization"] == "Bearer sk-real-secret"
+
+    # Must NOT have leaked mcpServers into settings.json/settings.local.json —
+    # those files should not even exist, since nothing else in this test
+    # writes them and generate_provider_configs() only touches the
+    # configured committed-file/secrets-file paths.
+    assert not (project_root / ".claude" / "settings.json").exists()
+    assert not (project_root / ".claude" / "settings.local.json").exists()
+
+
+def test_update_json_config_self_heals_empty_file(tmp_path):
+    # Regression test for #400 Secondary Finding A: a zero-byte existing
+    # file must not be treated as an unparseable conflict that silently
+    # skips MCP injection.
+    path = tmp_path / ".mcp.json"
+    path.write_text("", encoding="utf-8")
+    log = SyncLog()
+
+    _update_json_config(path, "mcpServers", {"foo": {"type": "sse", "url": "https://x"}}, log, dry_run=False, allow_secrets=True)
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written["mcpServers"]["foo"]["url"] == "https://x"
+
+
+def test_generate_provider_configs_warns_about_leftover_mcp_servers_key(tmp_path):
+    # Migration aid for #388/#400: a project synced before the .mcp.json fix
+    # can have an inert mcpServers block left over in settings.local.json.
+    # sync.py must call this out instead of leaving it silently stale.
+    agent_meta_root = tmp_path / "agent-meta"
+    project_root = tmp_path / "project"
+
+    _write(
+        agent_meta_root / "config" / "mcp-registry.yaml",
+        yaml.dump({
+            "mcp-servers": {
+                "example-server": {
+                    "connection": {"type": "sse", "url": "{{EXAMPLE_URL}}"},
+                }
+            }
+        }),
+    )
+    # Simulate the pre-fix leftover in the old target file.
+    _write(
+        project_root / ".claude" / "settings.local.json",
+        json.dumps({"mcpServers": {"example-server": {"type": "sse", "url": "${EXAMPLE_URL}"}}}),
+    )
+
+    config = {"mcp-servers": ["example-server"], "platforms": []}
+    provider_config = {
+        "Claude": {
+            "settings_file": ".claude/settings.json",
+            "settings_local_file": ".claude/settings.local.json",
+            "mcp-config": {
+                "committed-file": ".mcp.json",
+                "secrets-file": ".mcp.json",
+                "format": "claude-settings",
+            },
+        }
+    }
+    log = SyncLog()
+
+    generate_provider_configs(
+        agent_meta_root, project_root, config, provider_config, log,
+        dry_run=False, provider="Claude",
+    )
+
+    assert any("leftover 'mcpServers'" in w for w in log.warnings)


### PR DESCRIPTION
## Summary
- Fixes #388, #400: Claude Code does not read a top-level `mcpServers` key from settings.json/settings.local.json — only from `.mcp.json` at the project root. `config/ai-providers.yaml`'s Claude `mcp-config` pointed at the wrong files, producing a fully inert, silently-broken MCP integration for every agent-meta-generated Claude project. Both `committed-file` and `secrets-file` now point at `.mcp.json` (already in Claude's `gitignore_entries`, unused until now).
- Secondary fix: a zero-byte existing settings/mcp file was treated as unparseable and silently skipped the whole injection. Now self-heals to `{}`.
- Migration aid: added a one-time warning when a leftover `mcpServers` key is found in the old settings.json/settings.local.json location, since sync.py deliberately never auto-strips unrelated keys from those files. Cleaned up agent-meta's own leftover copies as part of this fix.

## Test plan
- [x] 4 new tests in `tests/test_mcp_config.py` — config points at `.mcp.json`, resolved secrets land there end-to-end, leftover-key warning fires, zero-byte file self-heals
- [x] `pytest -q --ignore=external` -- 304 passed (4 pre-existing/branch-unrelated failures, same as baseline)
- [x] `python scripts/sync.py` / `--validate` -- clean, 0 warnings after cleanup

Closes #388, closes #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em3vfVxQRESDd2za1PcpHe
