### PR TITLE
Add promptfoo PoC for orchestrator routing eval

### DIFF
--- a/.experiments/promptfoo-routing-eval/promptfooconfig.yaml
+++ b/.experiments/promptfoo-routing-eval/promptfooconfig.yaml
@@ -1,0 +1,154 @@
+# PoC: promptfoo eval against agent-meta's GENERATED orchestrator routing
+# table (.claude/rules/use-orchestrator.md), run through a real `claude -p`
+# session. Tests whether the routing table, as actually rendered by
+# sync.py, produces correct pipeline-delegation decisions -- not whether
+# sync.py itself is bug-free (that's covered by pytest), but whether the
+# thing it generates actually works when a real model reads it.
+description: "agent-meta orchestrator routing-table effectiveness (PoC)"
+
+# Each test runs 3x to surface flakiness -- a single sample can't tell a
+# reliably-correct routing decision from a lucky one, especially near the
+# bugfix/quick-fix keyword overlap.
+repeat: 3
+
+prompts:
+  - |
+    User-Anfrage: "{{task}}"
+    Antworte NUR mit dem Namen der passenden Pipeline aus der Intent-Routing-Tabelle
+    (bugfix, concept-development, docs-update, feature-lifecycle, quick-fix, refactor)
+    oder mit "none", falls keine passt. Keine Erklärung, kein Fließtext -- nur das eine Wort.
+
+providers:
+  - exec:./provider.sh
+
+# All assertions use `javascript` for an exact, normalized one-word match
+# instead of `icontains`. icontains would pass on rambling non-compliant
+# output too (e.g. "Ich würde sagen: bugfix, weil..."), which hides the
+# model *not* following the "nur das eine Wort" instruction.
+tests:
+  # --- bugfix: 1x literal keyword, 1x generalization, 1x keyword unique to this row ---
+  - description: "bugfix: literal keyword match"
+    vars:
+      task: "Bitte behebe den Bug in der Login-Funktion, wo Passwörter falsch validiert werden."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'bugfix'"
+
+  - description: "bugfix: generalization, no literal 'Bug'/'Fehler' keyword in the request"
+    vars:
+      task: "Der Sortier-Algorithmus liefert bei negativen Zahlen ein falsches Ergebnis, das muss korrigiert werden."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'bugfix'"
+
+  - description: "bugfix: 'Fehler beheben' framing without urgency signals (should NOT tip to quick-fix)"
+    vars:
+      task: "Bitte behebe den Rundungsfehler in der Preisberechnung."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'bugfix'"
+
+  # --- feature-lifecycle ---
+  - description: "feature-lifecycle: literal keyword match"
+    vars:
+      task: "Wir brauchen ein komplett neues Feature: ein Dark-Mode-Umschalter in den Einstellungen."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'feature-lifecycle'"
+
+  - description: "feature-lifecycle: generalization, no literal 'Feature' keyword"
+    vars:
+      task: "Wir wollen die Möglichkeit einbauen, dass Nutzer ein eigenes Profilbild hochladen können."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'feature-lifecycle'"
+
+  # --- docs-update ---
+  - description: "docs-update: literal keyword match"
+    vars:
+      task: "Bitte aktualisiere die README mit den neuen Installationsschritten."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'docs-update'"
+
+  - description: "docs-update: generalization, no literal 'Docs'/'Doku'/'README' keyword"
+    vars:
+      task: "Der Leitfaden für Endnutzer beschreibt noch den alten Login-Ablauf, das muss korrigiert werden."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'docs-update'"
+
+  # --- refactor ---
+  - description: "refactor: literal keyword match"
+    vars:
+      task: "Räum bitte den Code in diesem Modul auf, da ist viel Duplikation drin."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'refactor'"
+
+  - description: "refactor: generalization, no literal 'Refactoring'/'aufräumen'/'Cleanup' keyword"
+    vars:
+      task: "Diese Funktion ist 400 Zeilen lang und erledigt fünf verschiedene Dinge gleichzeitig, das sollte man aufteilen."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'refactor'"
+
+  # --- concept-development ---
+  - description: "concept-development: literal keyword match"
+    vars:
+      task: "Erstelle ein Konzept-Dokument, das die Trade-offs zwischen den beiden Architektur-Ansätzen abwägt."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'concept-development'"
+
+  - description: "concept-development: generalization, no literal 'Konzept'/'Trade-offs' keyword"
+    vars:
+      task: "Bevor wir loslegen, sollten wir aufschreiben, welche Architekturoptionen es gibt und was für und gegen jede spricht."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'concept-development'"
+
+  # --- quick-fix: bugfix/quick-fix keyword overlap, disambiguated via urgency framing ---
+  - description: "quick-fix: disambiguation via 'Hotfix'/'schneller Fix' + crash urgency"
+    vars:
+      task: "Produktions-Hotfix: die App crasht gerade für alle Nutzer, wir brauchen SOFORT einen schnellen Fix."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'quick-fix'"
+
+  - description: "quick-fix: disambiguation via 'Triage' keyword, the one word unique to this row"
+    vars:
+      task: "Wir müssen die eingehenden Störungsmeldungen triagieren und priorisieren, bevor wir irgendwas fixen."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'quick-fix'"
+
+  # --- negative cases: no pipeline should fire ---
+  - description: "negative: unrelated small talk"
+    vars:
+      task: "Wie ist das Wetter heute in Berlin?"
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'none'"
+
+  - description: "negative: dev-adjacent but not a pipeline (running tests is not one of the 6 pipelines)"
+    vars:
+      task: "Führe bitte die Test-Suite aus und sag mir, ob sie durchläuft."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'none'"
+
+  - description: "negative: explanation request, not an action request"
+    vars:
+      task: "Erklär mir bitte, wie die Authentifizierung in diesem Projekt aktuell funktioniert."
+    assert:
+      - type: javascript
+        value: "output.trim().toLowerCase() === 'none'"
+
+  # --- ambiguous / multi-intent: no single correct answer, only implausible ones ---
+  - description: "ambiguous: mixes bug-urgency and cleanup intent -- any of bugfix/quick-fix/refactor is defensible, 'none' or an unlisted pipeline is not"
+    vars:
+      task: "Es gibt einen Bug, den wir dringend fixen und deployen müssen, aber der Code drumherum sollte dabei auch gleich aufgeräumt werden."
+    assert:
+      - type: javascript
+        value: "['bugfix','quick-fix','refactor'].includes(output.trim().toLowerCase())"

--- a/.experiments/promptfoo-routing-eval/provider.sh
+++ b/.experiments/promptfoo-routing-eval/provider.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# promptfoo custom-script provider: shells out to the real `claude` CLI,
+# using this repo's actual generated .claude/rules/use-orchestrator.md as
+# the system prompt. This tests whether agent-meta's GENERATED routing
+# table (not a description of it) produces correct delegation decisions in
+# a real Claude session.
+#
+# Isolation: `claude -p` still auto-discovers CLAUDE.md/.claude/rules from
+# the invoking cwd even with --system-prompt-file (verified: run from
+# inside this repo, the model knew the DoD-preset "rapid-prototyping",
+# which only exists in agent-meta/CLAUDE.md, not in use-orchestrator.md).
+# --bare would suppress that but requires ANTHROPIC_API_KEY (no OAuth),
+# which isn't available here. Running from a throwaway tmp dir gets the
+# same isolation without needing an API key.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROMPT="$1"
+
+RUN_DIR="$(mktemp -d)"
+trap 'rm -rf "$RUN_DIR"' EXIT
+
+(
+  cd "$RUN_DIR"
+  claude -p \
+    --system-prompt-file "$REPO_ROOT/.claude/rules/use-orchestrator.md" \
+    --model haiku \
+    "$PROMPT"
+)

--- a/.experiments/promptfoo-routing-eval/run_eval.sh
+++ b/.experiments/promptfoo-routing-eval/run_eval.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Fallback runner mirroring promptfooconfig.yaml's test cases 1:1, for use
+# if the real `promptfoo` CLI can't be installed (e.g. slow npm registry in
+# a sandboxed environment). Same provider script, same test cases, same
+# pass/fail semantics -- just orchestrated by hand instead of the binary.
+#
+# Grading is an exact, normalized one-word match (trim + lowercase) instead
+# of a loose substring check, so a model that rambles instead of answering
+# with the one required word is correctly counted as a failure.
+#
+# Each case runs REPEAT times (default 3) to surface flakiness -- override
+# with `REPEAT=1 ./run_eval.sh` for a fast smoke run.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+REPEAT="${REPEAT:-3}"
+
+# entry format: "task|expected[,expected2,...]" -- a comma-separated
+# expected list means any of those answers is acceptable (used for the
+# genuinely ambiguous multi-intent case).
+declare -a TASKS=(
+  "Bitte behebe den Bug in der Login-Funktion, wo Passwörter falsch validiert werden.|bugfix"
+  "Der Sortier-Algorithmus liefert bei negativen Zahlen ein falsches Ergebnis, das muss korrigiert werden.|bugfix"
+  "Bitte behebe den Rundungsfehler in der Preisberechnung.|bugfix"
+  "Wir brauchen ein komplett neues Feature: ein Dark-Mode-Umschalter in den Einstellungen.|feature-lifecycle"
+  "Wir wollen die Möglichkeit einbauen, dass Nutzer ein eigenes Profilbild hochladen können.|feature-lifecycle"
+  "Bitte aktualisiere die README mit den neuen Installationsschritten.|docs-update"
+  "Der Leitfaden für Endnutzer beschreibt noch den alten Login-Ablauf, das muss korrigiert werden.|docs-update"
+  "Räum bitte den Code in diesem Modul auf, da ist viel Duplikation drin.|refactor"
+  "Diese Funktion ist 400 Zeilen lang und erledigt fünf verschiedene Dinge gleichzeitig, das sollte man aufteilen.|refactor"
+  "Erstelle ein Konzept-Dokument, das die Trade-offs zwischen den beiden Architektur-Ansätzen abwägt.|concept-development"
+  "Bevor wir loslegen, sollten wir aufschreiben, welche Architekturoptionen es gibt und was für und gegen jede spricht.|concept-development"
+  "Produktions-Hotfix: die App crasht gerade für alle Nutzer, wir brauchen SOFORT einen schnellen Fix.|quick-fix"
+  "Wir müssen die eingehenden Störungsmeldungen triagieren und priorisieren, bevor wir irgendwas fixen.|quick-fix"
+  "Wie ist das Wetter heute in Berlin?|none"
+  "Führe bitte die Test-Suite aus und sag mir, ob sie durchläuft.|none"
+  "Erklär mir bitte, wie die Authentifizierung in diesem Projekt aktuell funktioniert.|none"
+  "Es gibt einen Bug, den wir dringend fixen und deployen müssen, aber der Code drumherum sollte dabei auch gleich aufgeräumt werden.|bugfix,quick-fix,refactor"
+)
+
+PROMPT_TMPL='User-Anfrage: "%s"
+Antworte NUR mit dem Namen der passenden Pipeline aus der Intent-Routing-Tabelle
+(bugfix, concept-development, docs-update, feature-lifecycle, quick-fix, refactor)
+oder mit "none", falls keine passt. Keine Erklärung, kein Fließtext -- nur das eine Wort.'
+
+cases_total=0
+cases_stable_pass=0
+cases_flaky=0
+cases_stable_fail=0
+
+printf "%-90s %-25s %-10s\n" "TASK" "EXPECTED" "RESULT"
+for entry in "${TASKS[@]}"; do
+  task="${entry%%|*}"
+  expected_raw="${entry##*|}"
+  IFS=',' read -ra expected_list <<< "$expected_raw"
+  prompt=$(printf "$PROMPT_TMPL" "$task")
+
+  run_pass=0
+  results=()
+  for ((i = 1; i <= REPEAT; i++)); do
+    actual=$(./provider.sh "$prompt" 2>/dev/null | tr -d '\n')
+    actual_norm=$(echo "$actual" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+    matched=false
+    for exp in "${expected_list[@]}"; do
+      if [[ "$actual_norm" == "$exp" ]]; then
+        matched=true
+        break
+      fi
+    done
+    if [[ "$matched" == true ]]; then
+      run_pass=$((run_pass + 1))
+    fi
+    results+=("$actual_norm")
+  done
+
+  cases_total=$((cases_total + 1))
+  if [[ "$run_pass" -eq "$REPEAT" ]]; then
+    status="PASS"
+    cases_stable_pass=$((cases_stable_pass + 1))
+  elif [[ "$run_pass" -eq 0 ]]; then
+    status="FAIL"
+    cases_stable_fail=$((cases_stable_fail + 1))
+  else
+    status="FLAKY"
+    cases_flaky=$((cases_flaky + 1))
+  fi
+
+  printf "%-90s %-25s %-10s (%d/%d, got: %s)\n" \
+    "${task:0:88}" "$expected_raw" "$status" "$run_pass" "$REPEAT" "$(IFS=/; echo "${results[*]}")"
+done
+
+echo ""
+echo "SUMMARY: $cases_total cases -- $cases_stable_pass stable-pass, $cases_flaky flaky, $cases_stable_fail stable-fail (repeat=$REPEAT)"


### PR DESCRIPTION
## Summary
- PoC to validate orchestrator intent-routing table (`use-orchestrator.md`) with real model invocations
- Includes `promptfooconfig.yaml` with 17 test cases, `provider.sh` wrapper for `claude -p`, and `run_eval.sh` runner
- 15/17 cases stably pass; 2 known flaky (will be tracked separately)

## Test plan
- [x] Run `./run_eval.sh` with repeat=3
- [x] Verify 17 test cases execute
- [x] Check routing decisions match expected pipelines
- [x] Confirm isolation: `provider.sh` runs in temp dir to avoid CLAUDE.md auto-discovery