### PR TITLE
fix: optional *_SNIPPETS_PATH / DEV_STACK_START placeholders leak without guard

### DIFF
--- a/.claude/agents/data-engineer.md
+++ b/.claude/agents/data-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: data-engineer
-version: 0.1.0
+version: 0.1.1
 description: ETL/ELT pipeline design, data-layer schema migration, data quality checks,
   lineage analysis, pipeline monitoring and streaming/batch design. Produces pipeline
   specs, data quality reports, lineage diagrams and migration scripts. Distinct from
@@ -16,7 +16,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/data-engineer.md@0.1.0
+generated-from: 1-generic/data-engineer.md@0.1.1
 model: claude-sonnet-5
 memory: project
 ---
@@ -38,7 +38,7 @@ You are the **Data Engineer** for agent-meta. You design and operate **data pipe
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`.
 
 2. **REQ check:** 
-3. **Read context:** `.claude/3-project/am-data-engineer-ext.md` if present. `.claude/snippets/` if present — apply patterns.
+3. **Read context:** `.claude/3-project/am-data-engineer-ext.md` if present.
 
 ## 2. Pipeline workflow
 
@@ -123,7 +123,7 @@ A2A-Envelopes verwenden: IPayload (t, ctx, con, refs, pri, dep), IEnvelope (prot
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.claude/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-version: 1.0.4
+version: 1.0.5
 based-on: 1-generic/developer.md@3.1.1
 description: 'Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen
   Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur,
@@ -16,7 +16,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 2-platform/agent-meta-developer.md@1.0.4
+generated-from: 2-platform/agent-meta-developer.md@1.0.5
 model: claude-sonnet-5
 ---
 
@@ -38,7 +38,7 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** 
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `.claude/3-project/am-developer-ext.md` if present. `.claude/snippets/` if present — apply all code patterns.
+4. **Read context:** `.claude/3-project/am-developer-ext.md` if present.
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior. For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.
 7. **Validate:** existing tests must not break. 

--- a/.claude/agents/docker.md
+++ b/.claude/agents/docker.md
@@ -1,6 +1,6 @@
 ---
 name: docker
-version: 1.4.3
+version: 1.4.4
 description: 'Docker operations: Compose stacks, binary management, test environments,
   and diagnostics — platform-independent.'
 hint: Start/stop dev stack, Dockerfiles, binary management
@@ -13,7 +13,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/docker.md@1.4.3
+generated-from: 1-generic/docker.md@1.4.4
 model: claude-haiku-4-5-20251001
 ---
 

--- a/.claude/agents/junior-developer.md
+++ b/.claude/agents/junior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: junior-developer
-version: 1.2.0
+version: 1.2.1
 description: 'Fast, well-scoped code changes: 1-2 files, no architecture impact. Escalates
   in a structured way as soon as scope grows.'
 hint: 'Low-tier developer: trivial fixes, typos, small well-scoped changes — escalates
@@ -14,7 +14,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/junior-developer.md@1.2.0
+generated-from: 1-generic/junior-developer.md@1.2.1
 model: claude-haiku-4-5-20251001
 ---
 
@@ -85,7 +85,7 @@ As soon as any scope criterion is violated:
 - YAML Frontmatter in allen Agent-Templates
 
 
-**Language best practices:** Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.claude/snippets/` exists: read now, apply all patterns.
+**Language best practices:** Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.claude/agents/principal-developer.md
+++ b/.claude/agents/principal-developer.md
@@ -1,6 +1,6 @@
 ---
 name: principal-developer
-version: 1.0.0
+version: 1.0.1
 description: Last-resort escalation tier. Invoked only after senior-developer has
   failed repeatedly on a task. Root-cause diagnosis before a single line of code.
   Maximum thoroughness, maximum cost.
@@ -18,7 +18,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/principal-developer.md@1.0.0
+generated-from: 1-generic/principal-developer.md@1.0.1
 model: claude-opus-4-8
 memory: project
 ---
@@ -142,7 +142,7 @@ You handle ONLY what has already defeated senior-developer:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.claude/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: refactoring-specialist
-version: 0.1.0
+version: 0.1.1
 description: 'Systematic large-scale code transformation with safety nets: Strangler
   Fig pattern, incremental refactoring, code smell detection, legacy modernization
   and feature-flag-driven rewrites with backwards-compatibility guarantees. Produces
@@ -16,7 +16,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/refactoring-specialist.md@0.1.0
+generated-from: 1-generic/refactoring-specialist.md@0.1.1
 model: claude-sonnet-5
 memory: project
 ---
@@ -40,7 +40,7 @@ You are the **Refactoring Specialist** for agent-meta. You perform **large-scale
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`. Input contracts: `task-spec-v1`, `explorer-output-v1` (blast-radius map).
 
 2. **REQ check:** 
-3. **Read context:** `.claude/3-project/am-refactoring-specialist-ext.md` if present. `.claude/snippets/` if present — apply patterns.
+3. **Read context:** `.claude/3-project/am-refactoring-specialist-ext.md` if present.
 
 ## 2. Transformation workflow
 
@@ -121,7 +121,7 @@ A2A-Envelopes verwenden: IPayload (t, ctx, con, refs, pri, dep), IEnvelope (prot
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.claude/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: senior-developer
-version: 1.2.1
+version: 1.2.2
 description: Complex features, architecture decisions, hard bugs and cross-cutting
   refactorings. Analyzes before implementing and documents decisions.
 hint: 'High-tier developer: architecture impact, complex/risky changes, hard bugs
@@ -16,7 +16,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/senior-developer.md@1.2.1
+generated-from: 1-generic/senior-developer.md@1.2.2
 model: claude-opus-4-8
 memory: project
 ---
@@ -113,7 +113,7 @@ Dispatch on at least one marker:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.claude/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,6 +1,6 @@
 ---
 name: tester
-version: 2.1.3
+version: 2.1.4
 description: Isolated unit tests with mocks/stubs following a TDD workflow. For integration
   tests → se-test-engineer.
 hint: Write tests (TDD), run the test suite, ensure coverage
@@ -13,7 +13,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/tester.md@2.1.3
+generated-from: 1-generic/tester.md@2.1.4
 model: claude-haiku-4-5-20251001
 ---
 
@@ -58,7 +58,6 @@ describe / class / suite: ModuleName
 - **No `any`** in test code
 - **No flaky tests**
 
-Language-specific syntax → `.claude/snippets/`.
 </workflow>
 
 <context>

--- a/.gemini/agents/data-engineer.md
+++ b/.gemini/agents/data-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: data-engineer
-version: 0.1.0
+version: 0.1.1
 description: ETL/ELT pipeline design, data-layer schema migration, data quality checks,
   lineage analysis, pipeline monitoring and streaming/batch design. Produces pipeline
   specs, data quality reports, lineage diagrams and migration scripts. Distinct from
@@ -16,7 +16,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/data-engineer.md@0.1.0
+generated-from: 1-generic/data-engineer.md@0.1.1
 model: gemini-3.1-pro-low
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -38,7 +38,7 @@ You are the **Data Engineer** for agent-meta. You design and operate **data pipe
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`.
 
 2. **REQ check:** 
-3. **Read context:** `.gemini/3-project/am-data-engineer-ext.md` if present. `.gemini/snippets/` if present — apply patterns.
+3. **Read context:** `.gemini/3-project/am-data-engineer-ext.md` if present.
 
 ## 2. Pipeline workflow
 
@@ -123,7 +123,7 @@ A2A-Envelopes verwenden: IPayload (t, ctx, con, refs, pri, dep), IEnvelope (prot
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.gemini/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-version: 1.0.4
+version: 1.0.5
 based-on: 1-generic/developer.md@3.1.1
 description: 'Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen
   Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur,
@@ -16,7 +16,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 2-platform/agent-meta-developer.md@1.0.4
+generated-from: 2-platform/agent-meta-developer.md@1.0.5
 model: gemini-3.1-pro-low
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -39,7 +39,7 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** 
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `.gemini/3-project/am-developer-ext.md` if present. `.gemini/snippets/` if present — apply all code patterns.
+4. **Read context:** `.gemini/3-project/am-developer-ext.md` if present.
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior. For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.
 7. **Validate:** existing tests must not break. 

--- a/.gemini/agents/docker.md
+++ b/.gemini/agents/docker.md
@@ -1,6 +1,6 @@
 ---
 name: docker
-version: 1.4.3
+version: 1.4.4
 description: 'Docker operations: Compose stacks, binary management, test environments,
   and diagnostics — platform-independent.'
 hint: Start/stop dev stack, Dockerfiles, binary management
@@ -13,7 +13,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/docker.md@1.4.3
+generated-from: 1-generic/docker.md@1.4.4
 model: gemini-3.5-flash-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).

--- a/.gemini/agents/junior-developer.md
+++ b/.gemini/agents/junior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: junior-developer
-version: 1.2.0
+version: 1.2.1
 description: 'Fast, well-scoped code changes: 1-2 files, no architecture impact. Escalates
   in a structured way as soon as scope grows.'
 hint: 'Low-tier developer: trivial fixes, typos, small well-scoped changes — escalates
@@ -14,7 +14,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/junior-developer.md@1.2.0
+generated-from: 1-generic/junior-developer.md@1.2.1
 model: gemini-3.5-flash-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -86,7 +86,7 @@ As soon as any scope criterion is violated:
 - YAML Frontmatter in allen Agent-Templates
 
 
-**Language best practices:** Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.gemini/snippets/` exists: read now, apply all patterns.
+**Language best practices:** Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.gemini/agents/principal-developer.md
+++ b/.gemini/agents/principal-developer.md
@@ -1,6 +1,6 @@
 ---
 name: principal-developer
-version: 1.0.0
+version: 1.0.1
 description: Last-resort escalation tier. Invoked only after senior-developer has
   failed repeatedly on a task. Root-cause diagnosis before a single line of code.
   Maximum thoroughness, maximum cost.
@@ -18,7 +18,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/principal-developer.md@1.0.0
+generated-from: 1-generic/principal-developer.md@1.0.1
 model: gemini-3.1-pro-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -142,7 +142,7 @@ You handle ONLY what has already defeated senior-developer:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.gemini/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/.gemini/agents/refactoring-specialist.md
+++ b/.gemini/agents/refactoring-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: refactoring-specialist
-version: 0.1.0
+version: 0.1.1
 description: 'Systematic large-scale code transformation with safety nets: Strangler
   Fig pattern, incremental refactoring, code smell detection, legacy modernization
   and feature-flag-driven rewrites with backwards-compatibility guarantees. Produces
@@ -16,7 +16,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/refactoring-specialist.md@0.1.0
+generated-from: 1-generic/refactoring-specialist.md@0.1.1
 model: gemini-3.1-pro-low
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -40,7 +40,7 @@ You are the **Refactoring Specialist** for agent-meta. You perform **large-scale
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`. Input contracts: `task-spec-v1`, `explorer-output-v1` (blast-radius map).
 
 2. **REQ check:** 
-3. **Read context:** `.gemini/3-project/am-refactoring-specialist-ext.md` if present. `.gemini/snippets/` if present — apply patterns.
+3. **Read context:** `.gemini/3-project/am-refactoring-specialist-ext.md` if present.
 
 ## 2. Transformation workflow
 
@@ -121,7 +121,7 @@ A2A-Envelopes verwenden: IPayload (t, ctx, con, refs, pri, dep), IEnvelope (prot
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.gemini/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.gemini/agents/senior-developer.md
+++ b/.gemini/agents/senior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: senior-developer
-version: 1.2.1
+version: 1.2.2
 description: Complex features, architecture decisions, hard bugs and cross-cutting
   refactorings. Analyzes before implementing and documents decisions.
 hint: 'High-tier developer: architecture impact, complex/risky changes, hard bugs
@@ -16,7 +16,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/senior-developer.md@1.2.1
+generated-from: 1-generic/senior-developer.md@1.2.2
 model: gemini-3.1-pro-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -113,7 +113,7 @@ Dispatch on at least one marker:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.gemini/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/.gemini/agents/tester.md
+++ b/.gemini/agents/tester.md
@@ -1,6 +1,6 @@
 ---
 name: tester
-version: 2.1.3
+version: 2.1.4
 description: Isolated unit tests with mocks/stubs following a TDD workflow. For integration
   tests → se-test-engineer.
 hint: Write tests (TDD), run the test suite, ensure coverage
@@ -13,7 +13,7 @@ tools:
 - Glob
 - Grep
 - TodoWrite
-generated-from: 1-generic/tester.md@2.1.3
+generated-from: 1-generic/tester.md@2.1.4
 model: gemini-3.5-flash-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -59,7 +59,6 @@ describe / class / suite: ModuleName
 - **No `any`** in test code
 - **No flaky tests**
 
-Language-specific syntax → `.gemini/snippets/`.
 </workflow>
 
 <context>

--- a/.opencode/agents/data-engineer.md
+++ b/.opencode/agents/data-engineer.md
@@ -1,12 +1,12 @@
 ---
 name: data-engineer
-version: 0.1.0
+version: 0.1.1
 description: ETL/ELT pipeline design, data-layer schema migration, data quality checks,
   lineage analysis, pipeline monitoring and streaming/batch design. Produces pipeline
   specs, data quality reports, lineage diagrams and migration scripts. Distinct from
   database-engineer query/index work.
 prompt_mode: modern
-generated-from: 1-generic/data-engineer.md@0.1.0
+generated-from: 1-generic/data-engineer.md@0.1.1
 mode: subagent
 model: opencode-go/deepseek-v4-pro
 permission:
@@ -34,7 +34,7 @@ You are the **Data Engineer** for agent-meta. You design and operate **data pipe
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`.
 
 2. **REQ check:** 
-3. **Read context:** `.opencode/3-project/am-data-engineer-ext.md` if present. `.opencode/snippets/` if present — apply patterns.
+3. **Read context:** `.opencode/3-project/am-data-engineer-ext.md` if present.
 
 ## 2. Pipeline workflow
 
@@ -119,7 +119,7 @@ A2A-Envelopes verwenden: IPayload (t, ctx, con, refs, pri, dep), IEnvelope (prot
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.opencode/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.opencode/agents/developer.md
+++ b/.opencode/agents/developer.md
@@ -1,11 +1,11 @@
 ---
 name: developer
-version: 1.0.4
+version: 1.0.5
 description: 'Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen
   Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur,
   Rollen-Anlegen-Prozess und Sync-Interface.'
 prompt_mode: modern
-generated-from: 2-platform/agent-meta-developer.md@1.0.4
+generated-from: 2-platform/agent-meta-developer.md@1.0.5
 mode: subagent
 model: opencode-go/deepseek-v4-pro
 permission:
@@ -34,7 +34,7 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** 
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `.opencode/3-project/am-developer-ext.md` if present. `.opencode/snippets/` if present — apply all code patterns.
+4. **Read context:** `.opencode/3-project/am-developer-ext.md` if present.
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior. For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.
 7. **Validate:** existing tests must not break. 

--- a/.opencode/agents/docker.md
+++ b/.opencode/agents/docker.md
@@ -1,10 +1,10 @@
 ---
 name: docker
-version: 1.4.3
+version: 1.4.4
 description: 'Docker operations: Compose stacks, binary management, test environments,
   and diagnostics — platform-independent.'
 prompt_mode: modern
-generated-from: 1-generic/docker.md@1.4.3
+generated-from: 1-generic/docker.md@1.4.4
 mode: subagent
 model: opencode-go/deepseek-v4-flash
 permission:

--- a/.opencode/agents/junior-developer.md
+++ b/.opencode/agents/junior-developer.md
@@ -1,10 +1,10 @@
 ---
 name: junior-developer
-version: 1.2.0
+version: 1.2.1
 description: 'Fast, well-scoped code changes: 1-2 files, no architecture impact. Escalates
   in a structured way as soon as scope grows.'
 prompt_mode: modern
-generated-from: 1-generic/junior-developer.md@1.2.0
+generated-from: 1-generic/junior-developer.md@1.2.1
 mode: subagent
 model: opencode-go/deepseek-v4-flash
 permission:
@@ -82,7 +82,7 @@ As soon as any scope criterion is violated:
 - YAML Frontmatter in allen Agent-Templates
 
 
-**Language best practices:** Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.opencode/snippets/` exists: read now, apply all patterns.
+**Language best practices:** Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.opencode/agents/principal-developer.md
+++ b/.opencode/agents/principal-developer.md
@@ -1,11 +1,11 @@
 ---
 name: principal-developer
-version: 1.0.0
+version: 1.0.1
 description: Last-resort escalation tier. Invoked only after senior-developer has
   failed repeatedly on a task. Root-cause diagnosis before a single line of code.
   Maximum thoroughness, maximum cost.
 prompt_mode: modern
-generated-from: 1-generic/principal-developer.md@1.0.0
+generated-from: 1-generic/principal-developer.md@1.0.1
 mode: subagent
 model: opencode-go/kimi-k2.7-code
 permission:
@@ -137,7 +137,7 @@ You handle ONLY what has already defeated senior-developer:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.opencode/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/.opencode/agents/refactoring-specialist.md
+++ b/.opencode/agents/refactoring-specialist.md
@@ -1,12 +1,12 @@
 ---
 name: refactoring-specialist
-version: 0.1.0
+version: 0.1.1
 description: 'Systematic large-scale code transformation with safety nets: Strangler
   Fig pattern, incremental refactoring, code smell detection, legacy modernization
   and feature-flag-driven rewrites with backwards-compatibility guarantees. Produces
   refactoring plan, transformation sequence, rollback strategy and compatibility matrix.'
 prompt_mode: modern
-generated-from: 1-generic/refactoring-specialist.md@0.1.0
+generated-from: 1-generic/refactoring-specialist.md@0.1.1
 mode: subagent
 model: opencode-go/deepseek-v4-pro
 permission:
@@ -36,7 +36,7 @@ You are the **Refactoring Specialist** for agent-meta. You perform **large-scale
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`. Input contracts: `task-spec-v1`, `explorer-output-v1` (blast-radius map).
 
 2. **REQ check:** 
-3. **Read context:** `.opencode/3-project/am-refactoring-specialist-ext.md` if present. `.opencode/snippets/` if present — apply patterns.
+3. **Read context:** `.opencode/3-project/am-refactoring-specialist-ext.md` if present.
 
 ## 2. Transformation workflow
 
@@ -117,7 +117,7 @@ A2A-Envelopes verwenden: IPayload (t, ctx, con, refs, pri, dep), IEnvelope (prot
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.opencode/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 </context>
 
 <tools>

--- a/.opencode/agents/senior-developer.md
+++ b/.opencode/agents/senior-developer.md
@@ -1,10 +1,10 @@
 ---
 name: senior-developer
-version: 1.2.1
+version: 1.2.2
 description: Complex features, architecture decisions, hard bugs and cross-cutting
   refactorings. Analyzes before implementing and documents decisions.
 prompt_mode: modern
-generated-from: 1-generic/senior-developer.md@1.2.1
+generated-from: 1-generic/senior-developer.md@1.2.2
 mode: subagent
 model: opencode-go/kimi-k2.6
 permission:
@@ -109,7 +109,7 @@ Dispatch on at least one marker:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `Python 3, Markdown, YAML`. If `.opencode/snippets/` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `Python 3, Markdown, YAML`.
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/.opencode/agents/tester.md
+++ b/.opencode/agents/tester.md
@@ -1,10 +1,10 @@
 ---
 name: tester
-version: 2.1.3
+version: 2.1.4
 description: Isolated unit tests with mocks/stubs following a TDD workflow. For integration
   tests → se-test-engineer.
 prompt_mode: modern
-generated-from: 1-generic/tester.md@2.1.3
+generated-from: 1-generic/tester.md@2.1.4
 mode: subagent
 model: opencode-go/deepseek-v4-flash
 permission:
@@ -56,7 +56,6 @@ describe / class / suite: ModuleName
 - **No `any`** in test code
 - **No flaky tests**
 
-Language-specific syntax → `.opencode/snippets/`.
 </workflow>
 
 <context>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Admin UI: the MCP server Env-Vars/Headers dict-editor and the Provider-Options KV editor silently corrupted data when a key was renamed to collide with an existing key in the same dict (one row would vanish, another's value silently overwritten) — both editors now reject the rename with a toast and revert the input. The dict-editor also silently dropped a row when its key field was cleared entirely; that's rejected the same way now (#432).
+- `DEVELOPER_SNIPPETS_PATH`, `TESTER_SNIPPETS_PATH`, `DEV_STACK_START`: optional variables left an unconditional raw `{{VAR}}` placeholder (or, once interpolated, a misleading trailing-slash path like `` `snippets/` if present``) in generated templates when unset. `build_variables()` now derives a `<VAR>_SET` boolean per var so the 13 referencing template lines across `developer.md`, `data-engineer.md`, `database-engineer.md`, `docker.md`, `junior-developer.md`, `principal-developer.md`, `refactoring-specialist.md`, `senior-developer.md`, `tester.md` and the `agent-meta`/`homeassistant`/`sharkord` platform developer overrides can wrap the whole clause in `{{#if <VAR>_SET}}...{{/if}}` and omit it cleanly (#425).
 
 ## [0.92.0] — 2026-08-07
 

--- a/agents/1-generic/data-engineer.md
+++ b/agents/1-generic/data-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: template-data-engineer
-version: "0.1.0"
+version: "0.1.1"
 description: "ETL/ELT pipeline design, data-layer schema migration, data quality checks, lineage analysis, pipeline monitoring and streaming/batch design. Produces pipeline specs, data quality reports, lineage diagrams and migration scripts. Distinct from database-engineer query/index work."
 hint: "Data-Pipelines: ETL/ELT, Schema-Migration (Datenebene), Data-Quality, Lineage, Pipeline-Monitoring, Streaming/Batch — übergibt Pipeline-Spec an developer"
 prompt_mode: modern
@@ -31,7 +31,8 @@ You are the **Data Engineer** for {{PROJECT_NAME}}. You design and operate **dat
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`.
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
-3. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-data-engineer-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.
+3. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-data-engineer-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.{{/if}}
 
 ## 2. Pipeline workflow
 
@@ -104,7 +105,8 @@ On `correction_hints` from a critic → fix ONLY the named findings. Track "roun
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `{{LANGUAGE}}`. If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `{{LANGUAGE}}`.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 </context>
 
 <tools>

--- a/agents/1-generic/database-engineer.md
+++ b/agents/1-generic/database-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: template-database-engineer
-version: "1.0.0"
+version: "1.0.1"
 description: "Relational schema design, database migrations, query optimization and index strategy. Produces backwards-compatible migration scripts with rollback paths and hands a schema contract to the developer."
 hint: "Database design: schema, migrations (Alembic/Flyway style), query optimization, index strategy — hands a schema contract to developer"
 prompt_mode: modern
@@ -29,7 +29,8 @@ You are the **Database Engineer** for {{PROJECT_NAME}}. You design relational sc
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`. Input contracts: `req-output-v1` (requirements), `api-spec-v1` (api-specialist).
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
-3. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-database-engineer-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.
+3. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-database-engineer-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.{{/if}}
 
 ## 2. Design and migration workflow
 
@@ -98,7 +99,8 @@ On `correction_hints` from a critic → fix ONLY the named findings. Track "roun
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `{{LANGUAGE}}`. If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `{{LANGUAGE}}`.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 </context>
 
 <tools>

--- a/agents/1-generic/developer.md
+++ b/agents/1-generic/developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-developer
-version: "4.0.0"
+version: "4.0.1"
 description: "Use when a REQ-ID or clearly scoped task needs direct feature/bugfix implementation."
 hint: "Use for feature/bugfix implementation by REQ-ID — Modern Mode, XML structure, TS contracts."
 prompt_mode: modern
@@ -28,7 +28,8 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.
+4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.{{/if}}
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior.{{#if WEB_PROJECT_ENABLED}} For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.{{/if}}
 7. **Migration verification (mandatory when the task moves, renames, or re-derives existing entities/IDs):** silent identity loss during a migration (e.g. a stable `unique_id` regenerated or dropped instead of carried over) can be invisible in a diff and irreversible once committed — it doesn't just risk history/state, it can permanently break references other systems hold to that ID. Before reporting done:

--- a/agents/1-generic/docker.md
+++ b/agents/1-generic/docker.md
@@ -1,6 +1,6 @@
 ---
 name: template-docker
-version: "1.4.3"
+version: "1.4.4"
 description: "Docker operations: Compose stacks, binary management, test environments, and diagnostics — platform-independent."
 hint: "Start/stop dev stack, Dockerfiles, binary management"
 prompt_mode: modern
@@ -77,7 +77,7 @@ Read `{{DOCKER_STACKS_OVERVIEW}}` for the available stacks. Per stack: compose p
 **Docker stacks of this project:** {{DOCKER_STACKS_OVERVIEW}}
 
 **Build system:** {{BUILD_COMMANDS}}
-**Dev stack:** {{DEV_STACK_START}}
+{{#if DEV_STACK_START_SET}}**Dev stack:** {{DEV_STACK_START}}{{/if}}
 </context>
 
 <tools>

--- a/agents/1-generic/junior-developer.md
+++ b/agents/1-generic/junior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-junior-developer
-version: "1.2.0"
+version: "1.2.1"
 description: "Fast, well-scoped code changes: 1-2 files, no architecture impact. Escalates in a structured way as soon as scope grows."
 hint: "Low-tier developer: trivial fixes, typos, small well-scoped changes — escalates on scope overrun"
 prompt_mode: modern
@@ -79,7 +79,8 @@ As soon as any scope criterion is violated:
 
 **Code conventions:** {{CODE_CONVENTIONS}}
 
-**Language best practices:** Strictly follow the best practices of `{{LANGUAGE}}`. If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read now, apply all patterns.
+**Language best practices:** Strictly follow the best practices of `{{LANGUAGE}}`.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read now, apply all patterns.{{/if}}
 </context>
 
 <tools>

--- a/agents/1-generic/principal-developer.md
+++ b/agents/1-generic/principal-developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-principal-developer
-version: "1.0.0"
+version: "1.0.1"
 description: "Last-resort escalation tier. Invoked only after senior-developer has failed repeatedly on a task. Root-cause diagnosis before a single line of code. Maximum thoroughness, maximum cost."
 hint: "Last-resort developer: only after senior-developer failed multiple times — root-cause analysis, systemic reasoning, no symptom fixes. The most expensive call in the system."
 prompt_mode: modern
@@ -127,7 +127,8 @@ You handle ONLY what has already defeated senior-developer:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `{{LANGUAGE}}`. If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `{{LANGUAGE}}`.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/agents/1-generic/refactoring-specialist.md
+++ b/agents/1-generic/refactoring-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: template-refactoring-specialist
-version: "0.1.0"
+version: "0.1.1"
 description: "Systematic large-scale code transformation with safety nets: Strangler Fig pattern, incremental refactoring, code smell detection, legacy modernization and feature-flag-driven rewrites with backwards-compatibility guarantees. Produces refactoring plan, transformation sequence, rollback strategy and compatibility matrix."
 hint: "Systematische Transformation: Strangler Fig, inkrementelles Refactoring, Legacy-Modernisierung, Feature-Flag-Rewrites — braucht exklusiven Zugriff auf betroffene Module"
 prompt_mode: modern
@@ -33,7 +33,8 @@ You are the **Refactoring Specialist** for {{PROJECT_NAME}}. You perform **large
 A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: plain directive from `main_chat`. Input contracts: `task-spec-v1`, `explorer-output-v1` (blast-radius map).
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
-3. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-refactoring-specialist-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.
+3. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-refactoring-specialist-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.{{/if}}
 
 ## 2. Transformation workflow
 
@@ -102,7 +103,8 @@ On `correction_hints` from a critic → fix ONLY the named findings. Track "roun
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `{{LANGUAGE}}`. If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `{{LANGUAGE}}`.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 </context>
 
 <tools>

--- a/agents/1-generic/senior-developer.md
+++ b/agents/1-generic/senior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-senior-developer
-version: "1.2.1"
+version: "1.2.2"
 description: "Complex features, architecture decisions, hard bugs and cross-cutting refactorings. Analyzes before implementing and documents decisions."
 hint: "High-tier developer: architecture impact, complex/risky changes, hard bugs — analyzes first, then implements"
 prompt_mode: modern
@@ -100,7 +100,8 @@ Dispatch on at least one marker:
 
 ## Language best practices (MANDATORY)
 
-Strictly follow the best practices of `{{LANGUAGE}}`. If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.
+Strictly follow the best practices of `{{LANGUAGE}}`.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 
 **General:** named exports only · kebab-case file names · existing patterns over personal preference.
 </context>

--- a/agents/1-generic/tester.md
+++ b/agents/1-generic/tester.md
@@ -1,6 +1,6 @@
 ---
 name: template-tester
-version: "2.1.3"
+version: "2.1.4"
 description: "Isolated unit tests with mocks/stubs following a TDD workflow. For integration tests → se-test-engineer."
 hint: "Write tests (TDD), run the test suite, ensure coverage"
 prompt_mode: modern
@@ -55,7 +55,7 @@ describe / class / suite: ModuleName
 - **No `any`** in test code
 - **No flaky tests**
 
-Language-specific syntax → `{{SNIPPETS_DIR}}/{{TESTER_SNIPPETS_PATH}}`.
+{{#if TESTER_SNIPPETS_PATH_SET}}Language-specific syntax → `{{SNIPPETS_DIR}}/{{TESTER_SNIPPETS_PATH}}`.{{/if}}
 </workflow>
 
 <context>

--- a/agents/2-platform/agent-meta-developer.md
+++ b/agents/2-platform/agent-meta-developer.md
@@ -1,6 +1,6 @@
 ---
 name: agent-meta-developer
-version: "1.0.4"
+version: "1.0.5"
 based-on: "1-generic/developer.md@3.1.1"
 description: "Developer-Agent für das agent-meta Meta-Repository. Erweitert den generischen Developer um Framework-Wissen: Schichten-Architektur, Platzhalter-Lifecycle, Python-Modulstruktur, Rollen-Anlegen-Prozess und Sync-Interface."
 hint: "Feature-Implementierung und Bugfixes im agent-meta Framework (Python, Markdown, YAML)"
@@ -33,7 +33,8 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.
+4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.{{/if}}
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior.{{#if WEB_PROJECT_ENABLED}} For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.{{/if}}
 7. **Validate:** existing tests must not break. {{DOD_TESTS_BLOCK}}

--- a/agents/2-platform/homeassistant-developer.md
+++ b/agents/2-platform/homeassistant-developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-version: "1.1.2"
+version: "1.1.3"
 based-on: "1-generic/developer.md@2.3.0"
 description: "Home Assistant Developer — YAML-Konfigurationen, Automatisierungen, Templates, Energy-Layer und Package-Struktur."
 hint: "Feature-Implementierung und Bugfixes für Home Assistant (YAML, Jinja2, Packages)"
@@ -49,7 +49,8 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.
+4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.{{/if}}
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior.{{#if WEB_PROJECT_ENABLED}} For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.{{/if}}
 7. **Validate:** existing tests must not break. {{DOD_TESTS_BLOCK}}

--- a/agents/2-platform/sharkord-developer.md
+++ b/agents/2-platform/sharkord-developer.md
@@ -1,6 +1,6 @@
 ---
 name: sharkord-developer
-version: "2.1.3"
+version: "2.1.4"
 based-on: "1-generic/developer.md@2.3.0"
 description: "Sharkord-spezifischer Developer-Agent. Ergänzt den generischen Developer um Sharkord-Build-Kommandos. Das Sharkord Plugin-SDK Wissen (PluginContext API, Mediasoup, Commands, Events, Don'ts) kommt automatisch aus der Rule rules/2-platform/sharkord-sdk.md."
 hint: "Feature-Implementierung und Bugfixes nach REQ-IDs (Sharkord Plugin SDK)"
@@ -29,7 +29,8 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 
 2. **REQ check:** {{DOD_REQ_BLOCK}}
 3. **Scope:** identify the minimal change — only what the task requires.
-4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present. `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.
+4. **Read context:** `{{EXTENSION_DIR}}/{{PREFIX}}-developer-ext.md` if present.
+{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply all code patterns.{{/if}}
 5. **Implement:** follow code conventions (see `<context>`). Respect the architecture.
 6. **Self-verification:** actually run/call the changed code — do not rely on green unit tests alone. Observe the result; on regression risk, manually walk neighbouring paths. Do not report done before observing the expected behavior.{{#if WEB_PROJECT_ENABLED}} For UI-relevant changes: start the app / dev server, run the feature in a browser, observe the visible result before reporting done.{{/if}}
 7. **Validate:** existing tests must not break. {{DOD_TESTS_BLOCK}}

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -500,6 +500,16 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
             variables[key] = str(value)
         else:
             variables[key] = value
+    # Optional, project-specific string variables (#425): unlike ARCHITECTURE/
+    # DEV_COMMANDS below, an empty-string fallback is wrong here because the
+    # referencing templates interpolate the value inline (e.g.
+    # "{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}") — substituting "" would
+    # render a misleading trailing-slash path instead of omitting the clause.
+    # A derived <VAR>_SET boolean lets templates wrap the whole clause in
+    # {{#if <VAR>_SET}}...{{/if}} (see strip_inactive_conditional_blocks).
+    for _optional_var in ("DEVELOPER_SNIPPETS_PATH", "TESTER_SNIPPETS_PATH", "DEV_STACK_START"):
+        variables[f"{_optional_var}_SET"] = "true" if variables.get(_optional_var) else "false"
+        variables.setdefault(_optional_var, "")
     # REQ category placeholders: guarantee substitution so generated context
     # files never keep a literal {{REQ_CATEGORIES_LIST}} / {{REQ_CATEGORIES}}.
     # User-set values (loaded above) take precedence; otherwise derive the long
@@ -853,6 +863,7 @@ def strip_inactive_conditional_blocks(text: str, variables: dict) -> str:
     conditional_vars.update({k for k in variables if k.startswith("PIPELINE_") and k.endswith("_ENABLED")})
     conditional_vars.update({k for k in variables if k in ("ORCHESTRATOR_ENABLED", "ORCHESTRATOR_STRICT", "DIRECT_DISPATCH_ENABLED", "UNKNOWN_FALLBACK_ASK_USER", "UNKNOWN_FALLBACK_META_FEEDBACK", "UNKNOWN_FALLBACK_MAIN_CHAT", "A2A_PROTOCOL_ENABLED", "ORCHESTRATOR_OUTCOME_CACHING", "CHECKPOINTING_ENABLED", "NATIVE_EXTENSIONS_ENABLED", "NATIVE_EXTENSIONS_WHITELIST_ACTIVE", "ANALYSIS_ENABLED", "FILE_BASED_AGENTS")})
     conditional_vars.update({k for k in variables if k.startswith("ORCH_MODE_")})
+    conditional_vars.update({k for k in variables if k.endswith("_SET")})
 
     if not conditional_vars:
         return text

--- a/tests/test_optional_snippets_path_conditional.py
+++ b/tests/test_optional_snippets_path_conditional.py
@@ -1,0 +1,70 @@
+"""Regression tests for #425: DEVELOPER_SNIPPETS_PATH, TESTER_SNIPPETS_PATH and
+DEV_STACK_START are optional, project-specific string variables. Templates
+interpolate them (e.g. "{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}"), so a
+plain empty-string fallback (like ARCHITECTURE/DEV_COMMANDS in
+test_config_variable_fallbacks.py) would render a misleading trailing-slash
+path instead of omitting the clause. build_variables() instead derives a
+<VAR>_SET boolean so templates can wrap the whole clause in a standalone
+{{#if <VAR>_SET}}...{{/if}} line (own-line, not inline — an inline trailing
+clause would make strip_inactive_conditional_blocks's inactive-block removal
+also eat the newline before the following line, merging it into the next
+line of prose).
+"""
+
+from pathlib import Path
+
+from scripts.lib.config import build_variables, strip_inactive_conditional_blocks, substitute
+from scripts.lib.log import SyncLog
+
+OPTIONAL_VARS = ("DEVELOPER_SNIPPETS_PATH", "TESTER_SNIPPETS_PATH", "DEV_STACK_START")
+
+
+def test_unset_optional_vars_default_to_empty_string_and_unset_flag():
+    repo_root = Path(__file__).resolve().parents[1]
+    variables, _ = build_variables({}, repo_root)
+    for var in OPTIONAL_VARS:
+        assert variables.get(var) == ""
+        assert variables.get(f"{var}_SET") == "false"
+
+
+def test_explicit_optional_var_sets_flag_true():
+    repo_root = Path(__file__).resolve().parents[1]
+    config = {"variables": {"DEVELOPER_SNIPPETS_PATH": "python-fastapi"}}
+    variables, _ = build_variables(config, repo_root)
+    assert variables["DEVELOPER_SNIPPETS_PATH"] == "python-fastapi"
+    assert variables["DEVELOPER_SNIPPETS_PATH_SET"] == "true"
+    # Vars the project never set stay unset.
+    assert variables["TESTER_SNIPPETS_PATH_SET"] == "false"
+
+
+def test_conditional_block_omitted_when_unset_no_placeholder_leak_no_line_merge():
+    repo_root = Path(__file__).resolve().parents[1]
+    variables, _ = build_variables({}, repo_root)
+    template = (
+        "4. Read context.\n"
+        "{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.{{/if}}\n"
+        "5. Implement."
+    )
+    rendered = strip_inactive_conditional_blocks(template, variables)
+    rendered = substitute(rendered, variables, "test", SyncLog())
+    assert rendered == "4. Read context.\n5. Implement."
+    assert "DEVELOPER_SNIPPETS_PATH" not in rendered
+    assert "{{" not in rendered
+
+
+def test_conditional_block_rendered_when_set():
+    repo_root = Path(__file__).resolve().parents[1]
+    config = {"variables": {
+        "DEVELOPER_SNIPPETS_PATH": "python-fastapi",
+        "SNIPPETS_DIR": "snippets",
+    }}
+    variables, _ = build_variables(config, repo_root)
+    template = (
+        "4. Read context.\n"
+        "{{#if DEVELOPER_SNIPPETS_PATH_SET}}`{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` if present — apply patterns.{{/if}}\n"
+        "5. Implement."
+    )
+    rendered = strip_inactive_conditional_blocks(template, variables)
+    rendered = substitute(rendered, variables, "test", SyncLog())
+    assert rendered == "4. Read context.\n`snippets/python-fastapi` if present — apply patterns.\n5. Implement."
+    assert "{{" not in rendered


### PR DESCRIPTION
## Summary
- Fixes #425: `DEVELOPER_SNIPPETS_PATH`, `TESTER_SNIPPETS_PATH`, `DEV_STACK_START` are optional variables with no fallback — unset projects got a leaked raw placeholder (or, if given a plain empty-string default, a misleading trailing-slash path).
- `build_variables()` now derives a `<VAR>_SET` boolean per var so the 13 referencing lines across 12 templates (developer/data-engineer/database-engineer/docker/junior-developer/principal-developer/refactoring-specialist/senior-developer/tester + agent-meta/homeassistant/sharkord platform overrides) can wrap the clause in `{{#if <VAR>_SET}}...{{/if}}` and omit it cleanly.
- Each conditional clause was placed on its own line rather than inline after other prose — `strip_inactive_conditional_blocks()` also consumes a removed block's trailing newline, so an inline placement merges the next line of prose into the current one when inactive. Confirmed this live against both `agent-meta-test`'s sandbox and this repo's own generated output.

## Side finding (filed separately, not fixed here)
While testing, found that `AGENTS.md` accumulates blank lines on repeated, otherwise-unchanged `sync.py` runs (non-idempotent managed-block regeneration). Confirmed unrelated to this change by reverting it and still reproducing the growth. Filed as #434, intentionally out of scope for this PR.

## Verification
- Live-reproduced the leak in this repo's own generated output before the fix (`` `.claude/snippets/` if present`` trailing-slash artifact in `.claude/agents/developer.md`) and confirmed it's gone after.
- Re-synced `agent-meta-test`'s sandbox: zero `Variable ... not in config` warnings for these three vars (previously present).
- New unit tests `tests/test_optional_snippets_path_conditional.py` (4 tests): SET-flag derivation, both rendered states, no placeholder leak.
- Full regression: `pytest -q --ignore=external --ignore=tests/browser` → 301 passed. Browser suite → 16 passed, same 3 known pre-existing/unrelated failures.
- `sync.py --validate` clean (only the known, unrelated external-submodule warning).

## Test plan
- [x] Reproduce leak live, pre-fix
- [x] Confirm fix live (both unset/set states), post-fix
- [x] New regression tests
- [x] Full pytest suite: no new failures
- [x] sync.py --validate clean