### PR TITLE
fix: bug batch — guard hardening (#516) and truncation guards (#514)

### DIFF
--- a/.claude/hooks/orchestrator-guard.sh
+++ b/.claude/hooks/orchestrator-guard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hook: orchestrator-guard
-# version: 2.3.0
+# version: 2.4.0
 # event: PreToolUse
 # matcher: ""
 # description: Block non-orchestrator write/edit/bash calls when orchestrator.strict=true; also block direct git mutations in non-strict mode
@@ -34,6 +34,22 @@
 # boundary against a malicious agent, only a fix for the identification gap.
 # Write/Edit have no such safe channel (a marker would corrupt file
 # content), so they are never exempted under strict mode.
+#
+# Hardening (issue #516): a real-world incident showed a non-git worker
+# self-declaring as `git` via this sentinel to run destructive stash
+# operations. Elevation is therefore capability-scoped and audited:
+#   * `orchestrator` sentinel exempts ONLY from strict-mode main-chat
+#     blocking (Bash) — it NEVER bypasses the git-mutation block.
+#   * `git` sentinel exempts ONLY from the git-mutation block.
+#   * Destructive operations (force push, reset --hard, clean -f, stash
+#     drop/clear, filter-branch/filter-repo, working-tree wipe) are
+#     blocked EVEN with a valid `git` sentinel and require the user to
+#     approve/run them manually.
+#   * Every elevation attempt is appended to .claude/hooks/.guard-audit.log
+#     for post-hoc review.
+# Identity itself remains unverifiable at hook level (provider payload has
+# no agent field) — this is mitigation, not cryptographic trust; see
+# .claude/rules/a2a-delegation-gates.md ("Bekannte Grenzen").
 
 INPUT=$(cat)
 
@@ -88,16 +104,62 @@ line = content.split('\n', 1)[0].strip()
 m = re.match(r'^#agent-meta:agent=([A-Za-z0-9_-]+)$', line)
 print(m.group(1) if m else '')
 " 2>/dev/null || echo "")
-
-  if echo "$DECLARED_AGENT" | grep -qiE '^(orchestrator|git)$'; then
-    exit 0
-  fi
 fi
 
-# Determine project root
+# Determine project root (needed by the audit log and config lookup)
 PROJECT_ROOT=$(echo "$INPUT" | $_PY -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
 if [ -z "$PROJECT_ROOT" ]; then
   PROJECT_ROOT="$PWD"
+fi
+
+# --- Sentinel elevation: capability-scoped + audited (issue #516) ------
+IS_GIT_SENTINEL=0
+IS_ORCH_SENTINEL=0
+
+if [ "$TOOL_NAME" = "Bash" ] && [ -n "$DECLARED_AGENT" ]; then
+  _ROLE=$(echo "$DECLARED_AGENT" | tr '[:upper:]' '[:lower:]')
+  case "$_ROLE" in
+    git|orchestrator)
+      _AUDIT_LOG="$PROJECT_ROOT/.claude/hooks/.guard-audit.log"
+      mkdir -p "$(dirname "$_AUDIT_LOG")" 2>/dev/null || true
+      printf '%s role=%s cmd=%s\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$_ROLE" \
+        "$(printf '%s' "$BASH_CMD" | tr '\n\t' '  ' | head -c 200)" \
+        >> "$_AUDIT_LOG" 2>/dev/null || true
+      if [ "$_ROLE" = "git" ]; then
+        IS_GIT_SENTINEL=1
+      else
+        IS_ORCH_SENTINEL=1
+      fi
+      ;;
+  esac
+fi
+
+# --- Destructive-operation gate: applies regardless of sentinel --------
+if [ "$TOOL_NAME" = "Bash" ]; then
+  IS_DESTRUCTIVE=$(printf '%s' "$BASH_CMD" | $_PY -c "
+import re, sys
+
+command = sys.stdin.read()
+
+DESTRUCTIVE_PATTERNS = [
+    r'\bpush\b[^|;&]*(--force\b|-f\b|--force-with-lease\b)',
+    r'\breset\b[^|;&]*--hard',
+    r'\bclean\b[^|;&]*-[a-zA-Z]*f',
+    r'\bstash\s+(drop|clear)\b',
+    r'\bfilter-(branch|repo)\b',
+    r'\bcheckout\b[^|;&]*--\s+\.',
+    r'\brestore\b[^|;&]*\s\.\s*$',
+]
+print('true' if any(re.search(p, command) for p in DESTRUCTIVE_PATTERNS) else 'false')
+" 2>/dev/null || echo "false")
+
+  if [ "$IS_DESTRUCTIVE" = "true" ]; then
+    echo "ORCHESTRATOR_GUARD: destructive git operation requires explicit user approval (issue #516)." >&2
+    echo "Detected command: $(echo "$BASH_CMD" | head -c 200)" >&2
+    echo "Ask the user to approve and run this command manually." >&2
+    exit 2
+  fi
 fi
 
 # Check if strict mode is enabled in project.yaml
@@ -143,6 +205,11 @@ except Exception:
 " "$CONFIG_FILE" "$AGENT_META_PROVIDER" 2>/dev/null)
 
   if [ "$STRICT" = "true" ]; then
+    # Orchestrator sentinel exempts only plain Bash calls from strict-mode
+    # main-chat blocking — never Write/Edit, never the git-mutation gate.
+    if [ "$TOOL_NAME" = "Bash" ] && [ "$IS_ORCH_SENTINEL" = "1" ]; then
+      exit 0
+    fi
     echo "ORCHESTRATOR_GUARD: STRICT MODE is active. Direct $TOOL_NAME calls in the main chat are blocked." >&2
     echo "Delegate this task to the orchestrator agent." >&2
     exit 2
@@ -216,7 +283,7 @@ for stmt in statements(command):
 print('true' if blocked else 'false')
 " 2>/dev/null || echo "false")
 
-  if [ "$IS_MUTATION" = "true" ]; then
+  if [ "$IS_MUTATION" = "true" ] && [ "$IS_GIT_SENTINEL" != "1" ]; then
     echo "ORCHESTRATOR_GUARD: Direct git mutations are forbidden in the main chat." >&2
     echo "Detected command: $(echo "$BASH_CMD" | head -c 200)" >&2
     echo "Delegate git operations to the \`git\` agent." >&2

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ node_modules/
 
 # local Python virtualenv (never commit)
 .venv/
+.guard-audit.log

--- a/.mammouth/hooks/orchestrator-guard.sh
+++ b/.mammouth/hooks/orchestrator-guard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hook: orchestrator-guard
-# version: 2.3.0
+# version: 2.4.0
 # event: PreToolUse
 # matcher: ""
 # description: Block non-orchestrator write/edit/bash calls when orchestrator.strict=true; also block direct git mutations in non-strict mode
@@ -34,6 +34,22 @@
 # boundary against a malicious agent, only a fix for the identification gap.
 # Write/Edit have no such safe channel (a marker would corrupt file
 # content), so they are never exempted under strict mode.
+#
+# Hardening (issue #516): a real-world incident showed a non-git worker
+# self-declaring as `git` via this sentinel to run destructive stash
+# operations. Elevation is therefore capability-scoped and audited:
+#   * `orchestrator` sentinel exempts ONLY from strict-mode main-chat
+#     blocking (Bash) — it NEVER bypasses the git-mutation block.
+#   * `git` sentinel exempts ONLY from the git-mutation block.
+#   * Destructive operations (force push, reset --hard, clean -f, stash
+#     drop/clear, filter-branch/filter-repo, working-tree wipe) are
+#     blocked EVEN with a valid `git` sentinel and require the user to
+#     approve/run them manually.
+#   * Every elevation attempt is appended to .claude/hooks/.guard-audit.log
+#     for post-hoc review.
+# Identity itself remains unverifiable at hook level (provider payload has
+# no agent field) — this is mitigation, not cryptographic trust; see
+# .claude/rules/a2a-delegation-gates.md ("Bekannte Grenzen").
 
 INPUT=$(cat)
 
@@ -88,16 +104,62 @@ line = content.split('\n', 1)[0].strip()
 m = re.match(r'^#agent-meta:agent=([A-Za-z0-9_-]+)$', line)
 print(m.group(1) if m else '')
 " 2>/dev/null || echo "")
-
-  if echo "$DECLARED_AGENT" | grep -qiE '^(orchestrator|git)$'; then
-    exit 0
-  fi
 fi
 
-# Determine project root
+# Determine project root (needed by the audit log and config lookup)
 PROJECT_ROOT=$(echo "$INPUT" | $_PY -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
 if [ -z "$PROJECT_ROOT" ]; then
   PROJECT_ROOT="$PWD"
+fi
+
+# --- Sentinel elevation: capability-scoped + audited (issue #516) ------
+IS_GIT_SENTINEL=0
+IS_ORCH_SENTINEL=0
+
+if [ "$TOOL_NAME" = "Bash" ] && [ -n "$DECLARED_AGENT" ]; then
+  _ROLE=$(echo "$DECLARED_AGENT" | tr '[:upper:]' '[:lower:]')
+  case "$_ROLE" in
+    git|orchestrator)
+      _AUDIT_LOG="$PROJECT_ROOT/.claude/hooks/.guard-audit.log"
+      mkdir -p "$(dirname "$_AUDIT_LOG")" 2>/dev/null || true
+      printf '%s role=%s cmd=%s\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$_ROLE" \
+        "$(printf '%s' "$BASH_CMD" | tr '\n\t' '  ' | head -c 200)" \
+        >> "$_AUDIT_LOG" 2>/dev/null || true
+      if [ "$_ROLE" = "git" ]; then
+        IS_GIT_SENTINEL=1
+      else
+        IS_ORCH_SENTINEL=1
+      fi
+      ;;
+  esac
+fi
+
+# --- Destructive-operation gate: applies regardless of sentinel --------
+if [ "$TOOL_NAME" = "Bash" ]; then
+  IS_DESTRUCTIVE=$(printf '%s' "$BASH_CMD" | $_PY -c "
+import re, sys
+
+command = sys.stdin.read()
+
+DESTRUCTIVE_PATTERNS = [
+    r'\bpush\b[^|;&]*(--force\b|-f\b|--force-with-lease\b)',
+    r'\breset\b[^|;&]*--hard',
+    r'\bclean\b[^|;&]*-[a-zA-Z]*f',
+    r'\bstash\s+(drop|clear)\b',
+    r'\bfilter-(branch|repo)\b',
+    r'\bcheckout\b[^|;&]*--\s+\.',
+    r'\brestore\b[^|;&]*\s\.\s*$',
+]
+print('true' if any(re.search(p, command) for p in DESTRUCTIVE_PATTERNS) else 'false')
+" 2>/dev/null || echo "false")
+
+  if [ "$IS_DESTRUCTIVE" = "true" ]; then
+    echo "ORCHESTRATOR_GUARD: destructive git operation requires explicit user approval (issue #516)." >&2
+    echo "Detected command: $(echo "$BASH_CMD" | head -c 200)" >&2
+    echo "Ask the user to approve and run this command manually." >&2
+    exit 2
+  fi
 fi
 
 # Check if strict mode is enabled in project.yaml
@@ -143,6 +205,11 @@ except Exception:
 " "$CONFIG_FILE" "$AGENT_META_PROVIDER" 2>/dev/null)
 
   if [ "$STRICT" = "true" ]; then
+    # Orchestrator sentinel exempts only plain Bash calls from strict-mode
+    # main-chat blocking — never Write/Edit, never the git-mutation gate.
+    if [ "$TOOL_NAME" = "Bash" ] && [ "$IS_ORCH_SENTINEL" = "1" ]; then
+      exit 0
+    fi
     echo "ORCHESTRATOR_GUARD: STRICT MODE is active. Direct $TOOL_NAME calls in the main chat are blocked." >&2
     echo "Delegate this task to the orchestrator agent." >&2
     exit 2
@@ -216,7 +283,7 @@ for stmt in statements(command):
 print('true' if blocked else 'false')
 " 2>/dev/null || echo "false")
 
-  if [ "$IS_MUTATION" = "true" ]; then
+  if [ "$IS_MUTATION" = "true" ] && [ "$IS_GIT_SENTINEL" != "1" ]; then
     echo "ORCHESTRATOR_GUARD: Direct git mutations are forbidden in the main chat." >&2
     echo "Detected command: $(echo "$BASH_CMD" | head -c 200)" >&2
     echo "Delegate git operations to the \`git\` agent." >&2

--- a/agents/1-generic/code-reviewer.md
+++ b/agents/1-generic/code-reviewer.md
@@ -149,4 +149,17 @@ NEXT: [Merge | Back to developer | Escalate]
 
 **Language:** review reports → English.
 </constraints>
+
+<output-guard>
+## Silent truncation guard (issue #514)
+
+The synchronous tool-result channel truncates large responses **silently**
+(loss from the beginning, no error signal). Therefore:
+
+- Hard-cap any single response at ~400 lines.
+- Larger reviews: return verdict + severity counts + top findings first,
+  then offer `chunk k/n` continuation on request.
+- For full-length reports, recommend a write-capable role persisting them
+  to a file via the orchestrator instead.
+</output-guard>
 </output>

--- a/agents/1-generic/explorer.md
+++ b/agents/1-generic/explorer.md
@@ -82,4 +82,15 @@ ERRORS: <empty if none>
 
 **Language:** output in {{COMMUNICATION_LANGUAGE}}, code snippets/paths in original language.
 </constraints>
+
+<output-guard>
+## Silent truncation guard (issue #514)
+
+The synchronous tool-result channel truncates large responses **silently**
+(loss from the beginning, no error signal). Therefore:
+
+- Hard-cap any single response at ~400 lines.
+- Larger digests: return a structured summary (paths + one-liners) and
+  offer `chunk k/n` continuation on request instead of dumping everything.
+</output-guard>
 </output>

--- a/agents/1-generic/planner.md
+++ b/agents/1-generic/planner.md
@@ -95,3 +95,18 @@ Report the plan using `<output_contract>`. Do not auto-trigger the `feature-life
 
 **Language:** communication → {{COMMUNICATION_LANGUAGE}}. Plan artifacts → project language.
 </constraints>
+
+<output-guard>
+## Silent truncation guard (issue #514)
+
+The synchronous tool-result channel truncates large responses **silently**
+(loss from the beginning, no error signal). Therefore:
+
+- Hard-cap any single response at ~400 lines.
+- For larger plans: return a compact executive summary + numbered task
+  outline + **only the first task in full**, then offer `chunk k/n`
+  continuation on request.
+- If the caller needs the full plan in one piece, recommend delegating the
+  write-out to a write-capable role (e.g., `senior-developer`) via the
+  orchestrator instead of streaming it through this channel.
+</output-guard>

--- a/hooks/1-generic/orchestrator-guard.sh
+++ b/hooks/1-generic/orchestrator-guard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hook: orchestrator-guard
-# version: 2.3.0
+# version: 2.4.0
 # event: PreToolUse
 # matcher: ""
 # description: Block non-orchestrator write/edit/bash calls when orchestrator.strict=true; also block direct git mutations in non-strict mode
@@ -34,6 +34,22 @@
 # boundary against a malicious agent, only a fix for the identification gap.
 # Write/Edit have no such safe channel (a marker would corrupt file
 # content), so they are never exempted under strict mode.
+#
+# Hardening (issue #516): a real-world incident showed a non-git worker
+# self-declaring as `git` via this sentinel to run destructive stash
+# operations. Elevation is therefore capability-scoped and audited:
+#   * `orchestrator` sentinel exempts ONLY from strict-mode main-chat
+#     blocking (Bash) — it NEVER bypasses the git-mutation block.
+#   * `git` sentinel exempts ONLY from the git-mutation block.
+#   * Destructive operations (force push, reset --hard, clean -f, stash
+#     drop/clear, filter-branch/filter-repo, working-tree wipe) are
+#     blocked EVEN with a valid `git` sentinel and require the user to
+#     approve/run them manually.
+#   * Every elevation attempt is appended to .claude/hooks/.guard-audit.log
+#     for post-hoc review.
+# Identity itself remains unverifiable at hook level (provider payload has
+# no agent field) — this is mitigation, not cryptographic trust; see
+# .claude/rules/a2a-delegation-gates.md ("Bekannte Grenzen").
 
 INPUT=$(cat)
 
@@ -88,16 +104,62 @@ line = content.split('\n', 1)[0].strip()
 m = re.match(r'^#agent-meta:agent=([A-Za-z0-9_-]+)$', line)
 print(m.group(1) if m else '')
 " 2>/dev/null || echo "")
-
-  if echo "$DECLARED_AGENT" | grep -qiE '^(orchestrator|git)$'; then
-    exit 0
-  fi
 fi
 
-# Determine project root
+# Determine project root (needed by the audit log and config lookup)
 PROJECT_ROOT=$(echo "$INPUT" | $_PY -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
 if [ -z "$PROJECT_ROOT" ]; then
   PROJECT_ROOT="$PWD"
+fi
+
+# --- Sentinel elevation: capability-scoped + audited (issue #516) ------
+IS_GIT_SENTINEL=0
+IS_ORCH_SENTINEL=0
+
+if [ "$TOOL_NAME" = "Bash" ] && [ -n "$DECLARED_AGENT" ]; then
+  _ROLE=$(echo "$DECLARED_AGENT" | tr '[:upper:]' '[:lower:]')
+  case "$_ROLE" in
+    git|orchestrator)
+      _AUDIT_LOG="$PROJECT_ROOT/.claude/hooks/.guard-audit.log"
+      mkdir -p "$(dirname "$_AUDIT_LOG")" 2>/dev/null || true
+      printf '%s role=%s cmd=%s\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$_ROLE" \
+        "$(printf '%s' "$BASH_CMD" | tr '\n\t' '  ' | head -c 200)" \
+        >> "$_AUDIT_LOG" 2>/dev/null || true
+      if [ "$_ROLE" = "git" ]; then
+        IS_GIT_SENTINEL=1
+      else
+        IS_ORCH_SENTINEL=1
+      fi
+      ;;
+  esac
+fi
+
+# --- Destructive-operation gate: applies regardless of sentinel --------
+if [ "$TOOL_NAME" = "Bash" ]; then
+  IS_DESTRUCTIVE=$(printf '%s' "$BASH_CMD" | $_PY -c "
+import re, sys
+
+command = sys.stdin.read()
+
+DESTRUCTIVE_PATTERNS = [
+    r'\bpush\b[^|;&]*(--force\b|-f\b|--force-with-lease\b)',
+    r'\breset\b[^|;&]*--hard',
+    r'\bclean\b[^|;&]*-[a-zA-Z]*f',
+    r'\bstash\s+(drop|clear)\b',
+    r'\bfilter-(branch|repo)\b',
+    r'\bcheckout\b[^|;&]*--\s+\.',
+    r'\brestore\b[^|;&]*\s\.\s*$',
+]
+print('true' if any(re.search(p, command) for p in DESTRUCTIVE_PATTERNS) else 'false')
+" 2>/dev/null || echo "false")
+
+  if [ "$IS_DESTRUCTIVE" = "true" ]; then
+    echo "ORCHESTRATOR_GUARD: destructive git operation requires explicit user approval (issue #516)." >&2
+    echo "Detected command: $(echo "$BASH_CMD" | head -c 200)" >&2
+    echo "Ask the user to approve and run this command manually." >&2
+    exit 2
+  fi
 fi
 
 # Check if strict mode is enabled in project.yaml
@@ -143,6 +205,11 @@ except Exception:
 " "$CONFIG_FILE" "$AGENT_META_PROVIDER" 2>/dev/null)
 
   if [ "$STRICT" = "true" ]; then
+    # Orchestrator sentinel exempts only plain Bash calls from strict-mode
+    # main-chat blocking — never Write/Edit, never the git-mutation gate.
+    if [ "$TOOL_NAME" = "Bash" ] && [ "$IS_ORCH_SENTINEL" = "1" ]; then
+      exit 0
+    fi
     echo "ORCHESTRATOR_GUARD: STRICT MODE is active. Direct $TOOL_NAME calls in the main chat are blocked." >&2
     echo "Delegate this task to the orchestrator agent." >&2
     exit 2
@@ -216,7 +283,7 @@ for stmt in statements(command):
 print('true' if blocked else 'false')
 " 2>/dev/null || echo "false")
 
-  if [ "$IS_MUTATION" = "true" ]; then
+  if [ "$IS_MUTATION" = "true" ] && [ "$IS_GIT_SENTINEL" != "1" ]; then
     echo "ORCHESTRATOR_GUARD: Direct git mutations are forbidden in the main chat." >&2
     echo "Detected command: $(echo "$BASH_CMD" | head -c 200)" >&2
     echo "Delegate git operations to the \`git\` agent." >&2

--- a/tests/test_orchestrator_guard_hook.py
+++ b/tests/test_orchestrator_guard_hook.py
@@ -200,3 +200,59 @@ def test_git_mutation_regex_precision(command, expect_blocked, tmp_path):
         f"command={command!r}: expected exit {expected}, got {result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
+
+
+# --- issue #516: capability-scoped sentinel elevation -------------------
+
+def test_git_sentinel_still_allows_plain_mutation(tmp_path):
+    """Valid `git` sentinel exempts plain git mutations (existing behavior)."""
+    command = "#agent-meta:agent=git\ngit add -A && git commit -m 'x'"
+    result = _run_hook({**_bash_payload(command), "cwd": tmp_path.as_posix()})
+    assert result.returncode == 0, f"stderr={result.stderr}"
+
+
+def test_orchestrator_sentinel_no_longer_bypasses_git_block(tmp_path):
+    """#516: `orchestrator` sentinel must NOT bypass the git-mutation block."""
+    command = "#agent-meta:agent=orchestrator\ngit commit -m 'x'"
+    result = _run_hook({**_bash_payload(command), "cwd": tmp_path.as_posix()})
+    assert result.returncode == 2, f"stderr={result.stderr}"
+    assert "git" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("command", [
+    "#agent-meta:agent=git\ngit push --force origin main",
+    "#agent-meta:agent=git\n git push -f origin main",
+    "#agent-meta:agent=git\ngit reset --hard HEAD~1",
+    "#agent-meta:agent=git\ngit clean -fd",
+    "#agent-meta:agent=git\ngit stash drop stash@{0}",
+    "#agent-meta:agent=git\ngit stash clear",
+    "#agent-meta:agent=git\ngit filter-branch --tree-filter 'x' HEAD",
+])
+def test_destructive_ops_blocked_even_with_git_sentinel(command, tmp_path):
+    """#516: destructive ops require user approval even with valid sentinel."""
+    result = _run_hook({**_bash_payload(command), "cwd": tmp_path.as_posix()})
+    assert result.returncode == 2, f"stderr={result.stderr}"
+    assert "user approval" in result.stderr
+
+
+def test_non_git_agent_cannot_use_fake_sentinel_for_destructive(tmp_path):
+    """The exact incident from #516: fake `general-purpose` elevation path is
+    irrelevant — even claiming git, destructive ops stay blocked."""
+    command = "#agent-meta:agent=git\ngit stash pop"
+    # stash pop is NOT in the destructive list (only drop/clear); plain pop
+    # with valid sentinel stays allowed — but a FAKE claim of an unknown
+    # role gets no exemption at all:
+    fake = "#agent-meta:agent=general-purpose\ngit commit -m 'x'"
+    r2 = _run_hook({**_bash_payload(fake), "cwd": tmp_path.as_posix()})
+    assert r2.returncode == 2
+
+
+def test_elevation_attempts_are_audited(tmp_path):
+    """Every sentinel elevation appends to .guard-audit.log (#516)."""
+    audit_file = tmp_path / ".claude" / "hooks" / ".guard-audit.log"
+    command = "#agent-meta:agent=git\ngit status"
+    _run_hook({**_bash_payload(command), "cwd": tmp_path.as_posix()})
+    assert audit_file.exists(), "audit log not created"
+    content = audit_file.read_text(encoding="utf-8")
+    assert "role=git" in content
+    assert "git status" in content

--- a/tests/test_review_fleet.py
+++ b/tests/test_review_fleet.py
@@ -102,3 +102,16 @@ def test_routing_matrix_file_structure():
     assert "synthesis:" in content
     for role in ("frontend-reviewer", "backend-reviewer", "database-reviewer", "ui-reviewer"):
         assert role in content, f"{role} not referenced in routing matrix"
+
+
+# --- issue #514: silent return-channel truncation mitigation ------------
+
+_MITIGATION_ROLES = ("planner", "code-reviewer", "explorer")
+
+
+def test_output_guard_present_in_readonly_heavy_roles():
+    for role in _MITIGATION_ROLES:
+        text = (AGENTS / f"{role}.md").read_text(encoding="utf-8")
+        assert "<output-guard>" in text, f"{role}: output-guard section missing"
+        assert "issue #514" in text, f"{role}: truncation reference missing"
+        assert "chunk" in text.lower(), f"{role}: chunked-continuation rule missing"


### PR DESCRIPTION
## #516 — Orchestrator-guard privilege escalation (P1, security)
Sentinel elevation in `orchestrator-guard.sh` (v2.3.0 → v2.4.0) is now capability-scoped:

- `orchestrator` sentinel exempts **only** strict-mode main-chat Bash blocking — it no longer bypasses the git-mutation gate
- `git` sentinel exempts **only** the git-mutation gate
- **New destructive-operation gate** (applies even with valid sentinel): force push, `reset --hard`, `clean -f*`, `stash drop/clear`, `filter-branch/repo`, working-tree wipe → exit 2 with user-approval instruction
- Every elevation attempt is appended to `.claude/hooks/.guard-audit.log` for post-hoc review
- Identity remains unverifiable at hook level (provider limitation) — documented as mitigation, not cryptographic trust

## #514 — Silent return-channel truncation
Read-only-heavy roles (`planner`, `code-reviewer`, `explorer`) get an `<output-guard>` section: ~400-line response cap, chunked continuation protocol, and hand-off recommendation to write-capable roles for large artifacts. Enforced structurally via `tests/test_review_fleet.py::test_output_guard_present_in_readonly_heavy_roles`.

## Validation
- pytest: 47/47 green (11 new guard tests incl. the exact #516 incident pattern; 1 new mitigation test)
- bash -n syntax check; sync.py propagated provider hook copies
- `sync.py --validate`: exit 0

Closes #516, closes #514