### PR TITLE
feat: add approval gates to quality pipeline stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+- Approval gates for quality pipeline stages (`scripts/lib/pipelines.py`): new optional
+  `approval_default` (pipeline-level) and `requires_approval` (stage-level, overrides the
+  pipeline default) fields in `config/role-defaults.yaml` / `.meta-config/project.yaml`
+  overrides. When effectively `true` for a stage, the generated pipeline block gets an
+  explicit "wait for user confirmation before this stage starts" instruction, provider-
+  independent, purely instructive like the rest of the pipeline notation. Neither field
+  set means `false` — no shipped base pipeline sets them, so existing generated output is
+  unchanged. Lets projects require sign-off on a planner-produced plan (or any other stage)
+  before it drives execution, e.g. via a `feature-lifecycle` `implement`-stage override.
+  See `docs/guides/quality-pipelines.md#approval-gates-abnahme`.
+
 ## [0.96.0] — 2026-08-15
 
 ### Added

--- a/docs/guides/quality-pipelines.md
+++ b/docs/guides/quality-pipelines.md
@@ -51,6 +51,36 @@ Jeder Provider bekommt angepasste Notation:
 | Gemini | `define_subagent` + `invoke_subagent` | `invoke_subagent("developer", "...")` |
 | Continue | Sequentieller Text | `1. @developer ...` |
 
+## Approval Gates (Abnahme)
+
+Jede Stage kann optional eine explizite Nutzer-Abnahme erzwingen, bevor sie startet:
+
+```yaml
+quality_pipelines:
+  feature-lifecycle:
+    approval_default: false   # Pipeline-weiter Default (optional)
+    stages:
+    - id: implement
+      mode: plan-driven
+      requires_approval: true # Override pro Stage (optional)
+      ...
+```
+
+- **Stage-Ebene** (`requires_approval`) überschreibt **Pipeline-Ebene** (`approval_default`).
+- Fehlen beide Felder → `false` (Default, abwärtskompatibel — keine bestehende Pipeline setzt sie).
+- Gilt für jeden Stage-Modus, nicht nur `plan-driven` — z.B. auch vor `commit`.
+- Rendering: eine `⏸`-Zeile vor dem normalen Stage-Block, provider-unabhängig (rein instruktiv, kein Runtime-Enforcement — wie bei `Execution mode`).
+
+Beispiel für den Planner-Anwendungsfall (Plan muss vor Ausführung abgenommen werden), als Projekt-Override in `.meta-config/project.yaml`:
+```yaml
+quality-pipelines:
+  overrides:
+    feature-lifecycle:
+      stages:
+        implement:
+          requires_approval: true
+```
+
 ## SE-Kaskade als Pipeline
 
 Die Systems-Engineering-Kaskade ist als `se-cascade` Pipeline definiert:

--- a/scripts/lib/pipelines.py
+++ b/scripts/lib/pipelines.py
@@ -24,6 +24,16 @@ def _pipeline_active_for_provider(pipeline: dict, provider: str) -> bool:
     return provider in providers_cfg.get("include", [])
 
 
+def _stage_requires_approval(stage: dict, pipeline: dict) -> bool:
+    """Return whether `stage` needs explicit user approval before it runs.
+
+    Stage-level `requires_approval` overrides the pipeline-level
+    `approval_default`. Neither field set means `False` — backward
+    compatible with pipelines that predate this mechanism.
+    """
+    return bool(stage.get("requires_approval", pipeline.get("approval_default", False)))
+
+
 def load_quality_pipelines(agent_meta_root: str) -> dict:
     """Load quality_pipelines from config/role-defaults.yaml."""
     try:
@@ -177,9 +187,23 @@ def validate_pipelines(pipelines: dict, available_roles: list, roles_config: dic
                             f"a known provider ({', '.join(KNOWN_PROVIDERS)})"
                         )
 
+        approval_default = pipeline.get("approval_default")
+        if approval_default is not None and not isinstance(approval_default, bool):
+            errors.append(
+                f"Pipeline '{name}': approval_default must be a boolean, got "
+                f"{type(approval_default).__name__}"
+            )
+
         errors.extend(_validate_pipeline_composition(pipelines, name, pipeline))
 
         for stage in stages:
+            requires_approval = stage.get("requires_approval")
+            if requires_approval is not None and not isinstance(requires_approval, bool):
+                errors.append(
+                    f"Pipeline '{name}': stage '{stage.get('id')}' requires_approval "
+                    f"must be a boolean, got {type(requires_approval).__name__}"
+                )
+
             agent = stage.get("agent")
             if agent and agent not in available_roles:
                 if stage.get("optional"):
@@ -631,6 +655,12 @@ def _generate_pipeline_block(
         agent = stage.get("agent", "")
         task = stage.get("task", "")
         stage_id = stage.get("id", "")
+
+        if _stage_requires_approval(stage, pipeline):
+            lines.append(
+                f"⏸ Abnahme erforderlich vor Stage '{stage_id}' — warte auf "
+                f"explizite Nutzerbestätigung, bevor {agent or 'diese Stage'} startet."
+            )
 
         if mode == "sequential":
             seq_idx += 1

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -578,6 +578,105 @@ def test_sync_agents_passes_real_dod_resolved_to_inject_pipeline_blocks(monkeypa
     assert "resolve_dod(" in source
 
 
+def test_generate_pipeline_block_no_approval_gate_by_default():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {"id": "implement", "agent": "developer", "task": "Feature bauen", "mode": "sequential"},
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    assert "Abnahme erforderlich" not in block
+
+
+def test_generate_pipeline_block_stage_requires_approval_renders_gate():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "stages": [
+            {
+                "id": "implement",
+                "agent": "developer",
+                "task": "Feature bauen",
+                "mode": "sequential",
+                "requires_approval": True,
+            },
+        ]
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    assert "Abnahme erforderlich vor Stage 'implement'" in block
+    # Gate must precede the stage's own rendered line.
+    assert block.index("Abnahme erforderlich") < block.index("Feature bauen")
+
+
+def test_generate_pipeline_block_pipeline_approval_default_applies_to_all_stages():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "approval_default": True,
+        "stages": [
+            {"id": "implement", "agent": "developer", "task": "Feature bauen", "mode": "sequential"},
+            {"id": "commit", "agent": "git", "task": "Commit + PR", "mode": "sequential"},
+        ],
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    assert "Abnahme erforderlich vor Stage 'implement'" in block
+    assert "Abnahme erforderlich vor Stage 'commit'" in block
+
+
+def test_generate_pipeline_block_stage_requires_approval_overrides_pipeline_default():
+    from scripts.lib.pipelines import _generate_pipeline_block
+
+    pipeline = {
+        "approval_default": True,
+        "stages": [
+            {
+                "id": "implement",
+                "agent": "developer",
+                "task": "Feature bauen",
+                "mode": "sequential",
+                "requires_approval": False,
+            },
+        ],
+    }
+    block = _generate_pipeline_block(pipeline, "Opencode")
+    assert "Abnahme erforderlich" not in block
+
+
+def test_validate_pipelines_rejects_non_bool_approval_default():
+    pipelines = {"p1": {"approval_default": "yes", "stages": []}}
+    errors = validate_pipelines(pipelines, available_roles=[])
+    assert any("approval_default" in e and "boolean" in e for e in errors)
+
+
+def test_validate_pipelines_rejects_non_bool_requires_approval():
+    pipelines = {
+        "p1": {
+            "stages": [
+                {"id": "implement", "agent": "developer", "task": "t", "mode": "sequential",
+                 "requires_approval": "yes"}
+            ]
+        }
+    }
+    errors = validate_pipelines(pipelines, available_roles=["developer"])
+    assert any("requires_approval" in e and "boolean" in e for e in errors)
+
+
+def test_role_defaults_pipelines_render_no_approval_gate_by_default():
+    # Backward-compat guard: no shipped base pipeline sets approval_default/
+    # requires_approval, so no generated block may contain a gate line.
+    from scripts.lib.pipelines import build_pipeline_variables, load_quality_pipelines
+
+    pipelines = load_quality_pipelines(".")
+    variables = build_pipeline_variables(pipelines, active_dod={})
+    for var_name, value in variables.items():
+        if not var_name.endswith("_PROVIDER_BLOCKS"):
+            continue
+        for provider, block in value.items():
+            assert "Abnahme erforderlich" not in block, f"{var_name}/{provider}"
+
+
 def test_feature_lifecycle_pipeline_definition_is_valid():
     import yaml
     from scripts.lib.pipelines import load_quality_pipelines, validate_pipelines


### PR DESCRIPTION
## Summary
Add optional approval gates to quality pipeline stages via new `approval_default` (pipeline-level) and `requires_approval` (stage-level override) configuration fields. Enables plan-phase walkthrough approval patterns while maintaining full backward compatibility.

## Test Plan
- [x] 43/43 pipeline tests pass
- [x] Backward compatibility regression tests included
- [x] sync.py --validate clean
- [x] Full suite: 456 passed (27 pre-existing unrelated browser-test errors from pytest-socket sandbox)

🤖 Generated with Claude Code