### PR TITLE
fix: follow-up audit fixes (#428, #429, #430)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -845,6 +845,8 @@ Die Knowledge Engine ist aktiviert. Domäne: **personal**.
 
 
 
+
+
 ## Eigene Notizen
 
 Hier kannst du eigene, projektspezifische Notizen eintragen. Dieser Bereich wird von `agent-meta` nicht überschrieben!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 >    - **Automated Default Init:** `python .agent-meta/scripts/sync.py --init`
 > 3. **Re-Sync After Config Changes:** Re-run `python .agent-meta/scripts/sync.py` whenever `.meta-config/project.yaml` is modified.
 
-[![Version](https://img.shields.io/badge/version-0.91.2-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-0.92.0-blue.svg)]()
 [![Python](https://img.shields.io/badge/python-3.x-green.svg)]()
 [![License](https://img.shields.io/badge/license-MIT-gray.svg)]()
 | **Date:** 2026-08-01
@@ -66,7 +66,7 @@ graph TD
 ```bash
 # Add as submodule
 git submodule add https://github.com/Popoboxxo/agent-meta .agent-meta
-cd .agent-meta && git checkout v0.91.2 && cd ..
+cd .agent-meta && git checkout v0.92.0 && cd ..
 
 # Install dependencies
 pip install -r .agent-meta/requirements.txt

--- a/config/ai-providers.yaml
+++ b/config/ai-providers.yaml
@@ -159,6 +159,7 @@ providers:
       - AGENTS.personal.md
       - .opencode/settings.local.json
       - .opencode/pending-tasks.md
+      - .opencode/mcp.local.json
     mcp-config:
       committed-file: opencode.json
       secrets-file: .opencode/mcp.local.json
@@ -210,7 +211,7 @@ providers:
     isolation-dirs:
       - .continue/
     gitignore_entries:
-      - .continue/settings.local.yaml
+      - .continue/config.local.yaml
       - .continue/pending-tasks.md
     mcp-config:
       committed-file: .continue/config.yaml

--- a/scripts/admin-server.py
+++ b/scripts/admin-server.py
@@ -572,9 +572,16 @@ class ConfigManager:
         (``_build_agent_hierarchy``, ``_find_schema_path``). Otherwise the
         primary path is returned (the file may not exist yet).
 
+        Deliberately mode-agnostic: ``_allowed_keys()`` always returns both
+        ``PROJECT_FILES`` and ``SUPER_ADMIN_FILES`` so project_admin mode can
+        still *view* framework defaults (e.g. ``role-defaults``). The write
+        boundary for project_admin mode is enforced in :py:meth:`write`, not
+        here -- resolving a path is not the same as being allowed to write it.
+
         Raises:
-            SecurityError: if ``key`` is unknown, restricted for the current
-                mode, or would escape ``root`` (path traversal protection).
+            SecurityError: if ``key`` is unknown, or the resolved path would
+                escape ``root`` (path traversal protection). Does NOT raise
+                for mode restrictions -- see :py:meth:`write`.
         """
         if not isinstance(key, str) or not key:
             raise SecurityError("invalid config key")

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -124,11 +124,26 @@ class TestWritePathWhitelist(unittest.TestCase):
             with self.assertRaises(admin_server.SecurityError):
                 mgr.write("definitely-not-allowed", {"x": 1})
 
-    def test_super_admin_only_key_rejected_in_project_mode(self) -> None:
+    def test_super_admin_only_key_readable_in_project_mode(self) -> None:
+        # resolve_path() (and by extension read()) is deliberately
+        # mode-agnostic -- project_admin mode must still be able to *view*
+        # framework defaults like role-defaults.yaml. The actual write
+        # boundary is enforced in write(), tested below. This test used to
+        # assert the opposite (a stale expectation that predates that design
+        # decision) and had been failing for weeks without anyone checking
+        # whether it pointed at a real vulnerability -- it didn't; write()
+        # already rejects this key in project_admin mode (audit follow-up,
+        # 2026-08-07).
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr = admin_server.ConfigManager(Path(tmp), mode="project_admin")
+            path = mgr.resolve_path("role-defaults")
+            self.assertTrue(str(path).endswith("role-defaults.yaml"))
+
+    def test_super_admin_only_key_rejected_on_write_in_project_mode(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             mgr = admin_server.ConfigManager(Path(tmp), mode="project_admin")
             with self.assertRaises(admin_server.SecurityError):
-                mgr.resolve_path("role-defaults")
+                mgr.write("role-defaults", {"roles": {}})
 
     def test_super_admin_key_allowed_in_super_admin_mode(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -28,6 +28,30 @@ def test_claude_mcp_config_targets_mcp_json_not_settings():
     assert ".mcp.json" in provider_config["Claude"]["gitignore_entries"]
 
 
+def test_every_provider_secrets_file_is_gitignored():
+    # Regression test found live in a follow-up system audit (2026-08-07):
+    # Continue's mcp-config.secrets-file was `.continue/config.local.yaml`,
+    # but gitignore_entries listed `.continue/settings.local.yaml` -- a
+    # filename that matched nothing, so the real secrets file was never
+    # gitignored. Opencode had the same class of gap: its secrets-file
+    # (`.opencode/mcp.local.json`) is a *third*, distinct path from
+    # settings_local_file and was missing from gitignore_entries entirely.
+    # Both are the same severity as #388/#400 (secrets ending up somewhere
+    # unprotected) -- generalized here so it can't silently regress again
+    # for any provider, present or future.
+    repo_root = Path(__file__).resolve().parents[1]
+    provider_config = load_providers_config(repo_root)
+    missing = []
+    for name, pc in provider_config.items():
+        secrets_file = pc.get("mcp-config", {}).get("secrets-file")
+        settings_local = pc.get("settings_local_file")
+        entries = set(pc.get("gitignore_entries", []))
+        for path in (secrets_file, settings_local):
+            if path and path not in entries:
+                missing.append(f"{name}: {path!r} not in gitignore_entries")
+    assert not missing, "\n".join(missing)
+
+
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")


### PR DESCRIPTION
Second audit round after v0.92.0. One real MCP-secrets-gitignore gap (severity like #388/#400), one stale test that turned out to mask no real vulnerability (verified), one README version drift. See commit message for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em3vfVxQRESDd2za1PcpHe