### PR TITLE
feat: model-inherit-main-chat super-override

### DIFF
--- a/.claude/agents/agent-meta-manager.md
+++ b/.claude/agents/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: agent-meta-manager
-version: 1.12.0
+version: 1.13.0
 description: 'Manage agent-meta: upgrades, sync, feedback delegation, project-specific
   agents, external-skill lifecycle, and creating extensions.'
 hint: 'Manage agent-meta: upgrade, sync, feedback, create project-specific agents'
@@ -15,7 +15,7 @@ tools:
 - Agent
 - WebFetch
 - TodoWrite
-generated-from: 1-generic/agent-meta-manager.md@1.12.0
+generated-from: 1-generic/agent-meta-manager.md@1.13.0
 model: claude-haiku-4-5-20251001
 ---
 
@@ -114,6 +114,81 @@ py scripts/sync.py --config .meta-config/project.yaml --create-ext <role>
 py scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
 
+## 8b. Model blast modes (override-all / inherit-main-chat)
+
+Two sibling keys control the model of **every** agent of one provider at once.
+They are **mutually exclusive per provider** — never set both truthy for the
+same provider (sync.py fails fast, see warning below).
+
+### 8b.1 Override-All (reversible promo blast)
+
+Blast every active agent of one provider onto a single model — e.g. to
+exploit provider discount promos or usage caps. This is the preferred,
+reversible mechanism (do NOT hand-edit per-role `model-overrides` for this).
+
+Mechanism: project.yaml key `model-override-all` (provider → tier/alias/model-ID).
+When a provider key is set, `sync.py` resolves ALL roles of that provider to that
+model, overriding per-role/tier/preset resolution. Remove the key (or the whole
+block) and the previous per-agent settings resume automatically — nothing else to
+clean up.
+
+```yaml
+# .meta-config/project.yaml
+model-override-all:
+  Claude: claude-sonnet-4-6      # blast all Claude agents onto this model
+  Gemini: gemini-2.5-pro
+```
+
+Toggle workflow:
+1. Read current state: `model-override-all` in `.meta-config/project.yaml`.
+2. To enable: set/merge the provider key, then re-sync.
+3. To disable: delete the provider key (or the entire `model-override-all` block), then re-sync.
+4. Always re-run `sync.py` after changing the key so generated agents pick it up.
+
+```bash
+# Enable (merge, keep other providers)
+py scripts/sync.py --config .meta-config/project.yaml
+# Disable: remove the key from project.yaml, then re-sync
+```
+
+Admin-UI shortcut: *Project → Model Overrides → "Override All"* bar writes the
+key directly (with a "Zurücksetzen" button to clear it). See skill
+`.claude/skills/model-override-all/SKILL.md`.
+
+### 8b.2 Inherit Main-Chat model (`model-inherit-main-chat`)
+
+Instead of pinning a fixed model, let every agent of one provider run on
+whatever model the main chat currently uses. Useful when you switch the main
+chat model often and want agents to follow automatically.
+
+Mechanism: project.yaml key `model-inherit-main-chat` (provider → true/false).
+When a provider is set to `true`, `sync.py` omits the generated agent's
+`model:` field entirely — the agent then inherits the main-chat model at
+runtime. `false` counts as unset (normal per-role/tier resolution applies).
+
+```yaml
+# .meta-config/project.yaml
+model-inherit-main-chat:
+  Claude: true      # all Claude agents inherit the main-chat model
+  Gemini: false     # unset — normal per-role resolution applies
+```
+
+Toggle workflow:
+1. Read current state: `model-inherit-main-chat` in `.meta-config/project.yaml`.
+2. To enable/disable: set the provider to `true`/`false`, then re-run `sync.py`.
+3. Re-sync is MANDATORY after every change — generated agents only reflect the key after regeneration.
+4. Check `sync.log` afterwards for `[WARN]`.
+
+> ⚠️ **HARD CONFLICT:** `model-inherit-main-chat` and `model-override-all`
+> are mutually exclusive **per provider**. Setting both truthy for the same
+> provider aborts `sync.py` immediately with exit code 1 (fail-fast validation
+> in `scripts/lib/config.py::_validate_model_inheritance`). Remove one of the
+> two provider entries before syncing.
+
+Admin/API shortcut: `POST /api/model-inherit` (admin server) toggles the key
+per provider and refuses conflicting writes while `model-override-all` holds a
+truthy entry for that provider.
+
 ## 9. External skills
 
 Full lifecycle: `rules/2-platform/agent-meta-sync-interface.md` (--add-skill flag).
@@ -166,7 +241,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.97.0 (2026-08-18)
+**Version info:** v0.97.0 (2026-08-22)
 </context>
 
 <tools>

--- a/.claude/skills/model-override-all/SKILL.md
+++ b/.claude/skills/model-override-all/SKILL.md
@@ -28,6 +28,14 @@ Value is resolved through `_resolve_tier_to_model`, so a tier (`nano`/`fast`/
 `balanced`/`powerful`/`max`), a legacy alias (`haiku`/`sonnet`/`opus`) or a full
 model ID (`claude-sonnet-4-6`) are all accepted.
 
+## Sibling mode: model-inherit-main-chat
+
+`model-inherit-main-chat[provider] = true` makes every role of that provider
+inherit the main chat's model: sync omits the generated `model:` field entirely.
+Per provider this is **hard-exclusive** with `model-override-all` — setting
+both keys for the same provider aborts sync with exit code 1. Toggle it via its
+own Admin-UI switch (*Project → Model Overrides*).
+
 ## project.yaml shape
 
 ```yaml

--- a/.gemini/agents/agent-meta-manager.md
+++ b/.gemini/agents/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: agent-meta-manager
-version: 1.12.0
+version: 1.13.0
 description: 'Manage agent-meta: upgrades, sync, feedback delegation, project-specific
   agents, external-skill lifecycle, and creating extensions.'
 hint: 'Manage agent-meta: upgrade, sync, feedback, create project-specific agents'
@@ -14,7 +14,7 @@ tools:
 - Grep
 - WebFetch
 - TodoWrite
-generated-from: 1-generic/agent-meta-manager.md@1.12.0
+generated-from: 1-generic/agent-meta-manager.md@1.13.0
 model: gemini-3.5-flash-high
 ---
 > **Registrierung erforderlich:** Dieser Agent wird zur Laufzeit via `define_subagent` registriert — er ist NICHT automatisch aktiv. Bootstrap-Instruktionen: `AGENTS.md` (Block `agent-meta:bootstrap`).
@@ -114,6 +114,81 @@ py scripts/sync.py --config .meta-config/project.yaml --create-ext <role>
 py scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
 
+## 8b. Model blast modes (override-all / inherit-main-chat)
+
+Two sibling keys control the model of **every** agent of one provider at once.
+They are **mutually exclusive per provider** — never set both truthy for the
+same provider (sync.py fails fast, see warning below).
+
+### 8b.1 Override-All (reversible promo blast)
+
+Blast every active agent of one provider onto a single model — e.g. to
+exploit provider discount promos or usage caps. This is the preferred,
+reversible mechanism (do NOT hand-edit per-role `model-overrides` for this).
+
+Mechanism: project.yaml key `model-override-all` (provider → tier/alias/model-ID).
+When a provider key is set, `sync.py` resolves ALL roles of that provider to that
+model, overriding per-role/tier/preset resolution. Remove the key (or the whole
+block) and the previous per-agent settings resume automatically — nothing else to
+clean up.
+
+```yaml
+# .meta-config/project.yaml
+model-override-all:
+  Claude: claude-sonnet-4-6      # blast all Claude agents onto this model
+  Gemini: gemini-2.5-pro
+```
+
+Toggle workflow:
+1. Read current state: `model-override-all` in `.meta-config/project.yaml`.
+2. To enable: set/merge the provider key, then re-sync.
+3. To disable: delete the provider key (or the entire `model-override-all` block), then re-sync.
+4. Always re-run `sync.py` after changing the key so generated agents pick it up.
+
+```bash
+# Enable (merge, keep other providers)
+py scripts/sync.py --config .meta-config/project.yaml
+# Disable: remove the key from project.yaml, then re-sync
+```
+
+Admin-UI shortcut: *Project → Model Overrides → "Override All"* bar writes the
+key directly (with a "Zurücksetzen" button to clear it). See skill
+`.claude/skills/model-override-all/SKILL.md`.
+
+### 8b.2 Inherit Main-Chat model (`model-inherit-main-chat`)
+
+Instead of pinning a fixed model, let every agent of one provider run on
+whatever model the main chat currently uses. Useful when you switch the main
+chat model often and want agents to follow automatically.
+
+Mechanism: project.yaml key `model-inherit-main-chat` (provider → true/false).
+When a provider is set to `true`, `sync.py` omits the generated agent's
+`model:` field entirely — the agent then inherits the main-chat model at
+runtime. `false` counts as unset (normal per-role/tier resolution applies).
+
+```yaml
+# .meta-config/project.yaml
+model-inherit-main-chat:
+  Claude: true      # all Claude agents inherit the main-chat model
+  Gemini: false     # unset — normal per-role resolution applies
+```
+
+Toggle workflow:
+1. Read current state: `model-inherit-main-chat` in `.meta-config/project.yaml`.
+2. To enable/disable: set the provider to `true`/`false`, then re-run `sync.py`.
+3. Re-sync is MANDATORY after every change — generated agents only reflect the key after regeneration.
+4. Check `sync.log` afterwards for `[WARN]`.
+
+> ⚠️ **HARD CONFLICT:** `model-inherit-main-chat` and `model-override-all`
+> are mutually exclusive **per provider**. Setting both truthy for the same
+> provider aborts `sync.py` immediately with exit code 1 (fail-fast validation
+> in `scripts/lib/config.py::_validate_model_inheritance`). Remove one of the
+> two provider entries before syncing.
+
+Admin/API shortcut: `POST /api/model-inherit` (admin server) toggles the key
+per provider and refuses conflicting writes while `model-override-all` holds a
+truthy entry for that provider.
+
 ## 9. External skills
 
 Full lifecycle: `rules/2-platform/agent-meta-sync-interface.md` (--add-skill flag).
@@ -166,7 +241,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.97.0 (2026-08-18)
+**Version info:** v0.97.0 (2026-08-22)
 </context>
 
 <tools>

--- a/.mammouth/agents/agent-meta-manager.md
+++ b/.mammouth/agents/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: agent-meta-manager
-version: 1.12.0
+version: 1.13.0
 description: 'Manage agent-meta: upgrades, sync, feedback delegation, project-specific
   agents, external-skill lifecycle, and creating extensions.'
 hint: 'Manage agent-meta: upgrade, sync, feedback, create project-specific agents'
@@ -15,7 +15,7 @@ tools:
 - Agent
 - WebFetch
 - TodoWrite
-generated-from: 1-generic/agent-meta-manager.md@1.12.0
+generated-from: 1-generic/agent-meta-manager.md@1.13.0
 model: claude-haiku-4-5-20251001
 ---
 > **Extension:** If `.mammouth/3-project/am-agent-meta-manager-ext.md` exists → read and apply immediately.
@@ -113,6 +113,81 @@ py scripts/sync.py --config .meta-config/project.yaml --create-ext <role>
 py scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
 
+## 8b. Model blast modes (override-all / inherit-main-chat)
+
+Two sibling keys control the model of **every** agent of one provider at once.
+They are **mutually exclusive per provider** — never set both truthy for the
+same provider (sync.py fails fast, see warning below).
+
+### 8b.1 Override-All (reversible promo blast)
+
+Blast every active agent of one provider onto a single model — e.g. to
+exploit provider discount promos or usage caps. This is the preferred,
+reversible mechanism (do NOT hand-edit per-role `model-overrides` for this).
+
+Mechanism: project.yaml key `model-override-all` (provider → tier/alias/model-ID).
+When a provider key is set, `sync.py` resolves ALL roles of that provider to that
+model, overriding per-role/tier/preset resolution. Remove the key (or the whole
+block) and the previous per-agent settings resume automatically — nothing else to
+clean up.
+
+```yaml
+# .meta-config/project.yaml
+model-override-all:
+  Claude: claude-sonnet-4-6      # blast all Claude agents onto this model
+  Gemini: gemini-2.5-pro
+```
+
+Toggle workflow:
+1. Read current state: `model-override-all` in `.meta-config/project.yaml`.
+2. To enable: set/merge the provider key, then re-sync.
+3. To disable: delete the provider key (or the entire `model-override-all` block), then re-sync.
+4. Always re-run `sync.py` after changing the key so generated agents pick it up.
+
+```bash
+# Enable (merge, keep other providers)
+py scripts/sync.py --config .meta-config/project.yaml
+# Disable: remove the key from project.yaml, then re-sync
+```
+
+Admin-UI shortcut: *Project → Model Overrides → "Override All"* bar writes the
+key directly (with a "Zurücksetzen" button to clear it). See skill
+`.claude/skills/model-override-all/SKILL.md`.
+
+### 8b.2 Inherit Main-Chat model (`model-inherit-main-chat`)
+
+Instead of pinning a fixed model, let every agent of one provider run on
+whatever model the main chat currently uses. Useful when you switch the main
+chat model often and want agents to follow automatically.
+
+Mechanism: project.yaml key `model-inherit-main-chat` (provider → true/false).
+When a provider is set to `true`, `sync.py` omits the generated agent's
+`model:` field entirely — the agent then inherits the main-chat model at
+runtime. `false` counts as unset (normal per-role/tier resolution applies).
+
+```yaml
+# .meta-config/project.yaml
+model-inherit-main-chat:
+  Claude: true      # all Claude agents inherit the main-chat model
+  Gemini: false     # unset — normal per-role resolution applies
+```
+
+Toggle workflow:
+1. Read current state: `model-inherit-main-chat` in `.meta-config/project.yaml`.
+2. To enable/disable: set the provider to `true`/`false`, then re-run `sync.py`.
+3. Re-sync is MANDATORY after every change — generated agents only reflect the key after regeneration.
+4. Check `sync.log` afterwards for `[WARN]`.
+
+> ⚠️ **HARD CONFLICT:** `model-inherit-main-chat` and `model-override-all`
+> are mutually exclusive **per provider**. Setting both truthy for the same
+> provider aborts `sync.py` immediately with exit code 1 (fail-fast validation
+> in `scripts/lib/config.py::_validate_model_inheritance`). Remove one of the
+> two provider entries before syncing.
+
+Admin/API shortcut: `POST /api/model-inherit` (admin server) toggles the key
+per provider and refuses conflicting writes while `model-override-all` holds a
+truthy entry for that provider.
+
 ## 9. External skills
 
 Full lifecycle: `rules/2-platform/agent-meta-sync-interface.md` (--add-skill flag).
@@ -165,7 +240,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.97.0 (2026-08-18)
+**Version info:** v0.97.0 (2026-08-22)
 </context>
 
 <tools>

--- a/.opencode/agents/agent-meta-manager.md
+++ b/.opencode/agents/agent-meta-manager.md
@@ -1,12 +1,12 @@
 ---
 name: agent-meta-manager
-version: 1.12.0
+version: 1.13.0
 description: 'Manage agent-meta: upgrades, sync, feedback delegation, project-specific
   agents, external-skill lifecycle, and creating extensions.'
 prompt_mode: modern
-generated-from: 1-generic/agent-meta-manager.md@1.12.0
+generated-from: 1-generic/agent-meta-manager.md@1.13.0
 mode: subagent
-model: opencode-go/deepseek-v4-flash
+model: opencode-go/ox-alpha-free
 permission:
   bash: allow
   read: allow
@@ -112,6 +112,81 @@ py scripts/sync.py --config .meta-config/project.yaml --create-ext <role>
 py scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
 
+## 8b. Model blast modes (override-all / inherit-main-chat)
+
+Two sibling keys control the model of **every** agent of one provider at once.
+They are **mutually exclusive per provider** — never set both truthy for the
+same provider (sync.py fails fast, see warning below).
+
+### 8b.1 Override-All (reversible promo blast)
+
+Blast every active agent of one provider onto a single model — e.g. to
+exploit provider discount promos or usage caps. This is the preferred,
+reversible mechanism (do NOT hand-edit per-role `model-overrides` for this).
+
+Mechanism: project.yaml key `model-override-all` (provider → tier/alias/model-ID).
+When a provider key is set, `sync.py` resolves ALL roles of that provider to that
+model, overriding per-role/tier/preset resolution. Remove the key (or the whole
+block) and the previous per-agent settings resume automatically — nothing else to
+clean up.
+
+```yaml
+# .meta-config/project.yaml
+model-override-all:
+  Claude: claude-sonnet-4-6      # blast all Claude agents onto this model
+  Gemini: gemini-2.5-pro
+```
+
+Toggle workflow:
+1. Read current state: `model-override-all` in `.meta-config/project.yaml`.
+2. To enable: set/merge the provider key, then re-sync.
+3. To disable: delete the provider key (or the entire `model-override-all` block), then re-sync.
+4. Always re-run `sync.py` after changing the key so generated agents pick it up.
+
+```bash
+# Enable (merge, keep other providers)
+py scripts/sync.py --config .meta-config/project.yaml
+# Disable: remove the key from project.yaml, then re-sync
+```
+
+Admin-UI shortcut: *Project → Model Overrides → "Override All"* bar writes the
+key directly (with a "Zurücksetzen" button to clear it). See skill
+`.claude/skills/model-override-all/SKILL.md`.
+
+### 8b.2 Inherit Main-Chat model (`model-inherit-main-chat`)
+
+Instead of pinning a fixed model, let every agent of one provider run on
+whatever model the main chat currently uses. Useful when you switch the main
+chat model often and want agents to follow automatically.
+
+Mechanism: project.yaml key `model-inherit-main-chat` (provider → true/false).
+When a provider is set to `true`, `sync.py` omits the generated agent's
+`model:` field entirely — the agent then inherits the main-chat model at
+runtime. `false` counts as unset (normal per-role/tier resolution applies).
+
+```yaml
+# .meta-config/project.yaml
+model-inherit-main-chat:
+  Claude: true      # all Claude agents inherit the main-chat model
+  Gemini: false     # unset — normal per-role resolution applies
+```
+
+Toggle workflow:
+1. Read current state: `model-inherit-main-chat` in `.meta-config/project.yaml`.
+2. To enable/disable: set the provider to `true`/`false`, then re-run `sync.py`.
+3. Re-sync is MANDATORY after every change — generated agents only reflect the key after regeneration.
+4. Check `sync.log` afterwards for `[WARN]`.
+
+> ⚠️ **HARD CONFLICT:** `model-inherit-main-chat` and `model-override-all`
+> are mutually exclusive **per provider**. Setting both truthy for the same
+> provider aborts `sync.py` immediately with exit code 1 (fail-fast validation
+> in `scripts/lib/config.py::_validate_model_inheritance`). Remove one of the
+> two provider entries before syncing.
+
+Admin/API shortcut: `POST /api/model-inherit` (admin server) toggles the key
+per provider and refuses conflicting writes while `model-override-all` holds a
+truthy entry for that provider.
+
 ## 9. External skills
 
 Full lifecycle: `rules/2-platform/agent-meta-sync-interface.md` (--add-skill flag).
@@ -164,7 +239,7 @@ On request: extend `.meta-config/project.yaml` with an SE block. Explain the var
 
 **Sync workflow:** Mandatory order on changes → 1. test sync.py locally → 2. review .claude/agents → 3. commit → 4. (optionally) PR.
 
-**Version info:** v0.97.0 (2026-08-18)
+**Version info:** v0.97.0 (2026-08-22)
 </context>
 
 <tools>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Kategorien für `docs/REQUIREMENTS.md`:
 
 > **AI ROUTING:** Claude -> CLAUDE.md | Opencode, Gemini -> AGENTS.md | Mammouth -> MAMMOUTH.md
 
-Generiert von agent-meta v0.97.0 — `2026-08-18`
+Generiert von agent-meta v0.97.0 — `2026-08-22`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 > **Einstiegspunkt:** Du bist im `main-chat` Modus. Du agierst direkt als Router und Worker (siehe `use-orchestrator.md`).
 

--- a/MAMMOUTH.md
+++ b/MAMMOUTH.md
@@ -84,7 +84,7 @@ Kategorien für `docs/REQUIREMENTS.md`:
 
 > **AI ROUTING:** Claude -> CLAUDE.md | Opencode, Gemini -> AGENTS.md | Mammouth -> MAMMOUTH.md
 
-Generiert von agent-meta v0.97.0 — `2026-08-18`
+Generiert von agent-meta v0.97.0 — `2026-08-22`
 DoD-Preset: **rapid-prototyping** | REQ-Traceability: false | Tests: false | Codebase-Overview: false | Security-Audit: false
 > **Einstiegspunkt:** Starte mit dem `orchestrator`-Agenten für alle Entwicklungsaufgaben — Ausnahmen siehe Abschnitt »Orchestrator — Universal Router«.
 

--- a/agents/1-generic/agent-meta-manager.md
+++ b/agents/1-generic/agent-meta-manager.md
@@ -1,6 +1,6 @@
 ---
 name: template-agent-meta-manager
-version: "1.12.0"
+version: "1.13.0"
 description: "Manage agent-meta: upgrades, sync, feedback delegation, project-specific agents, external-skill lifecycle, and creating extensions."
 hint: "Manage agent-meta: upgrade, sync, feedback, create project-specific agents"
 prompt_mode: modern
@@ -111,11 +111,17 @@ py {{AGENT_META_REL_PATH}}scripts/sync.py --config .meta-config/project.yaml --c
 py {{AGENT_META_REL_PATH}}scripts/sync.py --config .meta-config/project.yaml --create-command deploy
 ```
 
-## 8b. Model Override-All (reversible promo blast)
+## 8b. Model blast modes (override-all / inherit-main-chat)
 
-Blast **every** active agent of one provider onto a single model — e.g. to
-exploit provider discount promos or usage caps. This is the preferred, reversible
-mechanism (do NOT hand-edit per-role `model-overrides` for this).
+Two sibling keys control the model of **every** agent of one provider at once.
+They are **mutually exclusive per provider** — never set both truthy for the
+same provider (sync.py fails fast, see warning below).
+
+### 8b.1 Override-All (reversible promo blast)
+
+Blast every active agent of one provider onto a single model — e.g. to
+exploit provider discount promos or usage caps. This is the preferred,
+reversible mechanism (do NOT hand-edit per-role `model-overrides` for this).
 
 Mechanism: project.yaml key `model-override-all` (provider → tier/alias/model-ID).
 When a provider key is set, `sync.py` resolves ALL roles of that provider to that
@@ -145,6 +151,40 @@ py {{AGENT_META_REL_PATH}}scripts/sync.py --config .meta-config/project.yaml
 Admin-UI shortcut: *Project → Model Overrides → "Override All"* bar writes the
 key directly (with a "Zurücksetzen" button to clear it). See skill
 `.claude/skills/model-override-all/SKILL.md`.
+
+### 8b.2 Inherit Main-Chat model (`model-inherit-main-chat`)
+
+Instead of pinning a fixed model, let every agent of one provider run on
+whatever model the main chat currently uses. Useful when you switch the main
+chat model often and want agents to follow automatically.
+
+Mechanism: project.yaml key `model-inherit-main-chat` (provider → true/false).
+When a provider is set to `true`, `sync.py` omits the generated agent's
+`model:` field entirely — the agent then inherits the main-chat model at
+runtime. `false` counts as unset (normal per-role/tier resolution applies).
+
+```yaml
+# .meta-config/project.yaml
+model-inherit-main-chat:
+  Claude: true      # all Claude agents inherit the main-chat model
+  Gemini: false     # unset — normal per-role resolution applies
+```
+
+Toggle workflow:
+1. Read current state: `model-inherit-main-chat` in `.meta-config/project.yaml`.
+2. To enable/disable: set the provider to `true`/`false`, then re-run `sync.py`.
+3. Re-sync is MANDATORY after every change — generated agents only reflect the key after regeneration.
+4. Check `sync.log` afterwards for `[WARN]`.
+
+> ⚠️ **HARD CONFLICT:** `model-inherit-main-chat` and `model-override-all`
+> are mutually exclusive **per provider**. Setting both truthy for the same
+> provider aborts `sync.py` immediately with exit code 1 (fail-fast validation
+> in `scripts/lib/config.py::_validate_model_inheritance`). Remove one of the
+> two provider entries before syncing.
+
+Admin/API shortcut: `POST /api/model-inherit` (admin server) toggles the key
+per provider and refuses conflicting writes while `model-override-all` holds a
+truthy entry for that provider.
 
 ## 9. External skills
 

--- a/config/project-config.schema.json
+++ b/config/project-config.schema.json
@@ -308,6 +308,14 @@
         "description": "Tier, alias or full model ID to blast onto every role of this provider."
       }
     },
+    "model-inherit-main-chat": {
+      "type": "object",
+      "description": "Per-provider main-chat inheritance. When a provider key is set to true, agents of that provider get no model field during sync.py and inherit the main chat model at runtime — overriding all per-role overrides, tiers and presets. Mutually exclusive with model-override-all on the same provider key. Fully reversible: remove the key (or the whole block) and the previous per-agent settings apply again automatically.",
+      "additionalProperties": {
+        "type": "boolean",
+        "description": "Set to true to omit the model field for every agent of this provider so it inherits the main chat model."
+      }
+    },
     "model-overrides": {
       "type": "object",
       "description": "Override the default model tier or model ID per role. Two forms supported: (1) flat role→tier for Claude-only legacy use; (2) provider-keyed blocks for multi-provider control. Provider-specific blocks take precedence over flat values for that provider.",

--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -1,6 +1,6 @@
 # CODEBASE_OVERVIEW — agent-meta
 
-> Letzte Aktualisierung: 2026-08-08 (v0.92.0: `howto/`→`docs/guides/`+`docs/se-cascade/`-Pfade korrigiert; Knowledge Engine seit v0.82.0 implementiert, Phase A-C abgeschlossen)
+> Letzte Aktualisierung: 2026-08-22 (feat/model-inherit-main-chat: zweiter Super-Override `model-inherit-main-chat`; zuvor v0.92.0: Pfade korrigiert, Knowledge Engine implementiert)
 
 ---
 
@@ -560,6 +560,10 @@ cheap:
 4. Sonst: versuche `mapping` oder fallback zu `role-defaults.yaml:tiers`
 5. SE-Rollen upgrade: +1 Tier via SE-Prefix (balanced → powerful, etc.)
 
+### Main-Chat-Erbfolge `model-inherit-main-chat` (zweiter Super-Override)
+
+Zweiter Super-Override neben `model-override-all`: project.yaml Key `model-inherit-main-chat:` (Provider→bool). Resolve-Reihenfolge in `lib/roles.py::resolve_model()`: (1) `model-override-all[provider]`, (2) truthy `model-inherit-main-chat[provider]` → Return `""` ⇒ `inject_model_field()` lässt das `model:`-Feld weg ⇒ Agent erbt zur Laufzeit das Main-Chat-Modell. Pro Provider exklusiv zu `model-override-all` — Verstoß bricht den Sync hart ab (`_validate_model_inheritance()` in `lib/config.py`, stderr + Exit 1; `false` zählt als unset). Admin-UI: Toggle-Balken auf der Models-Page + `POST /api/model-inherit` (`_handle_post_model_inherit()` in admin-server.py, HTTP 409 bei Konflikt; Disable entfernt den Provider-Key, leerer Block wird komplett entfernt). Template-Doku: agent-meta-manager v1.13.0 §8b.2.
+
 ### `config/pricing-overlay.yaml` & `config/generated/model-registry.json`
 
 **Pricing Overlay:** Manueller Überschreib-Mechanismus für Preise. API-Preise werden bevorzugt, außer Overlay definiert einen eigenen Preis (z.B. 0.00$ für Zen-Subscriptions). Preise können direkt in der Admin-UI editiert werden.
@@ -944,6 +948,7 @@ Redundante `hint`-Felder werden automatisch aus Agent-Frontmattern gelöscht wen
 | `/api/backups` | `GET` · `POST` | Liste aller Config-Backups lesen / neue Backup erstellen |
 | `/api/backups/<archive>` | `DELETE` | Backup löschen |
 | `/api/backups/restore` | `POST` | Konfiguration aus Backup wiederherstellen |
+| `/api/model-inherit` | `POST` | Main-Chat-Erbfolge pro Provider togglen (`{"provider", "enabled"}`); 409 bei `model-override-all`-Konflikt |
 
 **Neue UI-Pages (Phase 5):**
 

--- a/docs/guides/project.yaml.example
+++ b/docs/guides/project.yaml.example
@@ -62,6 +62,28 @@ max-parallel-agents: 4
 #   default_scope: ""
 
 # ============================================================
+# MODEL CONFIGURATION
+# ============================================================
+# model-inherit-main-chat: provider → bool map.
+#   true  → sync.py omits the generated agents' `model:` field entirely,
+#           so EVERY agent of that provider inherits the main-chat model
+#           at runtime (follows automatically when you switch models).
+#   false → counts as unset — normal per-role/tier resolution applies.
+#
+#   Reversible: set the provider back to false (or remove the key)
+#   and re-run sync.py — previous per-agent settings resume, nothing
+#   else to clean up. Re-sync is mandatory after every change.
+#
+#   ⚠️ HARD CONFLICT: mutually exclusive with `model-override-all`
+#   PER PROVIDER — setting both truthy for the same provider aborts
+#   sync.py immediately with exit code 1 (fail-fast validation).
+#   Remove one of the two provider entries before syncing.
+
+# model-inherit-main-chat:
+#   Claude: true       # all Claude agents inherit the main-chat model
+#   Gemini: false      # unset — normal per-role resolution applies
+
+# ============================================================
 # TEST REPOSITORY VALIDATION
 # ============================================================
 # Enables validation of sync output against a separate test repository.

--- a/docs/ui/admin-ui.html
+++ b/docs/ui/admin-ui.html
@@ -6742,6 +6742,11 @@ async function viewProjectModelOverrides() {
   }
   wrap.appendChild(datalist);
 
+  // Fresh reader over the loaded project data — both model bars (Override-All
+  // and Inherit-Main-Chat) stay mutually consistent because every mutation
+  // writes its result back into `data` immediately.
+  const inheritEntries = () => ((data["model-inherit-main-chat"] && typeof data["model-inherit-main-chat"] === "object") ? data["model-inherit-main-chat"] : {});
+
   // --- Override-All bar: reversible global per-provider model blast ---
   // Writes project.yaml `model-override-all[provider] = model`. sync.py then
   // resolves EVERY active agent/role of that provider to this single model.
@@ -6762,10 +6767,17 @@ async function viewProjectModelOverrides() {
     const model = oaModel.value.trim();
     if (!prov) { oaStatus.textContent = "Override-All: zuerst einen Provider wählen."; return; }
     if (!model) { oaStatus.textContent = "Override-All: zuerst ein Modell eingeben."; return; }
+    // Mutual lock: model-override-all and model-inherit-main-chat are
+    // exclusive per provider — refuse while inheritance is active.
+    if (inheritEntries()[prov]) {
+      oaStatus.textContent = `Gesperrt: '${prov}' erbt das Main-Chat-Modell — erst den Inherit-Toggle ausschalten.`;
+      return;
+    }
     const cur = (data["model-override-all"] && typeof data["model-override-all"] === "object") ? { ...data["model-override-all"] } : {};
     cur[prov] = model;
     try {
       await saveProjectSection("model-override-all", cur, status);
+      data["model-override-all"] = cur;
       oaStatus.textContent = `${prov} → ${model} aktiv. Reversibel: Zurücksetzen oder Key löschen.`;
       if (oaProv.value === prov) oaModel.value = model;
     } catch { oaStatus.textContent = "Fehler beim Speichern von model-override-all."; }
@@ -6773,10 +6785,16 @@ async function viewProjectModelOverrides() {
   oaClear.addEventListener("click", async () => {
     const prov = oaProv.value;
     if (!prov) { oaStatus.textContent = "Zurücksetzen: zuerst einen Provider wählen."; return; }
+    // Mutual lock: refuse while inheritance is active for this provider.
+    if (inheritEntries()[prov]) {
+      oaStatus.textContent = `Gesperrt: '${prov}' erbt das Main-Chat-Modell — erst den Inherit-Toggle ausschalten.`;
+      return;
+    }
     const cur = (data["model-override-all"] && typeof data["model-override-all"] === "object") ? { ...data["model-override-all"] } : {};
     delete cur[prov];
     try {
       await saveProjectSection("model-override-all", cur, status);
+      data["model-override-all"] = cur;
       oaStatus.textContent = `${prov} entfernt → Normal-Auflösung greift wieder.`;
       oaModel.value = "";
     } catch { oaStatus.textContent = "Fehler beim Zurücksetzen von model-override-all."; }
@@ -6788,6 +6806,83 @@ async function viewProjectModelOverrides() {
   oaBar.appendChild(oaClear);
   oaBar.appendChild(oaStatus);
   wrap.appendChild(oaBar);
+
+  // --- Inherit-Main-Chat toggle bar: per-provider main-chat inheritance ---
+  // POSTs /api/model-inherit {provider, enabled}; the server writes/removes
+  // the provider key under project.yaml `model-inherit-main-chat`. Enabled
+  // providers get NO model fields — their agents inherit the main-chat model
+  // at runtime (lib/roles.py::resolve_model returns ""). Mutually exclusive
+  // with model-override-all of the SAME provider: blocked here client-side
+  // and enforced again server-side (HTTP 409 with an explanatory message).
+  const inheritBar = el("div", { class: "btn-row", style: "margin:0 0 14px;padding:12px;background:var(--panel,#1c2230);border:1px solid var(--border,#2c3344);border-radius:8px;" });
+  const inhProv = el("select");
+  inhProv.appendChild(el("option", { value: "" }, ["Provider wählen…"]));
+  for (const tp of tierProviders) {
+    inhProv.appendChild(el("option", { value: tp.name }, [tp.display_name || tp.name]));
+  }
+  const overrideAllEntries = () => ((data["model-override-all"] && typeof data["model-override-all"] === "object") ? data["model-override-all"] : {});
+  const inhToggleWrap = el("label", { class: "toggle", style: "margin-left:8px;", title: "Aktiv → Agenten dieses Providers erhalten kein model:-Feld und erben das Modell des Main-Chats" });
+  const inhCb = el("input", { type: "checkbox" });
+  inhToggleWrap.appendChild(inhCb);
+  inhToggleWrap.appendChild(el("span", { class: "slider" }));
+  const inhStatus = el("span", { class: "muted", style: "margin-left:8px;" }, []);
+
+  // Reflect the picked provider's current state; keep the checkbox disabled
+  // until a provider is selected.
+  inhProv.addEventListener("change", () => {
+    const prov = inhProv.value;
+    inhCb.disabled = !prov;
+    if (!prov) { inhCb.checked = false; inhStatus.textContent = ""; return; }
+    inhCb.checked = !!inheritEntries()[prov];
+    if (overrideAllEntries()[prov]) {
+      inhStatus.textContent = `${prov}: Override-All aktiv → Inheritance gesperrt.`;
+    } else {
+      inhStatus.textContent = inheritEntries()[prov]
+        ? `${prov} erbt das Main-Chat-Modell.`
+        : `${prov} nutzt die eigene Modell-Auflösung.`;
+    }
+  });
+
+  inhCb.addEventListener("change", async () => {
+    const prov = inhProv.value;
+    const enabled = inhCb.checked;
+    if (!prov) {
+      inhCb.checked = false;
+      inhStatus.textContent = "Inherit-Toggle: zuerst einen Provider wählen.";
+      return;
+    }
+    // Client-side mutual exclusion against model-override-all of the same
+    // provider — the server re-checks this and answers 409 on conflict.
+    if (enabled && overrideAllEntries()[prov]) {
+      inhCb.checked = false;
+      inhStatus.textContent = `Gesperrt: '${prov}' hat einen model-override-all-Eintrag — zuerst im Override-All-Balken zurücksetzen.`;
+      return;
+    }
+    try {
+      const res = await api.post("/api/model-inherit", { provider: prov, enabled });
+      // Write the authoritative block from the server response back into the
+      // local cache so both bars observe consistent state.
+      data["model-inherit-main-chat"] = (res && typeof res.inherit_main_chat === "object") ? res.inherit_main_chat : {};
+      inhStatus.textContent = enabled
+        ? `${prov} erbt jetzt das Main-Chat-Modell.`
+        : `${prov} nutzt wieder die eigene Modell-Auflösung.`;
+      toast(`model-inherit-main-chat[${prov}] = ${enabled}`, "success");
+    } catch (err) {
+      inhCb.checked = !enabled;
+      inhStatus.textContent = err.status === 409
+        ? `Konflikt: ${err.message}`
+        : `Fehler beim Umschalten von model-inherit-main-chat: ${err.message}`;
+      toast(`model-inherit failed (${prov}): ${err.message}`, "error");
+    }
+  });
+  // Initialize state text/disabled flag for the initial (empty) selection.
+  inhProv.dispatchEvent(new Event("change"));
+
+  inheritBar.appendChild(el("strong", { style: "margin-right:8px;" }, ["Inherit Main-Chat:"]));
+  inheritBar.appendChild(inhProv);
+  inheritBar.appendChild(inhToggleWrap);
+  inheritBar.appendChild(inhStatus);
+  wrap.appendChild(inheritBar);
 
   // Flatten existing model-overrides into editable rows.
   const existing = (data["model-overrides"] && typeof data["model-overrides"] === "object") ? data["model-overrides"] : {};

--- a/howto/configs/project.yaml.example
+++ b/howto/configs/project.yaml.example
@@ -178,6 +178,28 @@ model-overrides:
     developer: balanced
     git: fast
 
+# Main-Chat-Modell erben (pro Provider) / Inherit the main-chat model (per provider)
+# Bei `true` werden alle Agenten des Providers OHNE `model:`-Feld generiert und
+# erben das im Main-Chat aktive Modell — Tier-Preset & model-overrides werden
+# für diesen Provider ignoriert.
+# With `true`, all agents of this provider are generated WITHOUT a `model:`
+# field and inherit the model active in the main chat — tier preset &
+# model-overrides are ignored for that provider.
+# Exklusivität: Pro Provider gilt ENTWEDER `model-inherit-main-chat` ODER
+# `model-override-all` — beides `true` für denselben Provider bricht den Sync
+# mit einem Fehler ab (`false` zählt als nicht gesetzt).
+# Exclusivity: per provider, EITHER `model-inherit-main-chat` OR
+# `model-override-all` — both `true` for the same provider aborts the sync
+# with an error (`false` counts as unset).
+# Reversibel: Block entfernen oder Einträge auf `false` setzen und erneut
+# synchronisieren — die generierten Agenten erhalten wieder ihr reguläres
+# `model:`-Feld.
+# Reversible: remove the block (or set entries to `false`) and re-sync —
+# generated agents get their regular `model:` field back.
+# model-inherit-main-chat:
+#   Claude: true
+#   Gemini: true
+
 # ------------------------------------------------------------------------------
 # 10. Projekt-Variablen / Project Template Variables
 # ------------------------------------------------------------------------------

--- a/scripts/admin-server.py
+++ b/scripts/admin-server.py
@@ -83,6 +83,30 @@ SSE_HEARTBEAT_SECONDS = 15
 # here, so operators can change it without touching Python.
 _FALLBACK_MODEL_SOURCE = "registry"
 VALID_MODEL_SOURCES: tuple[str, ...] = ("registry", "modelsdev")
+# The two mutually exclusive per-provider model blocks in project.yaml.
+# A provider may be truthy-set in at most ONE of them. Sync-side enforcement
+# lives in lib/config.py::_validate_model_inheritance (hard-fatal, SystemExit);
+# the admin-server counterparts below keep UI/section writes from persisting a
+# config that would kill every later sync run.
+MODEL_EXCLUSIVE_BLOCKS: tuple[str, str] = ("model-override-all", "model-inherit-main-chat")
+
+
+def _other_model_block(section: str) -> str:
+    """Return the opposite block of :data:`MODEL_EXCLUSIVE_BLOCKS`."""
+    return MODEL_EXCLUSIVE_BLOCKS[1] if section == MODEL_EXCLUSIVE_BLOCKS[0] else MODEL_EXCLUSIVE_BLOCKS[0]
+
+
+def find_model_block_conflicts(data: Any, other: Any) -> list[str]:
+    """Return providers that would be truthy-set in BOTH exclusive blocks.
+
+    ``data`` is the incoming payload for one block, ``other`` the currently
+    persisted opposite block. Only truthy entries on both sides conflict —
+    ``false`` counts as unset and different providers never conflict,
+    mirroring lib/config.py::_validate_model_inheritance().
+    """
+    if not isinstance(data, dict) or not isinstance(other, dict):
+        return []
+    return [provider for provider, value in data.items() if value and other.get(provider)]
 
 # Framework provider name -> models.dev catalog slug. Mirrors
 # ``PROVIDER_MODELSDEV_MAP`` in ``docs/ui/admin-ui.html`` — keep both in sync.
@@ -1618,6 +1642,9 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         if path == "/api/model-source/batch":
             return self._handle_post_model_source_batch()
 
+        if path == "/api/model-inherit":
+            return self._handle_post_model_inherit()
+
         if path == "/api/models/exclude":
             return self._handle_post_models_exclude()
 
@@ -2547,7 +2574,80 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                     if isinstance(v, str) and v in VALID_MODEL_SOURCES
                 },
             })
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
+            return self._send_json({"error": str(exc)}, status=500)
+
+    def _handle_post_model_inherit(self) -> None:
+        """Toggle main-chat model inheritance for one provider.
+
+        Server-side counterpart of the Models page's second toggle bar
+        (next to the Override-All bar): sets or deletes the provider key in
+        the project.yaml ``model-inherit-main-chat`` block. When enabled,
+        sync.py omits the model field for every agent of that provider so it
+        inherits the main chat model at runtime (lib/roles.py::resolve_model
+        returns "" and inject_model_field() skips the field).
+
+        Body: ``{"provider": "Opencode", "enabled": true}``. Disabling
+        removes the provider key; an empty block is removed entirely.
+
+        Rejects enabling a provider that still has a truthy
+        ``model-override-all`` entry with HTTP 409 — the two keys are
+        mutually exclusive per provider (same rule the sync-side validation
+        in lib/config.py enforces hard-fatal on direct YAML edits).
+        """
+        try:
+            body = self._read_body()
+            if not isinstance(body, dict):
+                return self._send_json({"error": "expected JSON body"}, status=400)
+            provider = str(body.get("provider", "")).strip()
+            enabled = body.get("enabled")
+            if not provider:
+                return self._send_json({"error": "provider required"}, status=400)
+            if not isinstance(enabled, bool):
+                return self._send_json(
+                    {"error": "enabled must be true or false"}, status=400)
+
+            project = self.__class__.config_manager.read("project")
+            if not isinstance(project, dict):
+                project = {}
+
+            if enabled:
+                override_all = project.get("model-override-all")
+                if isinstance(override_all, dict) and override_all.get(provider):
+                    other = _other_model_block("model-inherit-main-chat")
+                    return self._send_json(
+                        {
+                            "error": (
+                                f"conflicting model configuration for provider "
+                                f"'{provider}': '{other}' and "
+                                f"'model-inherit-main-chat' are mutually "
+                                f"exclusive per provider — clear the '{other}' "
+                                f"entry for '{provider}' first."
+                            )
+                        },
+                        status=409,
+                    )
+
+            inherit = project.get("model-inherit-main-chat")
+            if not isinstance(inherit, dict):
+                inherit = {}
+            if enabled:
+                inherit[provider] = True
+            else:
+                inherit.pop(provider, None)
+            if inherit:
+                project["model-inherit-main-chat"] = inherit
+            else:
+                project.pop("model-inherit-main-chat", None)
+            self.__class__.config_manager.write("project", project)
+
+            return self._send_json({
+                "success": True,
+                "provider": provider,
+                "enabled": enabled,
+                "inherit_main_chat": dict(inherit),
+            })
+        except Exception as exc:
             return self._send_json({"error": str(exc)}, status=500)
 
     def _handle_get_model_suggestions(self) -> None:
@@ -3487,7 +3587,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         else:
             raise ValueError("expected JSON body with 'section' and 'data', or 'key' and 'value'")
         allowed = {
-            "agent-prompts",             "model-overrides", "model-override-all", "memory-overrides", "permission-mode-overrides",
+            "agent-prompts",             "model-overrides", "model-override-all", "model-inherit-main-chat", "memory-overrides", "permission-mode-overrides",
             "steps-overrides", "dod", "rules", "roles", "orchestrator", "viz", "admin-ui",
             "provider-tier-overrides", "project", "dod-preset", "rules-preset", "speech-mode",
             "conventions", "conventions-preset",
@@ -3503,8 +3603,58 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         existing = self.__class__.config_manager.read("project")
         if not isinstance(existing, dict):
             existing = {}
+        self._guard_model_block_write(section, data, existing)
         existing[section] = data
         return self._send_json(self.__class__.config_manager.write("project", existing))
+
+    def _guard_model_block_write(self, section: str, data: Any, existing: dict) -> None:
+        """Reject section writes that would break the next ``sync.py`` run.
+
+        Guards the two mutually exclusive per-provider model blocks
+        (``MODEL_EXCLUSIVE_BLOCKS``):
+
+        1. Exclusivity: a write whose resulting block would leave a provider
+           truthy-set in BOTH ``model-override-all`` AND
+           ``model-inherit-main-chat`` is rejected with ``ValueError``
+           (mapped to HTTP 400 by :meth:`do_POST`). resolve_model() returns
+           on a truthy override-all entry before inheritance is ever
+           consulted, so a both-set provider is a config bug — sync-side it
+           aborts with SystemExit(1) (lib/config.py::
+           _validate_model_inheritance); here the write itself fails so the
+           Admin UI gets the same guarantee as direct YAML edits.
+        2. Typing: every ``model-inherit-main-chat`` provider entry must be
+           a bool (schema: additionalProperties.type=boolean); non-bool
+           values are silently ignored by resolve_model() and hard-fail the
+           next sync.
+
+        ``false`` counts as unset; different providers never conflict.
+        """
+        if section not in MODEL_EXCLUSIVE_BLOCKS:
+            return
+
+        if section == "model-inherit-main-chat":
+            if not isinstance(data, dict):
+                raise ValueError(
+                    "invalid 'model-inherit-main-chat': expected a mapping "
+                    f"of provider -> true/false, got {type(data).__name__}"
+                )
+            non_bool = sorted(str(k) for k, v in data.items() if not isinstance(v, bool))
+            if non_bool:
+                raise ValueError(
+                    "invalid 'model-inherit-main-chat' entries (every "
+                    f"provider entry must be true/false): {', '.join(non_bool)}"
+                )
+
+        other = _other_model_block(section)
+        conflicts = find_model_block_conflicts(data, existing.get(other))
+        if conflicts:
+            quoted = ", ".join(f"'{p}'" for p in sorted(conflicts))
+            raise ValueError(
+                f"conflicting model configuration for provider(s): {quoted} — "
+                f"'{section}' and '{other}' are mutually exclusive per "
+                "provider. Clear the conflicting "
+                f"'{other}' or '{section}' entry for each listed provider first."
+            )
 
     def _validate_permitted_injections_overrides(self, overrides: dict) -> None:
         """Reject a project-override write whose ``permitted-injections`` would

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -118,11 +118,24 @@ def load_config(config_path: Path) -> dict:
 
 
 def _validate_config(config: dict, config_path: Path) -> None:
-    """Validate config against agent-meta.schema.json if jsonschema is available.
+    """Validate config before sync.
 
-    Validation errors are printed as warnings — never hard-fails so existing
-    projects without the dependency continue to work unchanged.
+    Two kinds of checks:
+
+    1. Hard-fatal model inheritance checks (_validate_model_inheritance):
+       wrong-typed 'model-inherit-main-chat' entries and per-provider
+       conflicts with 'model-override-all' abort the sync (stderr + exit 1),
+       because resolve_model() would silently prefer override-all and defeat
+       the inheritance feature. Runs unconditionally — stdlib only, does
+       NOT require jsonschema.
+
+    2. Schema validation against agent-meta.schema.json if jsonschema is
+       available. Schema violations are printed as warnings — never
+       hard-fails so existing projects without the dependency continue to
+       work unchanged.
     """
+    _validate_model_inheritance(config, config_path)
+
     if not _JSONSCHEMA_AVAILABLE:
         return
 
@@ -147,6 +160,84 @@ def _validate_config(config: dict, config_path: Path) -> None:
                 print(f"       ... and {len(errors) - 5} more", file=sys.stderr)
     except (ImportError, TypeError, ValueError):
         pass  # jsonschema not installed or validation error — best-effort
+
+
+def _validate_model_inheritance(config: dict, config_path: Path) -> None:
+    """Hard-validate 'model-inherit-main-chat' typing and mutual exclusivity.
+
+    Any violation aborts via SystemExit(1) — same fatal pattern load_config()
+    already uses for YAML/JSON parse errors. Checks:
+
+    1. The block must be a mapping and every provider entry must be a bool.
+       Non-bool values would be silently ignored by resolve_model(), so they
+       are rejected here instead of being swallowed.
+
+    2. 'model-override-all' and 'model-inherit-main-chat' are mutually
+       exclusive per provider: resolve_model() returns on a truthy
+       override-all entry before inheritance is ever consulted, so a truthy
+       value in both for the same provider is a config bug.
+       'false' counts as unset; different providers never conflict.
+    """
+    inherit = config.get("model-inherit-main-chat")
+    if not inherit:  # missing / empty / falsy scalar — nothing to validate
+        return
+
+    if not isinstance(inherit, dict):
+        print(
+            f"ERROR: {config_path}: invalid 'model-inherit-main-chat': "
+            f"expected a mapping of provider -> true/false, "
+            f"got {type(inherit).__name__}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    type_errors = [
+        f"  '{provider}': expected true/false (bool), got {value!r} "
+        f"({type(value).__name__})"
+        for provider, value in sorted(inherit.items())
+        if not isinstance(value, bool)
+    ]
+    if type_errors:
+        print(
+            f"ERROR: {config_path}: invalid 'model-inherit-main-chat' entries "
+            "(every provider entry must be a bool):",
+            file=sys.stderr,
+        )
+        for type_error in type_errors:
+            print(type_error, file=sys.stderr)
+        sys.exit(1)
+
+    override_all = config.get("model-override-all")
+    if not isinstance(override_all, dict):
+        # Wrong types here are covered by the schema warnings below;
+        # resolve_model() ignores non-mapping blocks as well.
+        return
+
+    conflicts = [
+        provider
+        for provider, value in sorted(inherit.items())
+        if value and override_all.get(provider)
+    ]
+    if conflicts:
+        print(
+            f"ERROR: {config_path}: conflicting model configuration for "
+            f"provider(s): {', '.join(conflicts)}.",
+            file=sys.stderr,
+        )
+        for provider in conflicts:
+            print(
+                f"  Provider '{provider}' is set in BOTH 'model-override-all' AND "
+                "'model-inherit-main-chat' — these two keys are mutually exclusive "
+                "per provider.",
+                file=sys.stderr,
+            )
+            print(
+                f"  Fix: delete one of the two keys for '{provider}', e.g. remove "
+                f"the '{provider}: ...' line under 'model-override-all:' OR remove "
+                f"'{provider}' (or the whole block) under 'model-inherit-main-chat:'.",
+                file=sys.stderr,
+            )
+        sys.exit(1)
 
 
 def find_agent_meta_root(script_path: Path) -> Path:

--- a/scripts/lib/roles.py
+++ b/scripts/lib/roles.py
@@ -98,7 +98,19 @@ def resolve_model(
     provider_config: dict | None = None,
     log: Optional["SyncLog"] = None,
 ) -> str:
-    """Resolve the model ID for a role and provider using tier presets and registry."""
+    """Resolve the model ID for a role and provider using tier presets and registry.
+
+    Resolution order (highest to lowest):
+    1. Global override: project_config["model-override-all"][provider] —
+       tier/alias/model ID applied to every role of this provider.
+    2. Main-chat inheritance: project_config["model-inherit-main-chat"][provider]
+       truthy → return "" so inject_model_field() omits the model: field and
+       the agent inherits the main-chat model at runtime.
+    Stages 1 and 2 are mutually exclusive per provider; validation of that
+    constraint happens in scripts/lib/config.py::_validate_config(), not here.
+    3. Everything else: per-role overrides, role-defaults, tier-overrides and
+       tier presets, resolved via _resolve_tier_to_model().
+    """
 
     tier_or_id = ""
     explicit_override = False
@@ -116,6 +128,20 @@ def resolve_model(
             if log:
                 log.debug(f"{provider}/{role}", f"GLOBAL override-all for provider '{provider}' (reversible): {resolved_all}")
             return resolved_all
+
+    # model-inherit-main-chat: the agent deliberately gets NO model: field and
+    # inherits the main-chat model at runtime. Returning "" is the established
+    # mechanism — inject_model_field() omits the model: field for an empty
+    # resolved value. Mutually exclusive with model-override-all per provider;
+    # that constraint is validated in config.py::_validate_config().
+    inherit_main_chat = project_config.get("model-inherit-main-chat", {})
+    if isinstance(inherit_main_chat, dict) and inherit_main_chat.get(provider):
+        if log:
+            log.debug(
+                f"{provider}/{role}",
+                f"model-inherit-main-chat active for provider '{provider}': omitting model field (inherits main-chat model)",
+            )
+        return ""
 
     provider_overrides = project_config.get("model-overrides", {})
     provider_specific = provider_overrides.get(provider, {})

--- a/templates/configs/project.yaml.example
+++ b/templates/configs/project.yaml.example
@@ -113,6 +113,19 @@ project:
 #   developer: powerful
 #
 # Rückwärtskompatibel: haiku / sonnet / opus funktionieren weiterhin für Claude.
+#
+# Main-Chat-Modell erben — Agenten eines Providers bekommen KEIN festes
+# model: in den generierten Agentendateien und erben zur Laufzeit das
+# Modell, das gerade im Main-Chat aktiv ist. Nützlich wenn man das
+# Main-Chat-Modell oft wechselt und die Agenten automatisch folgen sollen.
+# model-inherit-main-chat:
+#   Claude: true             # alle Claude-Agenten erben das Main-Chat-Modell
+#   Gemini: false            # unset — normale Rollen-/Tier-Auflösung greift
+#
+# ACHTUNG: Pro Provider exklusiv zu model-override-all — steht derselbe
+# Provider in BEIDEN Keys, bricht der Sync sofort mit Fehler ab.
+# Reversibel: einfach den Provider-Key (oder den ganzen Block) löschen
+# und neu syncen — die bisherigen pro-Rolle-Einstellungen greifen wieder.
 
 # Definition of Done — einzelne Kriterien überschreiben
 # dod:

--- a/tests/test_model_inherit.py
+++ b/tests/test_model_inherit.py
@@ -1,0 +1,207 @@
+"""Tests for model-inherit-main-chat (main-chat model inheritance).
+
+Covers:
+- resolve_model(): truthy 'model-inherit-main-chat'[provider] returns ""
+  for every role of that provider, beating per-role overrides,
+  tier-overrides and tier presets.
+- config._validate_model_inheritance(): mutual exclusivity with
+  'model-override-all' per provider (SystemExit on conflict/type errors),
+  different providers never conflict.
+- Regression: plain 'model-override-all' still resolves to a model ID.
+- No-op semantics: absent / None / false entries change nothing.
+
+Tests use the real config files from the repo — no mocking.
+All tests target the Claude provider for deterministic model IDs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.lib.config import _validate_model_inheritance
+from scripts.lib.providers import load_providers_config
+from scripts.lib.roles import resolve_model
+
+
+REPO_ROOT = Path(__file__).parent.parent
+
+CLAUDE_MODEL_POWERFUL = "claude-opus-4-8"
+CLAUDE_MODEL_FAST = "claude-haiku-4-5-20251001"
+CLAUDE_MODEL_BALANCED = "claude-sonnet-5"
+
+_PROVIDER_CONFIG = load_providers_config(REPO_ROOT)
+
+
+def _resolve(role: str, extra: dict | None = None) -> str:
+    """Helper: resolve model for a role with the Normal preset (+ extras)."""
+    project_config: dict = {"tier-preset": "Normal"}
+    if extra:
+        project_config.update(extra)
+    return resolve_model(
+        role=role,
+        project_config=project_config,
+        agent_meta_root=REPO_ROOT,
+        provider="Claude",
+        provider_config=_PROVIDER_CONFIG,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Inheritance wins over everything below it
+# ---------------------------------------------------------------------------
+
+def test_inherit_returns_empty_string_for_role() -> None:
+    """Truthy inherit entry → empty string so no model: field is injected."""
+    assert _resolve("developer", extra={"model-inherit-main-chat": {"Claude": True}}) == ""
+
+
+def test_inherit_beats_overrides_and_presets() -> None:
+    """Inheritance must beat per-role overrides, tier-overrides and presets."""
+    noisy = {
+        "model-inherit-main-chat": {"Claude": True},
+        "model-overrides": {"Claude": {"developer": CLAUDE_MODEL_POWERFUL}},
+        "tier-overrides": {"developer": "fast"},
+        "tier-preset": "Expensive as Hell",
+        "se-focus": True,
+    }
+    resolved = _resolve("developer", extra=noisy)
+    assert resolved == "", (
+        f"Inheritance must win over overrides/presets, got {resolved!r}"
+    )
+
+
+def test_inherit_without_noise_would_resolve_nonempty() -> None:
+    """Sanity: the same overrides WITHOUT inheritance produce a real model —
+    proves the empty string above comes from inheritance, not from broken config."""
+    baseline = {
+        "model-overrides": {"Claude": {"developer": CLAUDE_MODEL_POWERFUL}},
+        "tier-preset": "Expensive as Hell",
+    }
+    resolved = _resolve("developer", extra=baseline)
+    assert resolved == CLAUDE_MODEL_POWERFUL
+
+
+def test_inherit_only_applies_to_configured_provider() -> None:
+    """A Gemini-only inherit entry must not affect the Claude provider."""
+    resolved = _resolve(
+        "senior-developer",
+        extra={"model-inherit-main-chat": {"Gemini": True}},
+    )
+    assert resolved == CLAUDE_MODEL_POWERFUL, (
+        f"Claude must fall through to Normal preset resolution, got {resolved!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) Mutual exclusivity validation (_validate_model_inheritance)
+# ---------------------------------------------------------------------------
+
+def test_conflict_same_provider_exits_with_provider_and_keys() -> None:
+    """Same provider set in both keys → SystemExit(1), message names provider + both keys."""
+    config = {
+        "model-inherit-main-chat": {"Claude": True},
+        "model-override-all": {"Claude": "powerful"},
+    }
+    with pytest.raises(SystemExit) as excinfo:
+        _validate_model_inheritance(config, Path("project.yaml"))
+
+    assert excinfo.value.code == 1
+
+
+def test_conflict_message_contains_provider_and_both_keys(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr output must mention the provider and BOTH conflicting keys."""
+    config = {
+        "model-inherit-main-chat": {"Claude": True},
+        "model-override-all": {"Claude": "powerful"},
+    }
+    with pytest.raises(SystemExit):
+        _validate_model_inheritance(config, Path("project.yaml"))
+
+    stderr = capsys.readouterr().err
+    assert "Claude" in stderr
+    assert "model-override-all" in stderr
+    assert "model-inherit-main-chat" in stderr
+
+
+def test_no_conflict_across_different_providers(capsys: pytest.CaptureFixture[str]) -> None:
+    """Different providers never conflict — no SystemExit."""
+    config = {
+        "model-inherit-main-chat": {"Claude": True},
+        "model-override-all": {"Gemini": "powerful"},
+    }
+    _validate_model_inheritance(config, Path("project.yaml"))
+    assert "ERROR" not in capsys.readouterr().err
+
+
+def test_false_inherit_counts_as_unset_even_with_override_all() -> None:
+    """'false' counts as unset: false + override-all for the SAME provider is fine."""
+    config = {
+        "model-inherit-main-chat": {"Claude": False},
+        "model-override-all": {"Claude": "powerful"},
+    }
+    _validate_model_inheritance(config, Path("project.yaml"))
+
+
+def test_non_bool_entry_exits_with_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-bool provider entry (would be silently ignored at runtime) → hard abort."""
+    config = {"model-inherit-main-chat": {"Claude": "yes"}}
+    with pytest.raises(SystemExit) as excinfo:
+        _validate_model_inheritance(config, Path("project.yaml"))
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "model-inherit-main-chat" in stderr
+    assert "'yes'" in stderr
+    assert "bool" in stderr
+
+
+def test_non_mapping_block_exits_with_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """A scalar instead of a mapping → hard abort naming the key."""
+    config = {"model-inherit-main-chat": True}
+    with pytest.raises(SystemExit) as excinfo:
+        _validate_model_inheritance(config, Path("project.yaml"))
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "model-inherit-main-chat" in stderr
+
+
+# ---------------------------------------------------------------------------
+# (c) REGRESSION: override-all still resolves to a model ID
+# ---------------------------------------------------------------------------
+
+def test_regression_override_all_resolves_tier_to_model_id() -> None:
+    """Plain override-all with a tier name must resolve to the concrete model ID."""
+    resolved = _resolve("developer", extra={"model-override-all": {"Claude": "powerful"}})
+    assert resolved == CLAUDE_MODEL_POWERFUL
+
+
+def test_regression_override_all_passthrough_model_id() -> None:
+    """Plain override-all with a full model ID must be returned as-is."""
+    resolved = _resolve("developer", extra={"model-override-all": {"Claude": CLAUDE_MODEL_FAST}})
+    assert resolved == CLAUDE_MODEL_FAST
+
+
+# ---------------------------------------------------------------------------
+# (d) No-op semantics: absent / None / false
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        pytest.param({}, id="key-absent"),
+        pytest.param({"model-inherit-main-chat": None}, id="explicit-none"),
+        pytest.param({"model-inherit-main-chat": {"Claude": False}}, id="explicit-false"),
+        pytest.param({"model-inherit-main-chat": {}}, id="empty-block"),
+    ],
+)
+def test_noop_variants_behave_like_baseline(extra: dict) -> None:
+    """Absent/None/false/empty inherit must not change normal resolution."""
+    resolved = _resolve("developer", extra=extra)
+    baseline = _resolve("developer")
+    assert resolved == baseline == CLAUDE_MODEL_BALANCED, (
+        f"No-op variant must match Normal-preset baseline: got {resolved!r}, expected {baseline!r}"
+    )


### PR DESCRIPTION
## Summary

Fuegt `model-inherit-main-chat` als **zweiten Super-Override** neben `model-override-all` hinzu (Mapping Provider → bool).

### Verhalten
- Resolve → `""` ⇒ das `model`-Feld entfällt komplett ⇒ **Main-Chat-Erbfolge** (Agent erbt das Modell des Main-Chats).
- **Hart exklusiv pro Provider:** `model-override-all` und `model-inherit-main-chat` sind gegenseitig ausschliessend — Verstoß = Fail-Fast mit Exit 1.

### Komponenten
- Admin-Toggle im Admin-UI + neuer Endpoint `POST /api/model-inherit`
- Schema (`config/project-config.schema.json`), Beispiele (`templates/`, `howto/`, `docs/guides`), Skill `.claude/skills/model-override-all/SKILL.md`, Template §8b.2 (v1.13.0)

### Validation
- Tests: 51 passed
- `sync.py --validate`: Exit 0
- Regression `model-override-all`: intakt, 53/53

### Commits
1. `feat: add model-inherit-main-chat super-override mode`
2. `test: cover inherit-main-chat resolution and exclusivity`
3. `docs: document main-chat inheritance mode`
4. `chore(sync): regenerate context files and hashes`
