### PR TITLE
fix: deduplicate senior/principal-developer shared blocks

### DIFF
--- a/.claude/agents/principal-developer.md
+++ b/.claude/agents/principal-developer.md
@@ -1,6 +1,6 @@
 ---
 name: principal-developer
-version: 1.0.1
+version: 1.0.2
 description: Last-resort escalation tier. Invoked only after senior-developer has
   failed repeatedly on a task. Root-cause diagnosis before a single line of code.
   Maximum thoroughness, maximum cost.
@@ -18,7 +18,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/principal-developer.md@1.0.1
+generated-from: 1-generic/principal-developer.md@1.0.2
 model: claude-opus-4-8
 memory: project
 ---

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: senior-developer
-version: 1.2.2
+version: 1.2.3
 description: Complex features, architecture decisions, hard bugs and cross-cutting
   refactorings. Analyzes before implementing and documents decisions.
 hint: 'High-tier developer: architecture impact, complex/risky changes, hard bugs
@@ -16,7 +16,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/senior-developer.md@1.2.2
+generated-from: 1-generic/senior-developer.md@1.2.3
 model: claude-opus-4-8
 memory: project
 ---

--- a/.gemini/agents/principal-developer.md
+++ b/.gemini/agents/principal-developer.md
@@ -1,6 +1,6 @@
 ---
 name: principal-developer
-version: 1.0.1
+version: 1.0.2
 description: Last-resort escalation tier. Invoked only after senior-developer has
   failed repeatedly on a task. Root-cause diagnosis before a single line of code.
   Maximum thoroughness, maximum cost.
@@ -18,7 +18,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/principal-developer.md@1.0.1
+generated-from: 1-generic/principal-developer.md@1.0.2
 model: gemini-3.1-pro-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).

--- a/.gemini/agents/senior-developer.md
+++ b/.gemini/agents/senior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: senior-developer
-version: 1.2.2
+version: 1.2.3
 description: Complex features, architecture decisions, hard bugs and cross-cutting
   refactorings. Analyzes before implementing and documents decisions.
 hint: 'High-tier developer: architecture impact, complex/risky changes, hard bugs
@@ -16,7 +16,7 @@ tools:
 - WebFetch
 - WebSearch
 - TodoWrite
-generated-from: 1-generic/senior-developer.md@1.2.2
+generated-from: 1-generic/senior-developer.md@1.2.3
 model: gemini-3.1-pro-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).

--- a/.opencode/agents/principal-developer.md
+++ b/.opencode/agents/principal-developer.md
@@ -1,11 +1,11 @@
 ---
 name: principal-developer
-version: 1.0.1
+version: 1.0.2
 description: Last-resort escalation tier. Invoked only after senior-developer has
   failed repeatedly on a task. Root-cause diagnosis before a single line of code.
   Maximum thoroughness, maximum cost.
 prompt_mode: modern
-generated-from: 1-generic/principal-developer.md@1.0.1
+generated-from: 1-generic/principal-developer.md@1.0.2
 mode: subagent
 model: opencode-go/kimi-k2.7-code
 permission:

--- a/.opencode/agents/senior-developer.md
+++ b/.opencode/agents/senior-developer.md
@@ -1,10 +1,10 @@
 ---
 name: senior-developer
-version: 1.2.2
+version: 1.2.3
 description: Complex features, architecture decisions, hard bugs and cross-cutting
   refactorings. Analyzes before implementing and documents decisions.
 prompt_mode: modern
-generated-from: 1-generic/senior-developer.md@1.2.2
+generated-from: 1-generic/senior-developer.md@1.2.3
 mode: subagent
 model: opencode-go/kimi-k2.6
 permission:

--- a/agents/1-generic/principal-developer.md
+++ b/agents/1-generic/principal-developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-principal-developer
-version: "1.0.1"
+version: "1.0.2"
 description: "Last-resort escalation tier. Invoked only after senior-developer has failed repeatedly on a task. Root-cause diagnosis before a single line of code. Maximum thoroughness, maximum cost."
 hint: "Last-resort developer: only after senior-developer failed multiple times — root-cause analysis, systemic reasoning, no symptom fixes. The most expensive call in the system."
 prompt_mode: modern
@@ -66,15 +66,7 @@ You may NOT write a single line of code before completing steps 2–4.
 
 Thoroughness beats speed at every step. When in doubt, dig deeper — you are the tier that is supposed to take longer. Prior tiers may have failed on stale assumptions; verify framework behavior against official docs and exact versions.
 
-{{#if WEB_PROJECT_ENABLED}}
-### Browser verification (UI-relevant changes)
-
-- Actually start the app / dev server and run the feature in a browser
-- Check visual consistency: layout, spacing, states (hover/focus/disabled)
-- Observe responsive behavior across multiple viewports where relevant
-- Observe the visible result before reporting the change as done
-{{/if}}
-
+{{BROWSER_VERIFICATION_BLOCK}}
 ## 3. Decision note (mandatory)
 
 ```
@@ -125,12 +117,7 @@ You handle ONLY what has already defeated senior-developer:
 - **Systemic risk:** spans architecture boundaries, data integrity, concurrency, security
 - **High-stakes irreversibility:** a wrong move is expensive or hard to undo
 
-## Language best practices (MANDATORY)
-
-Strictly follow the best practices of `{{LANGUAGE}}`.
-{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
-
-**General:** named exports only · kebab-case file names · existing patterns over personal preference.
+{{LANGUAGE_BEST_PRACTICES_BLOCK}}{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 </context>
 
 <tools>

--- a/agents/1-generic/senior-developer.md
+++ b/agents/1-generic/senior-developer.md
@@ -1,6 +1,6 @@
 ---
 name: template-senior-developer
-version: "1.2.2"
+version: "1.2.3"
 description: "Complex features, architecture decisions, hard bugs and cross-cutting refactorings. Analyzes before implementing and documents decisions."
 hint: "High-tier developer: architecture impact, complex/risky changes, hard bugs — analyzes first, then implements"
 prompt_mode: modern
@@ -40,15 +40,7 @@ A2A envelope present → parse `payload.{t,ctx,con,refs,pri,dep}`. Otherwise: pl
 6. {{#if DOD_REQ_TRACEABILITY}}Commit: <type>(REQ-xxx): <description>{{/if}}
 ```
 
-{{#if WEB_PROJECT_ENABLED}}
-### Browser verification (UI-relevant changes)
-
-- Actually start the app / dev server and run the feature in a browser
-- Check visual consistency: layout, spacing, states (hover/focus/disabled)
-- Observe responsive behavior across multiple viewports where relevant
-- Observe the visible result before reporting the change as done
-{{/if}}
-
+{{BROWSER_VERIFICATION_BLOCK}}
 ## 3. Decision note (mandatory for architecture decisions)
 
 ```
@@ -98,12 +90,7 @@ Dispatch on at least one marker:
 - **Risk paths:** security, performance-critical, data integrity
 - **Escalations:** handed up from `junior-developer` / `developer`
 
-## Language best practices (MANDATORY)
-
-Strictly follow the best practices of `{{LANGUAGE}}`.
-{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
-
-**General:** named exports only · kebab-case file names · existing patterns over personal preference.
+{{LANGUAGE_BEST_PRACTICES_BLOCK}}{{#if DEVELOPER_SNIPPETS_PATH_SET}}If `{{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}` exists: read immediately, apply all patterns.{{/if}}
 </context>
 
 <tools>

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -844,6 +844,33 @@ def build_variables(config: dict, agent_meta_root: Path) -> tuple[dict, list[str
         _var_name = f"{_var_stem}_BLOCK"
         variables[_var_name] = _snippet_path.read_text(encoding="utf-8") if _snippet_path.exists() else ""
 
+    # Developer-tier shared blocks (senior/principal-developer.md): these were
+    # byte-identical duplicated text across both files until this was added --
+    # a shared snippet is the actual fix, not just a note to keep them in sync
+    # by hand. Same loading pattern as the orchestrator blocks above, with one
+    # difference: unlike the orchestrator snippets (which only use {{#if}}
+    # conditionals, resolved by a later whole-document pass), language-best-
+    # practices.md also references the plain {{LANGUAGE}} placeholder.
+    # substitute() runs once over the parent template and does not re-scan
+    # text it just inserted, so a {{VAR}} left inside a loaded block leaks
+    # through unresolved into the final output -- pre-resolve it here against
+    # the variables already built above, the same way A2A_HANDOFF_BLOCK
+    # inlines A2A_T_SIZE_LIMIT. Deliberately NOT extending this to
+    # {{SNIPPETS_DIR}}/{{DEVELOPER_SNIPPETS_PATH}}: those are per-provider
+    # values injected later in sync_agents_for_provider, not available here
+    # at all (confirmed: absent from this function's own `variables`) -- a
+    # sentence using them has to stay inline in each template, not in a
+    # shared block resolved at this stage.
+    _dev_snippets_dir = agent_meta_root / "snippets" / "developer"
+    for _snippet_name, _var_stem in (
+        ("browser-verification", "BROWSER_VERIFICATION"),
+        ("language-best-practices", "LANGUAGE_BEST_PRACTICES"),
+    ):
+        _snippet_path = _dev_snippets_dir / f"{_snippet_name}.md"
+        _snippet_text = _snippet_path.read_text(encoding="utf-8") if _snippet_path.exists() else ""
+        _snippet_text = _snippet_text.replace("{{LANGUAGE}}", str(variables.get("LANGUAGE", "")))
+        variables[f"{_var_stem}_BLOCK"] = _snippet_text
+
     return variables, unmapped
 
 

--- a/scripts/lib/consistency/placeholders.py
+++ b/scripts/lib/consistency/placeholders.py
@@ -69,6 +69,8 @@ _BUILTIN_VARS: frozenset[str] = frozenset({
     "A2A_T_SIZE_LIMIT", "A2A_T_SIZE_LIMIT_TOKENS", "A2A_MAX_DEPTH",
     # Orchestrator snippet blocks (loaded from snippets/orchestrator/*.md by build_variables)
     "SE_MODE_BLOCK", "A2A_PROTOCOL_BLOCK", "CHECKPOINTING_BLOCK", "QUALITY_PIPELINES_BLOCK",
+    # Developer-tier shared blocks (loaded from snippets/developer/*.md by build_variables)
+    "BROWSER_VERIFICATION_BLOCK", "LANGUAGE_BEST_PRACTICES_BLOCK",
     # SE cascade variables (from role-defaults.yaml se_variables)
     "SE_MIN_DEPTH", "SE_MAX_DEPTH", "SE_MAX_CRITIC_ITERATIONS", "SE_MAX_PARALLEL_CELLS",
     "SE_MAX_CELLS", "cost_limit_eur",

--- a/snippets/developer/browser-verification.md
+++ b/snippets/developer/browser-verification.md
@@ -1,0 +1,8 @@
+{{#if WEB_PROJECT_ENABLED}}
+### Browser verification (UI-relevant changes)
+
+- Actually start the app / dev server and run the feature in a browser
+- Check visual consistency: layout, spacing, states (hover/focus/disabled)
+- Observe responsive behavior across multiple viewports where relevant
+- Observe the visible result before reporting the change as done
+{{/if}}

--- a/snippets/developer/language-best-practices.md
+++ b/snippets/developer/language-best-practices.md
@@ -1,0 +1,5 @@
+## Language best practices (MANDATORY)
+
+Strictly follow the best practices of `{{LANGUAGE}}`.
+
+**General:** named exports only · kebab-case file names · existing patterns over personal preference.


### PR DESCRIPTION
## Summary

Lightweight developer-tier consolidation (user chose this over a structural "1 template, N tier-instances" rewrite, which would need core sync-pipeline changes -- left as a separate future effort if still wanted).

Re-verified the actual current duplication by reading all 4 tier files fresh rather than trusting an earlier estimate: `junior-developer.md`/`developer.md` have already diverged substantially (`developer.md` is a v4.0.1 rewrite), and only 2 sections are genuinely byte-identical, only between `senior-developer.md` and `principal-developer.md` -- the "Browser verification" block and the "Language best practices" block. Extracted both into `snippets/developer/*.md`, loaded via the same mechanism already used for the orchestrator's `SE_MODE_BLOCK`/`A2A_PROTOCOL_BLOCK`/etc.

Caught and fixed a real bug before it shipped: `substitute()` doesn't re-scan text it just inserted from a variable, so a `{{VAR}}` placeholder left inside a loaded snippet leaks through unresolved. Fixed by pre-resolving `{{LANGUAGE}}` in Python at load time (matching how `A2A_HANDOFF_BLOCK` already does this). One related placeholder (`{{SNIPPETS_DIR}}`/`{{DEVELOPER_SNIPPETS_PATH}}`) is genuinely per-provider and unavailable at this pipeline stage, so that one sentence stays inline in both templates rather than being incorrectly folded into the shared block.

Verified with a precise opcode-level diff (Python `difflib`, not a visual read) that the final generated output is byte-identical to before except for the intentional version bump -- pure deduplication, zero behavior change.

## Test plan

- [x] `pytest -q --ignore=external --ignore=tests/browser` -> 316 passed
- [x] `consistency-check.py` clean
- [x] Precise `difflib` opcode diff confirms `.claude/agents/senior-developer.md` and `principal-developer.md` are byte-identical to pre-change output except the version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG91TXdNCe5RBcHU16B1xm