### PR TITLE
fix: dod-push-check must not block tag-only pushes on main

### DIFF
--- a/.claude/hooks/dod-push-check.sh
+++ b/.claude/hooks/dod-push-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hook: dod-push-check
-# version: 1.3.0
+# version: 1.4.0
 # event: PreToolUse
 # matcher: Bash
 # provider: Claude
@@ -96,6 +96,48 @@ print(val)
 PYEOF
 }
 
+# --- Tag-only push detection ---
+# A tag push (`git push origin v1.2.3`, `git push origin --tags`,
+# `git push origin tag v1.2.3`, `git push origin refs/tags/v1.2.3`) does not
+# touch any branch ref — it cannot add commits to main/master, which is the
+# entire premise the Branch-Guard below exists to prevent. Without this
+# check, cutting a release while sitting on main (the normal place to be
+# right after a release PR merges) was blocked identically to an actual
+# direct push of main's commit history, even though the two are unrelated
+# in risk. Not a full shell parser (matches this repo's other hooks'
+# documented approach) — covers the realistic `git push <remote> <ref>` /
+# `--tags` / `tag <name>` forms; anything else (bare `git push`, `git push
+# origin`, an explicit branch ref) still falls through to the branch check.
+IS_TAG_ONLY_PUSH=$(python3 - "$COMMAND" <<'PYEOF' 2>/dev/null
+import subprocess, sys
+tokens = sys.argv[1].split()
+try:
+    rest = tokens[tokens.index("push") + 1:]
+except ValueError:
+    print("false"); sys.exit(0)
+if "--tags" in rest:
+    print("true"); sys.exit(0)
+non_flags = [t for t in rest if not t.startswith("-")]
+if len(non_flags) >= 3 and non_flags[1] == "tag":
+    print("true"); sys.exit(0)
+if len(non_flags) == 2:
+    ref = non_flags[1]
+    if ref.startswith("refs/tags/"):
+        print("true"); sys.exit(0)
+    is_tag = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{ref}"],
+        capture_output=True,
+    ).returncode == 0
+    is_branch = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{ref}"],
+        capture_output=True,
+    ).returncode == 0
+    print("true" if (is_tag and not is_branch) else "false")
+    sys.exit(0)
+print("false")
+PYEOF
+)
+
 # --- Branch-Guard: block push on main/master ---
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
@@ -107,7 +149,7 @@ if [ -z "$MAIN_BRANCH" ] && [ -n "$CONFIG_FILE" ]; then
 fi
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
 
-if [ "$CURRENT_BRANCH" = "$MAIN_BRANCH" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+if [ "$IS_TAG_ONLY_PUSH" != "true" ] && { [ "$CURRENT_BRANCH" = "$MAIN_BRANCH" ] || [ "$CURRENT_BRANCH" = "master" ]; }; then
   echo "Branch-Guard: Push blocked — you are on '$CURRENT_BRANCH'."
   echo "Create a feature branch first: git checkout -b feat/<topic>"
   echo "Direct pushes to $MAIN_BRANCH are not allowed by DoD policy."

--- a/hooks/1-generic/dod-push-check.sh
+++ b/hooks/1-generic/dod-push-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hook: dod-push-check
-# version: 1.3.0
+# version: 1.4.0
 # event: PreToolUse
 # matcher: Bash
 # provider: Claude
@@ -96,6 +96,48 @@ print(val)
 PYEOF
 }
 
+# --- Tag-only push detection ---
+# A tag push (`git push origin v1.2.3`, `git push origin --tags`,
+# `git push origin tag v1.2.3`, `git push origin refs/tags/v1.2.3`) does not
+# touch any branch ref — it cannot add commits to main/master, which is the
+# entire premise the Branch-Guard below exists to prevent. Without this
+# check, cutting a release while sitting on main (the normal place to be
+# right after a release PR merges) was blocked identically to an actual
+# direct push of main's commit history, even though the two are unrelated
+# in risk. Not a full shell parser (matches this repo's other hooks'
+# documented approach) — covers the realistic `git push <remote> <ref>` /
+# `--tags` / `tag <name>` forms; anything else (bare `git push`, `git push
+# origin`, an explicit branch ref) still falls through to the branch check.
+IS_TAG_ONLY_PUSH=$(python3 - "$COMMAND" <<'PYEOF' 2>/dev/null
+import subprocess, sys
+tokens = sys.argv[1].split()
+try:
+    rest = tokens[tokens.index("push") + 1:]
+except ValueError:
+    print("false"); sys.exit(0)
+if "--tags" in rest:
+    print("true"); sys.exit(0)
+non_flags = [t for t in rest if not t.startswith("-")]
+if len(non_flags) >= 3 and non_flags[1] == "tag":
+    print("true"); sys.exit(0)
+if len(non_flags) == 2:
+    ref = non_flags[1]
+    if ref.startswith("refs/tags/"):
+        print("true"); sys.exit(0)
+    is_tag = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{ref}"],
+        capture_output=True,
+    ).returncode == 0
+    is_branch = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{ref}"],
+        capture_output=True,
+    ).returncode == 0
+    print("true" if (is_tag and not is_branch) else "false")
+    sys.exit(0)
+print("false")
+PYEOF
+)
+
 # --- Branch-Guard: block push on main/master ---
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
@@ -107,7 +149,7 @@ if [ -z "$MAIN_BRANCH" ] && [ -n "$CONFIG_FILE" ]; then
 fi
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
 
-if [ "$CURRENT_BRANCH" = "$MAIN_BRANCH" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+if [ "$IS_TAG_ONLY_PUSH" != "true" ] && { [ "$CURRENT_BRANCH" = "$MAIN_BRANCH" ] || [ "$CURRENT_BRANCH" = "master" ]; }; then
   echo "Branch-Guard: Push blocked — you are on '$CURRENT_BRANCH'."
   echo "Create a feature branch first: git checkout -b feat/<topic>"
   echo "Direct pushes to $MAIN_BRANCH are not allowed by DoD policy."

--- a/tests/test_dod_push_check_hook.py
+++ b/tests/test_dod_push_check_hook.py
@@ -1,0 +1,120 @@
+"""Regression tests for hooks/1-generic/dod-push-check.sh.
+
+Background: the hook's Branch-Guard blocks any `git push` while the current
+branch is main/master, to prevent accidental direct pushes bypassing PR
+review. It used to apply that check uniformly, so a release's `git push
+origin vX.Y.Z` tag push -- which touches no branch ref at all, and is
+normally run right after the release PR merge while sitting on main -- was
+blocked identically to an actual direct push of main's commit history. This
+adds a tag-only-push detection (`--tags`, `push <remote> tag <name>`,
+`push <remote> <ref>` where <ref> resolves to an existing tag and not an
+existing branch) that skips the Branch-Guard for genuine tag pushes while
+leaving it fully in effect for anything that could touch a branch.
+
+This hook is a bash script outside the Python pytest suite, so nothing else
+guards against regressions here. These tests invoke the hook as a real
+subprocess against an isolated temp git repo (branch renamed to "main",
+with one commit and one tag) and assert on its exit code.
+
+Run: python -m pytest tests/test_dod_push_check_hook.py -v
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HOOK_PATH = _REPO_ROOT / "hooks" / "1-generic" / "dod-push-check.sh"
+
+_BASH = shutil.which("bash") or "bash"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform not in ("win32", "linux", "darwin"), reason="requires bash"
+)
+
+
+def _run_hook(cwd: Path, command: str) -> subprocess.CompletedProcess:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": cwd.as_posix(),
+    }
+    return subprocess.run(
+        [_BASH, str(_HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+
+
+@pytest.fixture
+def repo_on_main(tmp_path):
+    """An isolated git repo, on a branch literally named 'main', with a
+    commit and a tag 'v1.0.0' pointing at it -- and a branch 'other-branch'
+    pointing at the same commit, so tag-vs-branch name resolution is
+    exercised against real refs rather than assumed to work."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True
+    )
+    run("init", "-q")
+    run("config", "user.email", "test@example.com")
+    run("config", "user.name", "Test")
+    run("checkout", "-q", "-b", "main")
+    (repo / "f.txt").write_text("x", encoding="utf-8")
+    run("add", "f.txt")
+    run("commit", "-q", "-m", "init")
+    run("tag", "-a", "v1.0.0", "-m", "v1.0.0")
+    run("branch", "other-branch")
+    return repo
+
+
+BLOCKED_ON_MAIN = [
+    "git push",
+    "git push origin",
+    "git push origin main",
+    "git push origin HEAD",
+    # a branch ref, not a tag -- must NOT be misclassified as a tag push
+    "git push origin other-branch",
+]
+
+ALLOWED_TAG_PUSHES = [
+    "git push origin v1.0.0",
+    "git push -u origin v1.0.0",
+    "git push origin refs/tags/v1.0.0",
+    "git push origin --tags",
+    "git push --tags origin",
+    "git push origin tag v1.0.0",
+]
+
+
+@pytest.mark.parametrize("command", BLOCKED_ON_MAIN)
+def test_non_tag_push_still_blocked_on_main(repo_on_main, command):
+    result = _run_hook(repo_on_main, command)
+    assert result.returncode == 2, (
+        f"command={command!r} should still be blocked on main\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("command", ALLOWED_TAG_PUSHES)
+def test_tag_only_push_allowed_on_main(repo_on_main, command):
+    result = _run_hook(repo_on_main, command)
+    assert result.returncode == 0, (
+        f"command={command!r} is a tag-only push and must not be blocked "
+        f"by the Branch-Guard\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_push_of_nonexistent_ref_falls_back_to_branch_guard(repo_on_main):
+    # A ref that resolves to neither a tag nor a branch (typo, or a ref
+    # that doesn't exist locally yet) must not be treated as tag-safe --
+    # fail closed, keep the Branch-Guard active.
+    result = _run_hook(repo_on_main, "git push origin does-not-exist")
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary
- Branch-Guard was blocking ALL `git push` on main/master without inspecting push type
- Tag pushes (`git push origin vX.Y.Z`, `--tags`, etc.) don't touch branch refs but were blocked identically to direct main-branch pushes
- Blocked normal workflow: cutting release tag right after release PR merge (typical time to be on main)

## Changes
- Added Python-based tag-vs-branch ref classifier to `dod-push-check.sh`
- Recognizes realistic tag-push command forms, skips guard only for those
- Fails closed: unknown refs keep guard active (safe default)
- New test suite: 12 isolated temp-repo test cases (tag pushes pass, branch pushes blocked)

## Test plan
- [x] All 12 new regression tests pass (isolated temp git repos)
- [x] Full test suite: 443 passed, 1 skipped
- [x] `sync.py` regeneration: only expected generated-hook-copy diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)