### PR TITLE
feat: reversible model-override-all provider blast

### DIFF
--- a/.claude/skills/model-override-all/SKILL.md
+++ b/.claude/skills/model-override-all/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: model-override-all
+description: "Use when you want to blast EVERY active agent of a provider onto one model (discount promos / usage caps) — covers the reversible project.yaml model-override-all key, sync resolution priority, and how to toggle it."
+---
+
+# agent-meta — Model Override-All (reversible promo blast)
+
+Blast **all** active agents of a single provider onto one concrete model in one
+move — e.g. to exploit provider discount promotions or usage caps.
+
+## Why this (and not per-role `model-overrides`)
+
+`model-override-all` is a single, centralized, **reversible** switch:
+
+- Set `model-override-all[provider] = <model>` → sync resolves *every* role of
+  that provider to that model, overriding per-role / tier / preset / alias logic.
+- Remove the provider key (or the whole block) → the previous per-agent settings
+  resume automatically. No per-role cleanup required.
+
+Per-role `model-overrides` is the wrong tool here: it is not reversible in one
+step and must be edited role-by-role.
+
+## Resolution priority (scripts/lib/roles.py)
+
+`model-override-all[provider]` wins over everything else — it is checked first,
+before `model-overrides`, `tier-overrides`, role-defaults, presets and aliases.
+Value is resolved through `_resolve_tier_to_model`, so a tier (`nano`/`fast`/
+`balanced`/`powerful`/`max`), a legacy alias (`haiku`/`sonnet`/`opus`) or a full
+model ID (`claude-sonnet-4-6`) are all accepted.
+
+## project.yaml shape
+
+```yaml
+model-override-all:
+  Claude: claude-sonnet-4-6
+  Gemini: gemini-2.5-pro
+```
+
+Schema: `config/project-config.schema.json` → `model-override-all`
+(object, provider name → string). Allowed as a project section in
+`scripts/admin-server.py` (`_write_project_section` whitelist).
+
+## Toggle workflow
+
+1. Read current state from `.meta-config/project.yaml` (`model-override-all`).
+2. Enable: merge the provider key into the block.
+3. Disable: delete the provider key (or the entire block).
+4. **Always re-run `sync.py`** so generated agents pick up the change:
+   ```bash
+   py scripts/sync.py --config .meta-config/project.yaml
+   ```
+
+## Admin-UI shortcut
+
+*Project → Model Overrides → "Override All"* bar:
+- Provider dropdown + model input + **"Alle Rollen überschreiben"** → writes
+  `model-override-all[provider] = model`.
+- **"Zurücksetzen"** → removes that provider key (reversible).
+
+## Caveats
+
+- Only affects providers with model tiers (same gate as the rest of the
+  model-override UI). Mammouth / Continue are registry-only and excluded.
+- Reversible by design, but a blast overrides *all* agent intent for that
+  provider until cleared — confirm before enabling on a shared project.
+- Branch policy still applies: changing project.yaml + re-syncing propagates to
+  all pinned consumer projects → use a feature branch.

--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -111,6 +111,41 @@ py {{AGENT_META_REL_PATH}}scripts/sync.py --config .meta-config/project.yaml --c
 py {{AGENT_META_REL_PATH}}scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
 
+## 8b. Model Override-All (reversible promo blast)
+
+Blast **every** active agent of one provider onto a single model — e.g. to
+exploit provider discount promos or usage caps. This is the preferred, reversible
+mechanism (do NOT hand-edit per-role `model-overrides` for this).
+
+Mechanism: project.yaml key `model-override-all` (provider → tier/alias/model-ID).
+When a provider key is set, `sync.py` resolves ALL roles of that provider to that
+model, overriding per-role/tier/preset resolution. Remove the key (or the whole
+block) and the previous per-agent settings resume automatically — nothing else to
+clean up.
+
+```yaml
+# .meta-config/project.yaml
+model-override-all:
+  Claude: claude-sonnet-4-6      # blast all Claude agents onto this model
+  Gemini: gemini-2.5-pro
+```
+
+Toggle workflow:
+1. Read current state: `model-override-all` in `.meta-config/project.yaml`.
+2. To enable: set/merge the provider key, then re-sync.
+3. To disable: delete the provider key (or the entire `model-override-all` block), then re-sync.
+4. Always re-run `sync.py` after changing the key so generated agents pick it up.
+
+```bash
+# Enable (merge, keep other providers)
+py {{AGENT_META_REL_PATH}}scripts/sync.py --config .meta-config/project.yaml
+# Disable: remove the key from project.yaml, then re-sync
+```
+
+Admin-UI shortcut: *Project → Model Overrides → "Override All"* bar writes the
+key directly (with a "Zurücksetzen" button to clear it). See skill
+`.claude/skills/model-override-all/SKILL.md`.
+
 ## 9. External skills
 
 Full lifecycle: `rules/2-platform/agent-meta-sync-interface.md` (--add-skill flag).

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -300,6 +300,14 @@
         ]
       }
     },
+    "model-override-all": {
+      "type": "object",
+      "description": "Global per-provider model blast. When a provider key is set (non-empty), EVERY active agent/role of that provider resolves to this single model during sync.py — overriding all per-role, tier, preset and alias resolution. Fully reversible: remove the key (or the whole block) and the previous per-agent settings apply again automatically. Value may be a tier (nano/fast/balanced/powerful/max), a legacy alias (haiku/sonnet/opus) or a full model ID (e.g. claude-sonnet-4-6).",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Tier, alias or full model ID to blast onto every role of this provider."
+      }
+    },
     "model-overrides": {
       "type": "object",
       "description": "Override the default model tier or model ID per role. Two forms supported: (1) flat role→tier for Claude-only legacy use; (2) provider-keyed blocks for multi-provider control. Provider-specific blocks take precedence over flat values for that provider.",

--- a/docs/ui/admin-ui.html
+++ b/docs/ui/admin-ui.html
@@ -6439,6 +6439,53 @@ async function viewProjectModelOverrides() {
   }
   wrap.appendChild(datalist);
 
+  // --- Override-All bar: reversible global per-provider model blast ---
+  // Writes project.yaml `model-override-all[provider] = model`. sync.py then
+  // resolves EVERY active agent/role of that provider to this single model.
+  // Fully reversible: clearing the provider key makes sync fall back to the
+  // previous per-agent settings automatically — nothing else to clean up.
+  const oaBar = el("div", { class: "btn-row", style: "margin:14px 0;padding:12px;background:var(--panel,#1c2230);border:1px solid var(--border,#2c3344);border-radius:8px;" });
+  const oaProv = el("select");
+  oaProv.appendChild(el("option", { value: "" }, ["Provider wählen…"]));
+  for (const tp of tierProviders) {
+    oaProv.appendChild(el("option", { value: tp.name }, [tp.display_name || tp.name]));
+  }
+  const oaModel = el("input", { type: "text", list: "global-model-list", placeholder: "Modell-ID (z.B. claude-sonnet-4-6)", style: "min-width:240px;" });
+  const oaBtn = el("button", { class: "btn btn-warning", title: "Setzt model-override-all[provider]=model → alle Agenten dieses Providers brennen auf dieses Modell (reversibel)" }, ["Alle Rollen überschreiben"]);
+  const oaClear = el("button", { class: "btn", title: "Entfernt den Provider-Key aus model-override-all → Normal-Auflösung greift wieder" }, ["Zurücksetzen"]);
+  const oaStatus = el("span", { class: "muted", style: "margin-left:8px;" }, []);
+  oaBtn.addEventListener("click", async () => {
+    const prov = oaProv.value;
+    const model = oaModel.value.trim();
+    if (!prov) { oaStatus.textContent = "Override-All: zuerst einen Provider wählen."; return; }
+    if (!model) { oaStatus.textContent = "Override-All: zuerst ein Modell eingeben."; return; }
+    const cur = (data["model-override-all"] && typeof data["model-override-all"] === "object") ? { ...data["model-override-all"] } : {};
+    cur[prov] = model;
+    try {
+      await saveProjectSection("model-override-all", cur, status);
+      oaStatus.textContent = `${prov} → ${model} aktiv. Reversibel: Zurücksetzen oder Key löschen.`;
+      if (oaProv.value === prov) oaModel.value = model;
+    } catch { oaStatus.textContent = "Fehler beim Speichern von model-override-all."; }
+  });
+  oaClear.addEventListener("click", async () => {
+    const prov = oaProv.value;
+    if (!prov) { oaStatus.textContent = "Zurücksetzen: zuerst einen Provider wählen."; return; }
+    const cur = (data["model-override-all"] && typeof data["model-override-all"] === "object") ? { ...data["model-override-all"] } : {};
+    delete cur[prov];
+    try {
+      await saveProjectSection("model-override-all", cur, status);
+      oaStatus.textContent = `${prov} entfernt → Normal-Auflösung greift wieder.`;
+      oaModel.value = "";
+    } catch { oaStatus.textContent = "Fehler beim Zurücksetzen von model-override-all."; }
+  });
+  oaBar.appendChild(el("strong", { style: "margin-right:8px;" }, ["Override All:"]));
+  oaBar.appendChild(oaProv);
+  oaBar.appendChild(oaModel);
+  oaBar.appendChild(oaBtn);
+  oaBar.appendChild(oaClear);
+  oaBar.appendChild(oaStatus);
+  wrap.appendChild(oaBar);
+
   // Flatten existing model-overrides into editable rows.
   const existing = (data["model-overrides"] && typeof data["model-overrides"] === "object") ? data["model-overrides"] : {};
   const rows = [];

--- a/scripts/admin-server.py
+++ b/scripts/admin-server.py
@@ -3486,7 +3486,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         else:
             raise ValueError("expected JSON body with 'section' and 'data', or 'key' and 'value'")
         allowed = {
-            "agent-prompts", "model-overrides", "memory-overrides", "permission-mode-overrides",
+            "agent-prompts",             "model-overrides", "model-override-all", "memory-overrides", "permission-mode-overrides",
             "steps-overrides", "dod", "rules", "roles", "orchestrator", "viz", "admin-ui",
             "provider-tier-overrides", "project", "dod-preset", "rules-preset", "speech-mode",
             "tier-preset", "se-focus", "ai-providers", "platforms", "provider-options",

--- a/scripts/lib/roles.py
+++ b/scripts/lib/roles.py
@@ -103,7 +103,20 @@ def resolve_model(
     tier_or_id = ""
     explicit_override = False
 
-    # 1. Provider-specific project override
+    # --- Global per-provider "override all" (highest precedence, reversible) ---
+    # If ``model-override-all[provider]`` is set (non-empty), EVERY role of that
+    # provider is blasted onto this single model. Removing the key (or the whole
+    # block) from project.yaml makes sync fall back to the normal per-agent
+    # resolution automatically — no per-role cleanup required.
+    override_all = project_config.get("model-override-all", {})
+    if isinstance(override_all, dict):
+        raw_all = override_all.get(provider)
+        if raw_all:
+            resolved_all = _resolve_tier_to_model(str(raw_all), provider, provider_config)
+            if log:
+                log.debug(f"{provider}/{role}", f"GLOBAL override-all for provider '{provider}' (reversible): {resolved_all}")
+            return resolved_all
+
     provider_overrides = project_config.get("model-overrides", {})
     provider_specific = provider_overrides.get(provider, {})
     if isinstance(provider_specific, dict) and role in provider_specific:


### PR DESCRIPTION
## Summary
Adds a single, reversible project.yaml switch to blast **every** active agent/role of a provider onto one model — e.g. to exploit provider discount promos / usage caps.

- `model-override-all[provider] = <tier|alias|model-id>` is checked **first** in `scripts/lib/roles.py::resolve_model`, overriding all per-role/tier/preset/alias resolution.
- Fully reversible: removing the provider key (or the whole block) makes the previous per-agent settings resume automatically on the next `sync.py` run — no per-role cleanup.
- `config/project-config.schema.json`: new top-level `model-override-all` key.
- `scripts/admin-server.py`: whitelisted as a writable project section.
- `docs/ui/admin-ui.html`: "Override All" bar now writes/clears the key directly (with a "Zurücksetzen" button).
- `agents/1-generic/agent-meta-manager.md` + `.claude/skills/` : documents the toggle workflow.

## Test plan
- [x] `resolve_model` unit check: blast applies to all roles, clearing reverts to normal resolution.
- [x] `sync.py --validate` passes.
- [x] schema JSON valid.

🤖 Generated with [OpenCode](https://opencode.ai)