### PR TITLE
fix: admin-ui Phase 0 — HTML-entity leak, badge text, Loading ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Admin UI, Phase 0 of the consistency remediation plan (`docs/superpowers/plans/2026-08-07-admin-ui-consistency.md`): the "Preset Matrix" heading on Rules Presets showed the literal text `&#8212;` instead of an em dash (HTML entity in a text-node position never decodes); a skill's version badge read "Recommended Tag" instead of "Recommended"; 6 "Loading…" placeholders were split between the ellipsis character and three literal dots, now unified on the ellipsis character.
+
 ### Changed
 - A2A handoff concept simplified after a best-practice audit found most of `orchestrator.handoff.*` in `project.yaml` had no consumer anywhere (code or agent prompt): removed `validate-before-delegate`, `supersession-tracking`, `strict-validation`, `compact-mode`, `max_retries`, `human_approval_required`, `protocol_routing`, `token-budget` (only `protocol` remains; `config/project-config.schema.json`'s `handoff` block is now `additionalProperties: false` to stop this recurring). Removed the matching dead envelope fields from `schemas/a2a-handoff.schema.json` (`retry_count`, `max_retries`, `escalation`, `timeout_seconds`, `negotiated_format`) and 3 unreferenced schema `definitions`. Clarified in `snippets/orchestrator/a2a-protocol.md` and `A2A_HANDOFF_BLOCK` that a structured JSON envelope is only required for routes with a schema-backed contract (`role-defaults.yaml` `handoff.input_schema`/`output_schema` pointing at a real file) — everyday FANOUT/BARRIER delegation uses the existing plain-text format, previously undocumented and contradicting a "MUST" claim in the same snippet. `validate_envelope()` stays as a manually-invokable, now-tested utility (no automatic runtime interception point exists in this architecture). See `docs/concepts/a2a-best-practice-analysis-2026-08.md`.
 

--- a/docs/ui/admin-ui.html
+++ b/docs/ui/admin-ui.html
@@ -2660,7 +2660,7 @@ async function viewProjectSkillsOverrides() {
     const verWrap = el("div", {style:"display:flex; align-items:center; gap: 8px;"});
     verWrap.appendChild(el("span", {}, [`Version: ${currentVersion}`]));
     if (currentVersion === recommendedVersion && isFramework) {
-        verWrap.appendChild(el("span", { class: "badge", style:"background-color:#4f46e5; color:#fff" }, ["Recommended Tag"]));
+        verWrap.appendChild(el("span", { class: "badge", style:"background-color:#4f46e5; color:#fff" }, ["Recommended"]));
     } else if (isFramework) {
         verWrap.appendChild(el("span", { class: "badge badge-warning" }, [`Warning: Framework recommends ${recommendedVersion}`]));
     }
@@ -3161,7 +3161,7 @@ async function viewRulesPresets() {
   const ICON_DEF = '<span style="color:var(--text-muted);font-size:0.85em;" title="default (true)">&#8212;</span>';
 
   const matrixPanel = el("details", { class: "panel", open: true });
-  matrixPanel.appendChild(el("summary", { style: "cursor:pointer; font-weight:600;" }, ["Preset Matrix &#8212; all rules vs. all presets"]));
+  matrixPanel.appendChild(el("summary", { style: "cursor:pointer; font-weight:600;" }, ["Preset Matrix — all rules vs. all presets"]));
   const matrixTable = el("table", { style: "width:100%; border-collapse:collapse; font-size:0.8em; margin-top:8px;" });
   const mthead = el("thead");
   let headerRow = '<tr style="border-bottom:2px solid var(--border-color);"><th style="text-align:left;padding:4px 8px;min-width:140px;">Rule</th>';
@@ -6573,13 +6573,13 @@ async function viewBackups() {
   wrap.appendChild(el("h1", {}, ["System Backups"]));
   wrap.appendChild(el("p", { class: "muted" }, ["Manage full system backups (agent-meta config + provider folders)."]));
 
-  const status = el("div", { class: "muted" }, ["Loading..."]);
+  const status = el("div", { class: "muted" }, ["Loading…"]);
   wrap.appendChild(status);
 
   let data = null;
   const load = async () => {
     try {
-      status.textContent = "Loading backups...";
+      status.textContent = "Loading backups…";
       data = await api.get("/api/backups");
       status.textContent = "";
       render();
@@ -6661,7 +6661,7 @@ async function viewProviderDeactivation() {
     "Deactivated providers will no longer read agent sub-definitions. Root context files (CLAUDE.md, AGENTS.md) are NOT affected.",
   ]));
 
-  const status = el("div", { class: "muted" }, ["Loading deactivation status..."]);
+  const status = el("div", { class: "muted" }, ["Loading deactivation status…"]);
   wrap.appendChild(status);
 
   let deactStatus = null;
@@ -7517,7 +7517,7 @@ async function viewModels() {
     }
 
     if (state.loading) {
-      wrap.appendChild(el("div", { style: "padding:32px;text-align:center;opacity:0.6;" }, ["Loading..."]));
+      wrap.appendChild(el("div", { style: "padding:32px;text-align:center;opacity:0.6;" }, ["Loading…"]));
       return;
     }
 

--- a/tests/browser/test_admin_ui_consistency_p0.py
+++ b/tests/browser/test_admin_ui_consistency_p0.py
@@ -1,0 +1,64 @@
+"""Phase 0 of the admin-ui consistency plan (docs/superpowers/plans/2026-08-07-admin-ui-consistency.md):
+3 isolated, live-verified visual bugs found during the 2026-08-07 audit.
+"""
+
+import pytest
+pytest.importorskip('playwright')
+from playwright.sync_api import expect
+
+
+def test_rules_presets_matrix_heading_has_no_raw_html_entity(browser_ctx):
+    """Task 1: the "Preset Matrix" summary heading must show a real em dash,
+    not the literal string "&#8212;" — el() inserts text as a text node, so
+    HTML entities in that position are never decoded."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/config/rules-presets")
+        page.wait_for_load_state("networkidle")
+        heading = page.get_by_text("Preset Matrix", exact=False).first
+        expect(heading).to_be_visible(timeout=5000)
+        text = heading.text_content() or ""
+        assert "&#8212;" not in text, f"raw HTML entity leaked into heading text: {text!r}"
+        assert "—" in text
+    finally:
+        page.close()
+
+
+def test_skill_card_recommended_badge_has_no_literal_tag_suffix(browser_ctx):
+    """Task 2: the "Recommended" badge on a skill card must read exactly
+    "Recommended", not "Recommended Tag"."""
+    ctx, base = browser_ctx
+    page = ctx.new_page()
+    try:
+        page.goto(f"{base}/#/project/skills-overrides")
+        page.wait_for_load_state("networkidle")
+        badge = page.locator("span.badge", has_text="Recommended").first
+        expect(badge).to_be_visible(timeout=5000)
+        text = (badge.text_content() or "").strip()
+        assert text == "Recommended", f"badge text is {text!r}, expected exactly 'Recommended'"
+    finally:
+        page.close()
+
+
+def test_loading_indicator_uses_ellipsis_character_consistently():
+    """Task 3: all "Loading" placeholders use the single ellipsis character
+    (…), not three literal dots (...) — was previously split across the file
+    (2 already used the character, 4 used three dots, one of those built
+    dynamically as "Loading <noun>...").
+
+    A source-level check rather than a live one: the "loading" state is
+    transient and frequently resolves before Playwright observes it, which
+    made an earlier version of this test pass even without the fix (false
+    confidence) — the underlying admin-server responds fast enough locally
+    that the loading text is rarely on screen long enough to assert against.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    source = (repo_root / "docs" / "ui" / "admin-ui.html").read_text(encoding="utf-8")
+    offending = [
+        line for line in source.splitlines()
+        if "Loading" in line and "..." in line
+    ]
+    assert not offending, f"found three-dot 'Loading...' text, expected the unicode ellipsis (…): {offending}"


### PR DESCRIPTION
## Summary
- Fixes #440, Phase 0 of `docs/superpowers/plans/2026-08-07-admin-ui-consistency.md`.
- Rules Presets heading rendered raw `&#8212;` instead of an em dash — the only spot in the file where an HTML-entity string was passed through `el()`'s text-node path instead of `innerHTML` (verified: every other `&#NNNN;` occurrence in the file is legitimately assigned via `innerHTML`, where entities decode fine).
- Skill-card version badge read "Recommended Tag" instead of "Recommended" (hardcoded string, not a concatenation bug — "Recommended" alone matches the short-badge convention used elsewhere).
- "Loading..." vs "Loading…" unified on the ellipsis character across all 6 call sites (2 more than the audit's original count — found via a broader grep for the bare word "Loading").

## Verification
- Live-verified both HTML/badge fixes via screenshot in a running admin-server.
- New tests `tests/browser/test_admin_ui_consistency_p0.py` (3 tests) — confirmed red without the fix (`git stash`), green with it. The Loading-ellipsis test started as a live-DOM check but passed even without the fix (the loading state resolves too fast locally) — rewritten as a deterministic source-grep check instead.
- Full regression: `pytest -q --ignore=external --ignore=tests/browser` → 316 passed. Browser suite → 19 passed, same 3 known pre-existing/unrelated failures.
- `sync.py --validate` clean.

## Test plan
- [x] Reproduce all 3 bugs live, pre-fix
- [x] Confirm fixes live (2 of 3), post-fix
- [x] New regression tests fail without the fix, pass with it
- [x] Full pytest suite: no new failures
- [x] sync.py --validate clean