### PR TITLE
fix: dict-editor key rename silently corrupts data on collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Admin UI: the MCP server Env-Vars/Headers dict-editor and the Provider-Options KV editor silently corrupted data when a key was renamed to collide with an existing key in the same dict (one row would vanish, another's value silently overwritten) — both editors now reject the rename with a toast and revert the input. The dict-editor also silently dropped a row when its key field was cleared entirely; that's rejected the same way now (#432).
+
 ## [0.92.0] — 2026-08-07
 
 ### Added

--- a/docs/ui/admin-ui.html
+++ b/docs/ui/admin-ui.html
@@ -2268,19 +2268,29 @@ async function viewProjectMcpOverrides() {
               const inpV = el("input", { class: "form-control", value: v, style: "flex: 2;", placeholder: "Value" });
               const btnDel = el("button", { class: "btn btn-danger btn-sm" }, ["×"]);
               
-              inpK.onchange = (e) => { 
-                  // Preserve key order: rebuild object with renamed key in same position
+              inpK.onchange = (e) => {
                   const newKey = e.target.value;
+                  if (!newKey) {
+                      toast("Key cannot be empty.", "error");
+                      inpK.value = k;
+                      return;
+                  }
+                  if (newKey !== k && Object.prototype.hasOwnProperty.call(dictData, newKey)) {
+                      toast(`Key "${newKey}" already exists.`, "error");
+                      inpK.value = k;
+                      return;
+                  }
+                  // Preserve key order: rebuild object with renamed key in same position
                   const entries = Object.entries(dictData);
                   const idx = entries.findIndex(([ek]) => ek === k);
                   // Clear all keys
                   for (const dk of Object.keys(dictData)) delete dictData[dk];
                   // Re-insert with renamed key at same position
                   entries.forEach(([ek, ev], i) => {
-                      if (i === idx) { if (newKey) dictData[newKey] = inpV.value; }
+                      if (i === idx) { dictData[newKey] = inpV.value; }
                       else { dictData[ek] = ev; }
                   });
-                  onChange(); renderRows(); 
+                  onChange(); renderRows();
               };
               inpV.oninput = (e) => { dictData[inpK.value] = e.target.value; onChange(); };
               btnDel.onclick = () => { delete dictData[k]; onChange(); renderRows(); };
@@ -5694,6 +5704,11 @@ async function viewProjectProviders() {
       let lastKey = key;
       function sync() {
         const k = keyInput.value.trim();
+        if (k !== lastKey && Object.prototype.hasOwnProperty.call(provOpts, k)) {
+          toast(`Key "${k}" already exists.`, "error");
+          keyInput.value = lastKey;
+          return;
+        }
         if (k !== lastKey && lastKey) {
           delete provOpts[lastKey];
         }

--- a/tests/browser/test_dict_editor_rename_collision.py
+++ b/tests/browser/test_dict_editor_rename_collision.py
@@ -1,0 +1,115 @@
+"""Regression test: the generic dict-editor (MCP server Env/Headers overrides
+in Project -> MCP Servers) must reject renaming a key to one that already
+exists in the same dict, instead of silently overwriting/losing the colliding
+entry's value.
+"""
+
+import pytest
+pytest.importorskip('playwright')
+from playwright.sync_api import expect
+
+
+def _row_values(rows):
+    return [
+        [row.locator("input").nth(0).input_value(), row.locator("input").nth(1).input_value()]
+        for row in rows.all()
+    ]
+
+
+def test_header_rename_to_existing_key_is_rejected(browser_ctx):
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/project/mcp-overrides")
+        page.wait_for_load_state("networkidle")
+
+        panel = page.locator(".panel").filter(has=page.get_by_role("heading", name="honcho", exact=True))
+        panel.get_by_role("button", name="Customize", exact=False).click()
+
+        rows = panel.get_by_text("Headers", exact=True).locator("xpath=following-sibling::div[1]/div")
+        expect(rows).to_have_count(4, timeout=3000)
+        before = _row_values(rows)
+
+        target_row = next(
+            r for r in rows.all()
+            if r.locator("input").nth(0).input_value() == "X-Honcho-User-Name"
+        )
+        key_input = target_row.locator("input").nth(0)
+        key_input.fill("Authorization")
+        key_input.dispatch_event("change")
+        page.wait_for_timeout(300)
+
+        after = _row_values(rows)
+        assert after == before, (
+            "Renaming a header key to a key that already exists must be rejected, "
+            f"not silently corrupt data. before={before} after={after}"
+        )
+        assert key_input.input_value() == "X-Honcho-User-Name", "rejected rename must revert the input"
+
+        error_toast = page.locator(".toast-error")
+        expect(error_toast).to_be_visible(timeout=1000)
+        assert "already exists" in (error_toast.text_content() or "")
+    finally:
+        page.close()
+
+
+def test_header_rename_to_empty_key_is_rejected(browser_ctx):
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/project/mcp-overrides")
+        page.wait_for_load_state("networkidle")
+
+        panel = page.locator(".panel").filter(has=page.get_by_role("heading", name="honcho", exact=True))
+        panel.get_by_role("button", name="Customize", exact=False).click()
+
+        rows = panel.get_by_text("Headers", exact=True).locator("xpath=following-sibling::div[1]/div")
+        expect(rows).to_have_count(4, timeout=3000)
+        before = _row_values(rows)
+
+        target_row = next(
+            r for r in rows.all()
+            if r.locator("input").nth(0).input_value() == "X-Honcho-User-Name"
+        )
+        key_input = target_row.locator("input").nth(0)
+        key_input.fill("")
+        key_input.dispatch_event("change")
+        page.wait_for_timeout(300)
+
+        after = _row_values(rows)
+        assert after == before, (
+            "Clearing a header's key field must be rejected (use the delete button "
+            f"instead), not silently drop the row. before={before} after={after}"
+        )
+    finally:
+        page.close()
+
+
+def test_provider_option_rename_to_existing_key_is_rejected(browser_ctx):
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/project/providers")
+        page.wait_for_load_state("networkidle")
+
+        table = page.locator("table").filter(has=page.locator('input[placeholder="key"]')).first
+        rows = table.locator("tr").filter(has=page.locator('input[placeholder="key"]'))
+        keys_before = [rows.nth(i).locator('input[placeholder="key"]').input_value() for i in range(rows.count())]
+        assert len(keys_before) >= 2, "expected at least 2 provider-option rows to test a collision"
+
+        target_index = next(i for i, k in enumerate(keys_before) if k != keys_before[0])
+        key_input = rows.nth(target_index).locator('input[placeholder="key"]')
+        key_input.fill(keys_before[0])
+        key_input.dispatch_event("change")
+        page.wait_for_timeout(300)
+
+        keys_after = [rows.nth(i).locator('input[placeholder="key"]').input_value() for i in range(rows.count())]
+        assert keys_after == keys_before, (
+            "Renaming a provider-option key to a key that already exists must be "
+            f"rejected. before={keys_before} after={keys_after}"
+        )
+
+        error_toast = page.locator(".toast-error")
+        expect(error_toast).to_be_visible(timeout=1000)
+    finally:
+        page.close()


### PR DESCRIPTION
## Summary
- Fixes #432: the MCP server Env/Headers dict-editor and the Provider-Options KV editor both silently corrupted data when a key was renamed to collide with an existing key in the same dict (one row vanished, another's value was silently overwritten).
- The dict-editor also silently dropped a row when its key field was cleared entirely.
- Both handlers now reject the rename (toast + revert input) instead of corrupting/dropping data.

## Verification
- Live-reproduced the bug in a running admin-server via real browser interaction before the fix, confirmed the fix rejects both cases (collision + empty key) with the exact same live setup.
- New Playwright test `tests/browser/test_dict_editor_rename_collision.py` (3 tests) — confirmed red without the fix (`git stash`), green with it.
- Full regression: `pytest -q --ignore=external` → 313 passed, same 3 known pre-existing/unrelated browser-test failures (`test_models_page.py`, curated-badge tests) as baseline.
- `sync.py --validate` clean (only the known, unrelated external-submodule warning in `agent-meta-test`).
- No config files were touched during live testing (`git diff --stat .meta-config/project.yaml` empty).

## Test plan
- [x] Reproduce bug live, pre-fix
- [x] Confirm fix live, post-fix
- [x] New regression tests pass with fix, fail without it
- [x] Full pytest suite: no new failures
- [x] sync.py --validate clean